### PR TITLE
Add two Sonilo fal nodes: text-to-music + video-to-video (completes the fal set)

### DIFF
--- a/src/shared/nodes/registry.ts
+++ b/src/shared/nodes/registry.ts
@@ -12,6 +12,7 @@ import { SEEDANCE_I2V } from './seedanceI2V'
 import { SEEDANCE_REF2V } from './seedanceRef2V'
 import { KREA_V2 } from './kreaV2'
 import { SONILO_V2M } from './soniloVideoToMusic'
+import { SONILO_T2M } from './soniloTextToMusic'
 
 export const NODE_DEFS: readonly NodeDef[] = [
   GPT_IMAGE_2,
@@ -23,6 +24,7 @@ export const NODE_DEFS: readonly NodeDef[] = [
   SEEDANCE_REF2V,
   KREA_V2,
   SONILO_V2M,
+  SONILO_T2M,
 ]
 
 /** Look up a node def by its model id (`Frame.modelId`); undefined if unknown. */

--- a/src/shared/nodes/registry.ts
+++ b/src/shared/nodes/registry.ts
@@ -13,6 +13,7 @@ import { SEEDANCE_REF2V } from './seedanceRef2V'
 import { KREA_V2 } from './kreaV2'
 import { SONILO_V2M } from './soniloVideoToMusic'
 import { SONILO_T2M } from './soniloTextToMusic'
+import { SONILO_V2V } from './soniloVideoToVideo'
 
 export const NODE_DEFS: readonly NodeDef[] = [
   GPT_IMAGE_2,
@@ -25,6 +26,7 @@ export const NODE_DEFS: readonly NodeDef[] = [
   KREA_V2,
   SONILO_V2M,
   SONILO_T2M,
+  SONILO_V2V,
 ]
 
 /** Look up a node def by its model id (`Frame.modelId`); undefined if unknown. */

--- a/src/shared/nodes/soniloTextToMusic.test.ts
+++ b/src/shared/nodes/soniloTextToMusic.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { SONILO_T2M } from './soniloTextToMusic'
+import { defaultParams, emptyResolvedInputs } from './types'
+
+describe('SONILO_T2M.resolveEndpoint', () => {
+  it('always targets the single text-to-music endpoint', () => {
+    expect(SONILO_T2M.resolveEndpoint(emptyResolvedInputs())).toBe('sonilo/v1.1/text-to-music')
+  })
+})
+
+describe('SONILO_T2M.buildRequest', () => {
+  it('sends the trimmed prompt with the duration and sample defaults', () => {
+    const body = SONILO_T2M.buildRequest({
+      ...defaultParams(SONILO_T2M),
+      prompt: '  warm analog synths  ',
+    })
+    expect(body).toEqual({ prompt: 'warm analog synths', duration: 90, num_samples: 1 })
+  })
+
+  it('clamps the duration to the 600 s ceiling and coerces the sample count up to 1', () => {
+    const body = SONILO_T2M.buildRequest({ prompt: 'x', duration: 5000, num_samples: 0 })
+    expect(body).toMatchObject({ duration: 600, num_samples: 1 })
+  })
+
+  it('falls back to the 90 s default for a non-positive or unparseable duration', () => {
+    expect(SONILO_T2M.buildRequest({ prompt: 'x', duration: 0 }).duration).toBe(90)
+    expect(SONILO_T2M.buildRequest({ prompt: 'x', duration: 'soon' }).duration).toBe(90)
+  })
+})
+
+describe('SONILO_T2M.parseOutputs', () => {
+  it('maps the audios array to m4a refs', () => {
+    const refs = SONILO_T2M.parseOutputs({
+      audio: { url: 'https://fal/a.m4a', content_type: 'audio/mp4' },
+      audios: [
+        { url: 'https://fal/a.m4a', content_type: 'audio/mp4' },
+        { url: 'https://fal/b.m4a', content_type: 'audio/mp4' },
+      ],
+    })
+    expect(refs).toEqual([
+      { url: 'https://fal/a.m4a', ext: '.m4a', kind: 'audio' },
+      { url: 'https://fal/b.m4a', ext: '.m4a', kind: 'audio' },
+    ])
+  })
+
+  it('returns [] when the audios are missing or malformed', () => {
+    expect(SONILO_T2M.parseOutputs({})).toEqual([])
+    expect(SONILO_T2M.parseOutputs({ audios: [{ url: '' }] })).toEqual([])
+    expect(SONILO_T2M.parseOutputs(null)).toEqual([])
+  })
+})
+
+describe('SONILO_T2M.estimatePrice', () => {
+  it('prices per second × samples (duration is always known for text-to-music)', () => {
+    // 120 s × 2 samples × $0.009/s = $2.16.
+    const est = SONILO_T2M.estimatePrice?.({ duration: 120, num_samples: 2 })
+    expect(est?.amount).toBeCloseTo(2.16, 5)
+    expect(est?.approx).toBe(true)
+  })
+
+  it('prices the defaults (90 s × 1 sample = $0.81)', () => {
+    const est = SONILO_T2M.estimatePrice?.(defaultParams(SONILO_T2M))
+    expect(est?.amount).toBeCloseTo(0.81, 5)
+  })
+})
+
+describe('SONILO_T2M shape', () => {
+  it('takes no media input, keeps the prompt required, and outputs audio', () => {
+    expect(SONILO_T2M.inputs).toHaveLength(0)
+    expect(SONILO_T2M.promptOptional).toBeUndefined()
+    expect(SONILO_T2M.outputKind).toBe('audio')
+    expect(SONILO_T2M.provider).toBe('fal')
+  })
+})

--- a/src/shared/nodes/soniloTextToMusic.test.ts
+++ b/src/shared/nodes/soniloTextToMusic.test.ts
@@ -10,21 +10,28 @@ describe('SONILO_T2M.resolveEndpoint', () => {
 
 describe('SONILO_T2M.buildRequest', () => {
   it('sends the trimmed prompt with the duration and sample defaults', () => {
-    const body = SONILO_T2M.buildRequest({
-      ...defaultParams(SONILO_T2M),
-      prompt: '  warm analog synths  ',
-    })
+    const body = SONILO_T2M.buildRequest(
+      { ...defaultParams(SONILO_T2M), prompt: '  warm analog synths  ' },
+      emptyResolvedInputs(),
+    )
     expect(body).toEqual({ prompt: 'warm analog synths', duration: 90, num_samples: 1 })
   })
 
   it('clamps the duration to the 600 s ceiling and coerces the sample count up to 1', () => {
-    const body = SONILO_T2M.buildRequest({ prompt: 'x', duration: 5000, num_samples: 0 })
+    const body = SONILO_T2M.buildRequest(
+      { prompt: 'x', duration: 5000, num_samples: 0 },
+      emptyResolvedInputs(),
+    )
     expect(body).toMatchObject({ duration: 600, num_samples: 1 })
   })
 
   it('falls back to the 90 s default for a non-positive or unparseable duration', () => {
-    expect(SONILO_T2M.buildRequest({ prompt: 'x', duration: 0 }).duration).toBe(90)
-    expect(SONILO_T2M.buildRequest({ prompt: 'x', duration: 'soon' }).duration).toBe(90)
+    expect(
+      SONILO_T2M.buildRequest({ prompt: 'x', duration: 0 }, emptyResolvedInputs()).duration,
+    ).toBe(90)
+    expect(
+      SONILO_T2M.buildRequest({ prompt: 'x', duration: 'soon' }, emptyResolvedInputs()).duration,
+    ).toBe(90)
   })
 })
 

--- a/src/shared/nodes/soniloTextToMusic.ts
+++ b/src/shared/nodes/soniloTextToMusic.ts
@@ -1,0 +1,60 @@
+/**
+ * fal.ai `sonilo/v1.1/text-to-music` — generates an original track from a text description alone
+ * (no video input). See https://fal.ai/models/sonilo/v1.1/text-to-music.
+ *
+ * The video-to-music sibling reads a cut and writes to it; this one writes from words. The prompt
+ * carries the whole instruction here, so — unlike video-to-music — it stays required: describe the
+ * track (mood, instrumentation, tempo) and Sonilo returns audio takes. Outputs are licensed and
+ * safe for commercial use (terms apply — see the fal.ai model page). It rides the same fal
+ * transport and fal key as every other fal node.
+ */
+import { type NodeDef } from './types'
+import { constantEndpoint, parseAudioArray, approxPrice, numberParam } from './builders'
+
+const ENDPOINT = 'sonilo/v1.1/text-to-music'
+
+/** Coerce a param to a sample count of at least 1 (fal default). */
+function toSamples(value: unknown): number {
+  const n = Math.round(Number(value ?? 1))
+  return Number.isFinite(n) && n >= 1 ? n : 1
+}
+
+/** Coerce the duration to a positive second count, clamped to the endpoint's 600 s ceiling. */
+function toDuration(value: unknown): number {
+  const n = Math.round(Number(value ?? 90))
+  if (!Number.isFinite(n) || n < 1) return 90
+  return Math.min(n, 600)
+}
+
+export const SONILO_T2M: NodeDef = {
+  id: 'sonilo/v1.1/text-to-music',
+  title: 'Sonilo · Text → Music',
+  category: 'Audio',
+  provider: 'fal',
+  outputKind: 'audio',
+  // No media input — the prompt is the whole instruction, so it stays required (the default).
+  inputs: [],
+  params: [
+    numberParam('duration', 'Duration (s)', 90, { min: 1, max: 600, step: 1 }),
+    numberParam('num_samples', 'Samples', 1, { min: 1, step: 1 }),
+  ],
+  outputs: [{ id: 'audio', label: 'Music', kind: 'audio' }],
+
+  resolveEndpoint: constantEndpoint(ENDPOINT),
+
+  buildRequest(params: Record<string, unknown>): Record<string, unknown> {
+    return {
+      prompt: String(params.prompt ?? '').trim(),
+      duration: toDuration(params.duration),
+      num_samples: toSamples(params.num_samples),
+    }
+  },
+
+  parseOutputs: (response) => parseAudioArray(response),
+
+  // fal bills $0.009 per second of output audio, per sample. Duration is always known here (it's a
+  // param), so the estimate always shows. Source: fal.ai/models/sonilo/v1.1/text-to-music.
+  estimatePrice(params) {
+    return approxPrice(toDuration(params.duration) * toSamples(params.num_samples) * 0.009)
+  },
+}

--- a/src/shared/nodes/soniloVideoToVideo.test.ts
+++ b/src/shared/nodes/soniloVideoToVideo.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { SONILO_V2V } from './soniloVideoToVideo'
+import { defaultParams, emptyResolvedInputs, type ResolvedInputs } from './types'
+
+function withVideo(url: string): ResolvedInputs {
+  return { ...emptyResolvedInputs(), videos: [url] }
+}
+
+describe('SONILO_V2V.resolveEndpoint', () => {
+  it('always targets the single video-to-video endpoint', () => {
+    expect(SONILO_V2V.resolveEndpoint(emptyResolvedInputs())).toBe('sonilo/v1.1/video-to-video')
+  })
+})
+
+describe('SONILO_V2V.buildRequest', () => {
+  it('maps the video to video_url and keeps original speech off by default', () => {
+    const body = SONILO_V2V.buildRequest(
+      { ...defaultParams(SONILO_V2V), prompt: '' },
+      withVideo('https://fal/cut.mp4'),
+    )
+    expect(body).toEqual({
+      video_url: 'https://fal/cut.mp4',
+      num_samples: 1,
+      keep_speech_vocal: false,
+    })
+    expect(body.prompt).toBeUndefined()
+    expect(body.start_offset).toBeUndefined()
+    expect(body.duration).toBeUndefined()
+  })
+
+  it('passes the keep-speech toggle and a trimmed style prompt through', () => {
+    const body = SONILO_V2V.buildRequest(
+      { ...defaultParams(SONILO_V2V), keep_speech_vocal: true, prompt: '  warm analog synths  ' },
+      withVideo('u'),
+    )
+    expect(body.keep_speech_vocal).toBe(true)
+    expect(body.prompt).toBe('warm analog synths')
+  })
+
+  it('includes a positive segment start/duration and coerces the sample count', () => {
+    const body = SONILO_V2V.buildRequest(
+      { ...defaultParams(SONILO_V2V), num_samples: 3, start_offset: 12, duration: 30 },
+      withVideo('u'),
+    )
+    expect(body).toMatchObject({ num_samples: 3, start_offset: 12, duration: 30 })
+    expect(
+      SONILO_V2V.buildRequest({ ...defaultParams(SONILO_V2V), num_samples: 0 }, withVideo('u'))
+        .num_samples,
+    ).toBe(1)
+  })
+})
+
+describe('SONILO_V2V.parseOutputs', () => {
+  it('maps the primary video slot to a single mp4 ref, ignoring the videos array', () => {
+    const refs = SONILO_V2V.parseOutputs({
+      video: { url: 'https://fal/out.mp4', content_type: 'video/mp4' },
+      videos: [{ url: 'https://fal/out.mp4', content_type: 'video/mp4' }],
+    })
+    expect(refs).toEqual([{ url: 'https://fal/out.mp4', ext: '.mp4', kind: 'video' }])
+  })
+
+  it('returns [] when the video slot is missing or malformed', () => {
+    expect(SONILO_V2V.parseOutputs({})).toEqual([])
+    expect(SONILO_V2V.parseOutputs({ video: { url: '' } })).toEqual([])
+    expect(SONILO_V2V.parseOutputs(null)).toEqual([])
+  })
+})
+
+describe('SONILO_V2V.estimatePrice', () => {
+  it('prices per second × samples once a segment duration is set', () => {
+    // 30 s × 2 samples × $0.009/s = $0.54.
+    const est = SONILO_V2V.estimatePrice?.({ duration: 30, num_samples: 2 })
+    expect(est?.amount).toBeCloseTo(0.54, 5)
+    expect(est?.approx).toBe(true)
+  })
+
+  it('returns null at the full-video default (the video length is unknown here)', () => {
+    expect(SONILO_V2V.estimatePrice?.(defaultParams(SONILO_V2V))).toBeNull()
+  })
+})
+
+describe('SONILO_V2V shape', () => {
+  it('declares a required video input, an optional prompt, and a video output', () => {
+    expect(SONILO_V2V.inputs).toHaveLength(1)
+    expect(SONILO_V2V.inputs[0]).toMatchObject({ id: 'video', kind: 'video', required: true })
+    expect(SONILO_V2V.promptOptional).toBe(true)
+    expect(SONILO_V2V.outputKind).toBe('video')
+    expect(SONILO_V2V.provider).toBe('fal')
+  })
+})

--- a/src/shared/nodes/soniloVideoToVideo.ts
+++ b/src/shared/nodes/soniloVideoToVideo.ts
@@ -1,0 +1,85 @@
+/**
+ * fal.ai `sonilo/v1.1/video-to-video` — returns the input video with a generated, licensed track
+ * mixed in. See https://fal.ai/models/sonilo/v1.1/video-to-video.
+ *
+ * The video-to-music sibling hands back an audio take you wire into the Video Director; this one
+ * hands back the finished video, so it slots in when you want the mix done in one step. Set
+ * `keep_speech_vocal` to preserve the original speech alongside the new track. Like video-to-music
+ * the prompt is optional — Sonilo reads the video's pacing and mood when nothing is wired, and a
+ * prompt only steers the musical style. Outputs are licensed and safe for commercial use (terms
+ * apply — see the fal.ai model page). It rides the same fal transport and fal key as every other
+ * fal node.
+ */
+import { type NodeDef, type ResolvedInputs } from './types'
+import {
+  constantEndpoint,
+  parseSingleVideo,
+  numberParam,
+  booleanParam,
+  approxPrice,
+} from './builders'
+
+const ENDPOINT = 'sonilo/v1.1/video-to-video'
+
+/** Coerce a param to a sample count of at least 1 (fal default). */
+function toSamples(value: unknown): number {
+  const n = Math.round(Number(value ?? 1))
+  return Number.isFinite(n) && n >= 1 ? n : 1
+}
+
+/** Coerce an optional seconds param; null when unset/zero (the field is omitted from the request). */
+function toSeconds(value: unknown): number | null {
+  const n = Number(value ?? 0)
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
+export const SONILO_V2V: NodeDef = {
+  id: 'sonilo/v1.1/video-to-video',
+  title: 'Sonilo · Video → Video',
+  category: 'Video',
+  provider: 'fal',
+  outputKind: 'video',
+  inputs: [{ id: 'video', label: 'Video', kind: 'video', required: true }],
+  // Like video-to-music: the prompt only steers the musical style, so it's optional — Sonilo
+  // reads the video and writes its own when nothing is wired.
+  promptOptional: true,
+  params: [
+    // "Preserve original speech": when on, Sonilo separates the source audio and blends the
+    // original vocals back over the generated track (fal field: keep_speech_vocal).
+    booleanParam('keep_speech_vocal', 'Keep original speech', false, { advanced: false }),
+    numberParam('num_samples', 'Samples', 1, { min: 1, step: 1 }),
+    numberParam('start_offset', 'Start offset (s)', 0, { min: 0, step: 1 }),
+    numberParam('duration', 'Duration (s, 0 = full video)', 0, { min: 0, step: 1 }),
+  ],
+  outputs: [{ id: 'video', label: 'Video', kind: 'video' }],
+
+  resolveEndpoint: constantEndpoint(ENDPOINT),
+
+  buildRequest(params: Record<string, unknown>, resolved: ResolvedInputs): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+      video_url: resolved.videos[0] ?? '',
+      num_samples: toSamples(params.num_samples),
+      keep_speech_vocal: Boolean(params.keep_speech_vocal),
+    }
+    const prompt = String(params.prompt ?? '').trim()
+    if (prompt) body.prompt = prompt
+    const startOffset = toSeconds(params.start_offset)
+    if (startOffset !== null) body.start_offset = startOffset
+    const duration = toSeconds(params.duration)
+    if (duration !== null) body.duration = duration
+    return body
+  },
+
+  // The response carries a `video` slot (the first output) plus a `videos` array (one per sample);
+  // the canvas takes one video per node, so parse the single primary video into a take.
+  parseOutputs: (response) => parseSingleVideo(response),
+
+  // fal bills $0.009 per second of the mixed output, per sample. Without an explicit duration the
+  // video's length isn't known here, so the estimate only shows once a segment duration is set.
+  // Source: fal.ai/models/sonilo/v1.1/video-to-video.
+  estimatePrice(params) {
+    const duration = toSeconds(params.duration)
+    if (duration === null) return null
+    return approxPrice(duration * toSamples(params.num_samples) * 0.009)
+  },
+}


### PR DESCRIPTION
## What this adds

Two new generation nodes, both plain fal endpoints. Together with the video-to-music node merged in #9, this covers the Sonilo modes that fal deploys:

- **Text to Music** (`sonilo/v1.1/text-to-music`): a prompt in, a music take out, no video needed. Outputs are licensed and safe for commercial use (terms apply).
- **Video to Video** (`sonilo/v1.1/video-to-video`): your video back with a generated track already mixed in, plus a toggle to keep the original speech. Outputs are licensed and safe for commercial use (terms apply).

Disclosure, same as #9: I work on Sonilo.

Both nodes ride the app's existing fal transport and the user's own fal key, the same way the merged music node does. No new plumbing.

### Why this dropped the SFX node

An earlier version of this PR carried a third node, video-to-SFX, wired through a direct Sonilo REST transport. It's out now. The generation-engine-v2 refactor (merged as #8) moved node execution into the Python core and locked nodes to fal-only, which removed the electron transport layer the SFX node was built on. Sonilo's SFX mode has no fal deployment, so there's no fal path for it to take. It needs a rebuild against the new architecture, and I'll send that as a separate follow-up PR. That left the two fal nodes here, which slot into the new engine without any changes.

## The two nodes

- `soniloTextToMusic.ts`: provider `fal`, calls `sonilo/v1.1/text-to-music`. No media input; the prompt is required and carries the whole instruction. Duration (up to 600 s) and sample-count params, plus a per-second price estimate.
- `soniloVideoToVideo.ts`: provider `fal`, calls `sonilo/v1.1/video-to-video`. Required video input, optional style prompt, a "keep original speech" toggle (`keep_speech_vocal`), plus sample count and an optional segment. Returns a video take.

Each new NodeDef mirrors the merged music node file-for-file: same builders, same registry line, same prompt-optional handling. No UI changes, since the canvas is data-driven off the registry.

## Testing

`npm run typecheck`, `npm run lint` (0 warnings), `npm test` (90 passing, 18 new across the two fal nodes), and `npm run build` are all green. Same honesty as #9: I haven't driven a live generation through the app from this machine. The request and response shapes are covered by unit tests and match the published fal API contracts. Happy to record a run-through if that helps.
