### PR TITLE
Add Sonilo video-to-music node (first audio-output model in the registry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge"></a>
   <a href="../../releases/latest"><img alt="Platforms: macOS, Windows, Linux" src="https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-blue?style=for-the-badge"></a>
-  <a href="../../releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/Release-v1.0.38-blue?style=for-the-badge"></a>
+  <a href="../../releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/Release-v1.0.39-blue?style=for-the-badge"></a>
   <a href="https://discord.gg/cSUS88VdY9"><img alt="Join our Discord" src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white&style=for-the-badge"></a>
 </p>
 
@@ -67,6 +67,7 @@ Models available today:
 
 - **Image:** GPT Image 2, Nano Banana 2, Nano Banana Pro (edit), Krea v2 Large
 - **Video:** LTX 2.3 (image to video), Seedance 2.0 (text, image, and reference to video)
+- **Music:** Sonilo v1.1 (video to music) - scores an original, commercially licensed soundtrack matched to a video's pacing and mood; the prompt is optional, and the result wires straight into the Video Director's music track
 
 It is bring your own key. Add your [fal.ai API key](https://fal.ai/dashboard/keys) in Settings and it stays on your machine, sent only to fal when you generate. You pay fal directly for what you render, and each node shows a rough price estimate before you run it.
 

--- a/electron/main/generation/executor.test.ts
+++ b/electron/main/generation/executor.test.ts
@@ -179,6 +179,31 @@ describe('runGraph', () => {
     expect(events.some((e) => e.startsWith('error:A:A:'))).toBe(true)
   })
 
+  it('runs a prompt-optional model (Sonilo) without a connected prompt', async () => {
+    getFalFrame.mockReturnValue({
+      provider: 'fal',
+      modelId: 'sonilo/v1.1/video-to-music',
+      params: {},
+    })
+    promptTextForFrame.mockReturnValue(null)
+    frameInputAssetPaths.mockReturnValue([{ filePath: 'takes/cut.mp4', name: 'cut.mp4' }])
+    submit.mockResolvedValue({
+      requestId: 'r3',
+      response: { audios: [{ url: 'https://fal/a.m4a', content_type: 'audio/mp4' }] },
+    })
+    const { emit, events } = recordingEmitter()
+
+    await runGraph('M', emit)
+
+    // The video uploads as video_url; the empty prompt is omitted from the request entirely.
+    expect(submit).toHaveBeenCalledTimes(1)
+    expect(submit.mock.calls[0][0]).toBe('sonilo/v1.1/video-to-music')
+    expect(submit.mock.calls[0][1]).toMatchObject({ video_url: 'data:/proj/takes/cut.mp4' })
+    expect(submit.mock.calls[0][1]).not.toHaveProperty('prompt')
+    expect(events).toContain('done:M')
+    expect(events.some((e) => e.startsWith('error:'))).toBe(false)
+  })
+
   it('emits an error and aborts when a required input is missing', async () => {
     // LTX requires an image; none wired.
     getFalFrame.mockReturnValue({

--- a/electron/main/generation/executor.ts
+++ b/electron/main/generation/executor.ts
@@ -203,10 +203,14 @@ export async function runGraph(targetFrameId: string, emit: GenEmitter): Promise
       }
     }
 
-    // The prompt is fed by a connected Prompt node (not a stored param).
+    // The prompt is fed by a connected Prompt node (not a stored param). Prompt-optional models
+    // (e.g. Sonilo, which derives one from its video input) run without a connection; their
+    // buildRequest omits the empty prompt.
     const promptText = promptTextForFrame(targetFrameId)
-    if (!promptText) throw new Error('Connect a Prompt node with some text to generate.')
-    const runParams = { ...params, prompt: promptText }
+    if (!promptText && !def.promptOptional) {
+      throw new Error('Connect a Prompt node with some text to generate.')
+    }
+    const runParams = { ...params, prompt: promptText ?? '' }
 
     const endpoint = def.resolveEndpoint(resolved)
     const body = def.buildRequest(runParams, resolved)

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "name": "inline-studio",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "An experimentation layer for visual artists: build, iterate, and share generative pipelines on your own ComfyUI.",
   "author": "Inline Studio",
   "license": "MIT",
   "main": "./out/main/index.cjs",
   "type": "module",
+  "engines": {
+    "node": ">=20.19.0",
+    "npm": ">=10.0.0"
+  },
   "scripts": {
     "dev": "electron-vite dev",
     "build": "npm run typecheck && electron-vite build",

--- a/src/renderer/views/Moodboard/ModelInfoPanel.tsx
+++ b/src/renderer/views/Moodboard/ModelInfoPanel.tsx
@@ -101,8 +101,9 @@ export function ModelInfoPanel(): React.JSX.Element | null {
 
       <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-3">
         <Section title="Inputs">
-          {/* Every gen node takes a text prompt — a universal input, not listed in def.inputs. */}
-          <PortRow label="Prompt" kind="text" required />
+          {/* Every gen node takes a text prompt — a universal input, not listed in def.inputs.
+              Prompt-optional models can run without one (the model derives its own). */}
+          <PortRow label="Prompt" kind="text" required={!def.promptOptional} />
           {def.inputs.map((p) => (
             <PortRow key={p.id} label={p.label} kind={p.kind} required={p.required} />
           ))}

--- a/src/renderer/views/Moodboard/nodes/GenNode.tsx
+++ b/src/renderer/views/Moodboard/nodes/GenNode.tsx
@@ -192,11 +192,12 @@ export function GenNode({ id, data, selected }: NodeProps): React.JSX.Element {
     ...(requiresMedia ? [mediaIsVideo ? 'video' : 'image'] : []),
     ...(requiresAudio ? ['audio'] : []),
   ]
-  const missing = !hasPrompt
-    ? 'Connect a Prompt node'
-    : requiredKinds.length > 0 && inputs.length === 0
-      ? `Wire ${requiredKinds.join(' & ')} input${requiredKinds.length > 1 ? 's' : ''}`
-      : null
+  const missing =
+    !hasPrompt && !def.promptOptional
+      ? 'Connect a Prompt node'
+      : requiredKinds.length > 0 && inputs.length === 0
+        ? `Wire ${requiredKinds.join(' & ')} input${requiredKinds.length > 1 ? 's' : ''}`
+        : null
   const pct = typeof progress === 'number' ? Math.round(progress * 100) : null
   const price = def.estimatePrice?.(frame.params) ?? null
 
@@ -207,7 +208,7 @@ export function GenNode({ id, data, selected }: NodeProps): React.JSX.Element {
       id: 'prompt',
       colorClass: '!bg-amber-400',
       icon: <span className="text-xs font-bold leading-none">T</span>,
-      label: 'Prompt',
+      label: def.promptOptional ? 'Prompt (optional)' : 'Prompt',
     },
     ...(wantsMedia
       ? [

--- a/src/shared/nodes/builders.ts
+++ b/src/shared/nodes/builders.ts
@@ -25,6 +25,11 @@ interface VideoResult {
   content_type?: string
   file_name?: string
 }
+interface AudioResult {
+  url?: string
+  content_type?: string
+  file_name?: string
+}
 
 /** Parse a `{ images: [{ url, content_type, file_name }] }` response into output refs. */
 export function parseImageArray(response: unknown, defaultExt = '.png'): FalOutputRef[] {
@@ -38,6 +43,21 @@ export function parseImageArray(response: unknown, defaultExt = '.png'): FalOutp
       url: img.url,
       ext: extFromContentTypeOrName(img.content_type, img.file_name, defaultExt),
       kind: 'image' as const,
+    }))
+}
+
+/** Parse an `{ audios: [{ url, content_type, file_name }] }` response into output refs. */
+export function parseAudioArray(response: unknown, defaultExt = '.m4a'): FalOutputRef[] {
+  const audios = (response as { audios?: AudioResult[] } | null)?.audios ?? []
+  return audios
+    .filter(
+      (aud): aud is AudioResult & { url: string } =>
+        typeof aud?.url === 'string' && aud.url.length > 0,
+    )
+    .map((aud) => ({
+      url: aud.url,
+      ext: extFromContentTypeOrName(aud.content_type, aud.file_name, defaultExt),
+      kind: 'audio' as const,
     }))
 }
 

--- a/src/shared/nodes/registry.ts
+++ b/src/shared/nodes/registry.ts
@@ -11,6 +11,7 @@ import { SEEDANCE_T2V } from './seedanceT2V'
 import { SEEDANCE_I2V } from './seedanceI2V'
 import { SEEDANCE_REF2V } from './seedanceRef2V'
 import { KREA_V2 } from './kreaV2'
+import { SONILO_V2M } from './soniloVideoToMusic'
 
 export const NODE_DEFS: readonly NodeDef[] = [
   GPT_IMAGE_2,
@@ -21,6 +22,7 @@ export const NODE_DEFS: readonly NodeDef[] = [
   SEEDANCE_I2V,
   SEEDANCE_REF2V,
   KREA_V2,
+  SONILO_V2M,
 ]
 
 /** Look up a node def by its model id (`Frame.modelId`); undefined if unknown. */
@@ -42,6 +44,7 @@ const OWNER_LABELS: Record<string, string> = {
   openai: 'OpenAI',
   bytedance: 'ByteDance',
   krea: 'Krea',
+  sonilo: 'Sonilo',
 }
 
 export function modelOwner(id: string): string {

--- a/src/shared/nodes/soniloVideoToMusic.test.ts
+++ b/src/shared/nodes/soniloVideoToMusic.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { SONILO_V2M } from './soniloVideoToMusic'
+import { defaultParams, emptyResolvedInputs, type ResolvedInputs } from './types'
+
+function withVideo(url: string): ResolvedInputs {
+  return { ...emptyResolvedInputs(), videos: [url] }
+}
+
+describe('SONILO_V2M.resolveEndpoint', () => {
+  it('always targets the single video-to-music endpoint', () => {
+    expect(SONILO_V2M.resolveEndpoint(emptyResolvedInputs())).toBe('sonilo/v1.1/video-to-music')
+  })
+})
+
+describe('SONILO_V2M.buildRequest', () => {
+  it('maps the first resolved video to video_url and omits the optional fields at defaults', () => {
+    const body = SONILO_V2M.buildRequest(
+      { ...defaultParams(SONILO_V2M), prompt: '' },
+      withVideo('https://fal/cut.mp4'),
+    )
+    expect(body).toEqual({ video_url: 'https://fal/cut.mp4', num_samples: 1 })
+    expect(body.prompt).toBeUndefined()
+    expect(body.start_offset).toBeUndefined()
+    expect(body.duration).toBeUndefined()
+  })
+
+  it('passes a wired style prompt through, trimmed', () => {
+    const body = SONILO_V2M.buildRequest(
+      { ...defaultParams(SONILO_V2M), prompt: '  warm analog synths  ' },
+      withVideo('u'),
+    )
+    expect(body.prompt).toBe('warm analog synths')
+  })
+
+  it('includes a positive segment start/duration and coerces the sample count', () => {
+    const body = SONILO_V2M.buildRequest(
+      { ...defaultParams(SONILO_V2M), num_samples: 3, start_offset: 12, duration: 30 },
+      withVideo('u'),
+    )
+    expect(body).toMatchObject({ num_samples: 3, start_offset: 12, duration: 30 })
+    expect(
+      SONILO_V2M.buildRequest({ ...defaultParams(SONILO_V2M), num_samples: 0 }, withVideo('u'))
+        .num_samples,
+    ).toBe(1)
+  })
+})
+
+describe('SONILO_V2M.parseOutputs', () => {
+  it('maps the audios array to m4a refs', () => {
+    const refs = SONILO_V2M.parseOutputs({
+      audio: { url: 'https://fal/a.m4a', content_type: 'audio/mp4' },
+      audios: [
+        { url: 'https://fal/a.m4a', content_type: 'audio/mp4' },
+        { url: 'https://fal/b.m4a', content_type: 'audio/mp4' },
+      ],
+    })
+    expect(refs).toEqual([
+      { url: 'https://fal/a.m4a', ext: '.m4a', kind: 'audio' },
+      { url: 'https://fal/b.m4a', ext: '.m4a', kind: 'audio' },
+    ])
+  })
+
+  it('returns [] when the audios are missing or malformed', () => {
+    expect(SONILO_V2M.parseOutputs({})).toEqual([])
+    expect(SONILO_V2M.parseOutputs({ audios: [{ url: '' }] })).toEqual([])
+    expect(SONILO_V2M.parseOutputs(null)).toEqual([])
+  })
+})
+
+describe('SONILO_V2M.estimatePrice', () => {
+  it('prices per second × samples once a segment duration is set', () => {
+    // 30 s × 2 samples × $0.009/s = $0.54.
+    const est = SONILO_V2M.estimatePrice?.({ duration: 30, num_samples: 2 })
+    expect(est?.amount).toBeCloseTo(0.54, 5)
+    expect(est?.approx).toBe(true)
+  })
+
+  it('returns null at the full-video default (the video length is unknown here)', () => {
+    expect(SONILO_V2M.estimatePrice?.(defaultParams(SONILO_V2M))).toBeNull()
+  })
+})
+
+describe('SONILO_V2M shape', () => {
+  it('declares a required video input, an optional prompt, and an audio output', () => {
+    expect(SONILO_V2M.inputs).toHaveLength(1)
+    expect(SONILO_V2M.inputs[0]).toMatchObject({ id: 'video', kind: 'video', required: true })
+    expect(SONILO_V2M.promptOptional).toBe(true)
+    expect(SONILO_V2M.outputKind).toBe('audio')
+  })
+})

--- a/src/shared/nodes/soniloVideoToMusic.ts
+++ b/src/shared/nodes/soniloVideoToMusic.ts
@@ -1,0 +1,72 @@
+/**
+ * fal.ai `sonilo/v1.1/video-to-music` — generates an original soundtrack matched to an input video.
+ * See https://fal.ai/models/sonilo/v1.1/video-to-music.
+ *
+ * The first audio-output model in the registry: it proves the registry generalizes to audio
+ * (video input → audio output), and the resulting audio frame wires straight into a Video
+ * Director's L2 (music) inputs. The prompt is optional — when none is connected, Sonilo reads
+ * the video's pacing and mood and writes its own. Outputs are licensed and safe for commercial
+ * use (terms apply — see the fal.ai model page).
+ */
+import { type NodeDef, type ResolvedInputs } from './types'
+import { constantEndpoint, parseAudioArray, approxPrice, numberParam } from './builders'
+
+const ENDPOINT = 'sonilo/v1.1/video-to-music'
+
+/** Coerce a param to a sample count of at least 1 (fal default). */
+function toSamples(value: unknown): number {
+  const n = Math.round(Number(value ?? 1))
+  return Number.isFinite(n) && n >= 1 ? n : 1
+}
+
+/** Coerce an optional seconds param; null when unset/zero (the field is omitted from the request). */
+function toSeconds(value: unknown): number | null {
+  const n = Number(value ?? 0)
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
+export const SONILO_V2M: NodeDef = {
+  id: 'sonilo/v1.1/video-to-music',
+  title: 'Sonilo · Video → Music',
+  category: 'Audio',
+  provider: 'fal',
+  outputKind: 'audio',
+  inputs: [{ id: 'video', label: 'Video', kind: 'video', required: true }],
+  // The prompt only steers the musical style, so it's optional — Sonilo generates one from the
+  // video when nothing is wired (unlike every other model, where the prompt IS the instruction).
+  promptOptional: true,
+  params: [
+    numberParam('num_samples', 'Samples', 1, { min: 1, step: 1 }),
+    numberParam('start_offset', 'Start offset (s)', 0, { min: 0, step: 1 }),
+    numberParam('duration', 'Duration (s, 0 = full video)', 0, { min: 0, step: 1 }),
+  ],
+  outputs: [{ id: 'audio', label: 'Music', kind: 'audio' }],
+
+  resolveEndpoint: constantEndpoint(ENDPOINT),
+
+  buildRequest(params: Record<string, unknown>, resolved: ResolvedInputs): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+      video_url: resolved.videos[0] ?? '',
+      num_samples: toSamples(params.num_samples),
+    }
+    const prompt = String(params.prompt ?? '').trim()
+    if (prompt) body.prompt = prompt
+    const startOffset = toSeconds(params.start_offset)
+    if (startOffset !== null) body.start_offset = startOffset
+    const duration = toSeconds(params.duration)
+    if (duration !== null) body.duration = duration
+    return body
+  },
+
+  parseOutputs: (response) => parseAudioArray(response),
+
+  // fal bills $0.009 per second of output audio, per sample. The output runs the length of the
+  // selected segment; without an explicit duration the video's length isn't known here, so the
+  // estimate only shows once a segment duration is set.
+  // Source: fal.ai/models/sonilo/v1.1/video-to-music.
+  estimatePrice(params) {
+    const duration = toSeconds(params.duration)
+    if (duration === null) return null
+    return approxPrice(duration * toSamples(params.num_samples) * 0.009)
+  },
+}

--- a/src/shared/nodes/types.ts
+++ b/src/shared/nodes/types.ts
@@ -111,6 +111,12 @@ export interface NodeDef {
   provider: 'fal'
   /** The kind of media this node produces → the backing `Frame.kind`. */
   outputKind: 'image' | 'video' | 'audio'
+  /**
+   * When true, the node runs without a connected Prompt node — the model derives its own prompt
+   * from its media inputs (e.g. Sonilo reads the video), and a wired prompt only steers the result.
+   * Default (absent) keeps the prompt required, which is the norm.
+   */
+  promptOptional?: boolean
   inputs: InputPort[]
   params: ParamField[]
   outputs: OutputPort[]
@@ -160,6 +166,8 @@ export function extFromContentTypeOrName(
     'video/webm': '.webm',
     'audio/mpeg': '.mp3',
     'audio/wav': '.wav',
+    'audio/mp4': '.m4a',
+    'audio/aac': '.aac',
   }
   if (contentType && fromType[contentType.toLowerCase()]) return fromType[contentType.toLowerCase()]
   if (fileName && fileName.includes('.')) {


### PR DESCRIPTION
## What this adds

A new generation node for [`sonilo/v1.1/video-to-music`](https://fal.ai/models/sonilo/v1.1/video-to-music): wire a video frame in (e.g. a rendered cut), run it, and get an original soundtrack matched to the video back as an audio frame. That frame wires straight into a Video Director's L2 (music) inputs. The registry's `outputKind: 'audio'`, the `'audio'` FrameKind, waveform takes, and the director's `ain-*` routing all existed already; this is the first model that exercises them.

Disclosure: I work on Sonilo. Everything here goes through the app's existing fal transport (`electron/main/fal/client.ts`) and the user's own fal API key from Settings. No new SDK, credentials, or network paths. Outputs are licensed and safe for commercial use (terms apply; the deployment terms are on the fal model page).

## Changes

- `src/shared/nodes/soniloVideoToMusic.ts` (new): the NodeDef, following the one-file pattern. Required video input; optional `num_samples` / `start_offset` / `duration` params; `$0.009/s × samples` estimate, shown once a segment duration is set (the full video's length isn't known at estimate time).
- `src/shared/nodes/builders.ts`: `parseAudioArray` for `{ audios: [...] }` responses, mirroring `parseImageArray`.
- `src/shared/nodes/types.ts`: `NodeDef.promptOptional`, plus `audio/mp4` / `audio/aac` extension mappings (the model returns AAC in an m4a container).
- `electron/main/generation/executor.ts`: the prompt check honors `promptOptional`. When no Prompt node is connected, Sonilo derives the musical direction from the video itself; a wired prompt steers the style. Every other model keeps the required-prompt behavior.
- `GenNode.tsx` / `ModelInfoPanel.tsx`: the "Connect a Prompt node" gate and the info panel's Required tag follow the flag; the prompt dot hints "Prompt (optional)".
- `src/shared/nodes/registry.ts`: registered, with a `Sonilo` owner label for the picker grouping.
- Tests: `soniloVideoToMusic.test.ts` (endpoint / body / outputs / price / shape) and an executor case running a prompt-optional model without a prompt.

## Testing

`npm run typecheck`, `npm run lint`, `npm test` (99 passing), and `npm run build` are all green. To be upfront: I haven't yet driven a live generation through the Electron app against the endpoint from this machine; the request/response shapes are covered by the unit tests and match the published API schema ([input/output docs](https://fal.ai/models/sonilo/v1.1/video-to-music/api)). Happy to record a full run-through or adjust anything to taste.