### PR TITLE
Controlnet support: Control space & controlnet nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="LICENSE"><img alt="License: GPLv3" src="https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge"></a>
   <a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/Python-3.11%2B-blue?style=for-the-badge&logo=python&logoColor=white"></a>
-  <a href="../../releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/Release-v1.2.52-blue?style=for-the-badge"></a>
+  <a href="../../releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/Release-v1.2.53-blue?style=for-the-badge"></a>
   <a href="https://discord.gg/cSUS88VdY9"><img alt="Join our Discord" src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white&style=for-the-badge"></a>
 </p>
 
@@ -222,6 +222,18 @@ Two things are worth knowing before you download 26 GB twice:
 - **The VAE is the diffusers-format one**, fetched from [`Qwen/Qwen-Image`](https://huggingface.co/Qwen/Qwen-Image). ComfyUI's `qwen_image_vae.safetensors` holds the same weights in a different module layout that diffusers cannot read. The node's model popup downloads the right file for you.
 
 Nothing here needs a Hugging Face token: every repo involved is public, and Krea's own gated repos are never touched.
+
+### ControlNet
+
+Steer a local render with a pose, depth, or edge map. Wire a control map into a gen node's **Control** input and pick a ControlNet in the node's Adjust sidebar.
+
+- **Control Space** - a 3D pose editor in a node. Pose one or more characters, frame a camera, and render the scene as an OpenPose skeleton or a depth map. No reference photo needed.
+- **Apply ControlNet** - turn any image into a control map (OpenPose, Depth-Anything V2, MiDaS depth, or Canny edges). Detector weights download once on first use.
+- **Z-Image Turbo** - full ControlNet via the Fun Union model. Use the distilled `-2602-8steps` build; the plain one is blurry at 8 steps.
+- **Krea 2** - depth control via the [`Patil/Krea-2-depth-controlnet`](https://huggingface.co/Patil/Krea-2-depth-controlnet) control-LoRA.
+- **Control strength** - dial how hard the map is followed, per node.
+
+Drop ControlNet files into `core/models/controlnet/`, or use the node's model popup to download them.
 
 ### Community extensions
 

--- a/TODO
+++ b/TODO
@@ -1,3 +1,0 @@
-apply controlnet model fix
-improve control space
-link dot colour for control

--- a/TODO
+++ b/TODO
@@ -1,0 +1,3 @@
+apply controlnet model fix
+improve control space
+link dot colour for control

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -28,6 +28,10 @@ runtime = [
   "scipy>=1.11",
   # We call snapshot_download directly for the model popup, so pin it rather than rely on transit.
   "huggingface_hub>=0.23",
+  # ControlNet preprocessors (the Apply ControlNet node): OpenPose/DWPose, MiDaS/Zoe depth, canny,
+  # HED, lineart, MLSD, scribble, normal. DWPose runs its detector on ONNX Runtime.
+  "controlnet-aux>=0.0.7",
+  "onnxruntime>=1.17",
 ]
 server = [
   "fastapi>=0.110",
@@ -74,6 +78,8 @@ all = [
   "torchao>=0.14",
   "scipy>=1.11",
   "huggingface_hub>=0.23",
+  "controlnet-aux>=0.0.7",
+  "onnxruntime>=1.17",
   # server
   "fastapi>=0.110",
   "uvicorn[standard]>=0.29",

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 # PyPI name; the import package is `inline_core` (src/inline_core).
 name = "inline-core"
-version = "1.2.52"
+version = "1.2.53"
 description = "The generation engine behind Inline Studio."
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/core/src/inline_core/__init__.py
+++ b/core/src/inline_core/__init__.py
@@ -4,4 +4,11 @@ Takes a typed node graph and returns immutable takes. See PLAN.md for the archit
 docs/contract.md for the Storyline API.
 """
 
-__version__ = "0.0.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    #: Resolved from the installed package, so pyproject.toml stays the only place a release is
+    #: bumped. An editable install records this at install time; reinstall after bumping.
+    __version__ = version("inline-core")
+except PackageNotFoundError:  # a source tree that was never installed
+    __version__ = "0.0.0"

--- a/core/src/inline_core/device/memory.py
+++ b/core/src/inline_core/device/memory.py
@@ -202,9 +202,10 @@ class MemoryPolicy(DevicePolicy):
             return None
         cap = max(0.0, budget - _ACTIVATION_HEADROOM_GB)
         big = (fp.diffusion_bytes + fp.text_encoder_bytes) / 1e9
-        vae = fp.vae_bytes / 1e9
-        full = big + vae
-        int8 = big * _INT8_FACTOR + vae
+        # The VAE and a ControlNet are never quantized, so they cost the same under every plan.
+        fixed = (fp.vae_bytes + fp.controlnet_bytes) / 1e9
+        full = big + fixed
+        int8 = big * _INT8_FACTOR + fixed
         forced = _env_profile() is not None  # explicit --profile pins the profile; fit picks quant
 
         def prof(auto: Profile) -> Profile:

--- a/core/src/inline_core/device/policy.py
+++ b/core/src/inline_core/device/policy.py
@@ -87,10 +87,14 @@ class ModelFootprint:
     diffusion_bytes: int = 0
     text_encoder_bytes: int = 0
     vae_bytes: int = 0
+    #: A ControlNet loaded alongside the denoiser. Never quantized, so it counts full in every plan.
+    controlnet_bytes: int = 0
 
     @property
     def total_bytes(self) -> int:
-        return self.diffusion_bytes + self.text_encoder_bytes + self.vae_bytes
+        return (
+            self.diffusion_bytes + self.text_encoder_bytes + self.vae_bytes + self.controlnet_bytes
+        )
 
 
 @dataclass(frozen=True)

--- a/core/src/inline_core/graph/cache.py
+++ b/core/src/inline_core/graph/cache.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from ..takes import Take
 from .registry import Registry
-from .schema import Graph, Node
+from .schema import Graph, Node, PortKind
 
 
 class NodeCache(ABC):
@@ -40,8 +40,15 @@ def _canonical_params(node: Node, registry: Registry) -> dict[str, Any]:
 
 
 def is_cache_eligible(node: Node, registry: Registry) -> bool:
-    """False when any seed param resolves to a negative (random) value."""
+    """False when a control map is wired, or any seed param resolves to a negative (random) value.
+
+    A node driven by a control map re-runs every time: the user iterates on the pose/depth and
+    expects each run to apply the current control, so a cached take would read as "control not
+    taking effect" (even a re-render at the same seed must re-apply it)."""
     descriptor = registry.get(node.type)
+    for port in descriptor.inputs:
+        if port.kind is PortKind.CONTROL and node.inputs.get(port.id):
+            return False
     defaults = descriptor.defaults()
     for key in descriptor.seed_keys():
         value = node.params.get(key, defaults.get(key))

--- a/core/src/inline_core/graph/cache.py
+++ b/core/src/inline_core/graph/cache.py
@@ -81,3 +81,29 @@ def node_cache_key(
     digest = hashlib.sha256(json.dumps(payload, sort_keys=True, default=str).encode()).hexdigest()
     memo[node_id] = digest
     return digest
+
+
+def asset_content_hashes(graph: Graph) -> dict[str, str]:
+    """The byte hash of each file-backed source node's asset, keyed by node id. Feeds
+    ``node_cache_key`` so the cache invalidates when a file's *content* changes even though its path
+    did not (a re-rendered control map, an in-place-replaced input image). Only ``ref="path"`` refs
+    are hashable; a missing file is skipped - its path still keys the node through its params."""
+    import os
+
+    hashes: dict[str, str] = {}
+    for node in graph.nodes:
+        asset = node.params.get("asset")
+        if not isinstance(asset, dict) or asset.get("ref") != "path":
+            continue
+        path = asset.get("path")
+        if isinstance(path, str) and os.path.isfile(path):
+            hashes[node.id] = _file_hash(path)
+    return hashes
+
+
+def _file_hash(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/core/src/inline_core/graph/executor.py
+++ b/core/src/inline_core/graph/executor.py
@@ -6,6 +6,7 @@ It orchestrates cheap work inline. A model node's runner submits the denoise to 
 
 from __future__ import annotations
 
+import logging
 from dataclasses import replace
 from typing import Any
 
@@ -18,6 +19,8 @@ from .registry import Registry
 from .schema import Graph, Node
 from .topo import topo_sort, upstream_closure
 from .validate import validate
+
+logger = logging.getLogger(__name__)
 
 
 class Executor:
@@ -44,6 +47,12 @@ class Executor:
             emitter.emit(ErrorEvent(run_id=ctx.run_id, message=str(error), node_id=error.node_id))
         except InlineCoreError as error:
             emitter.emit(ErrorEvent(run_id=ctx.run_id, message=str(error)))
+        except Exception as error:  # noqa: BLE001
+            # A runner that raises a non-InlineCoreError (e.g. a diffusers/HF load error) must still
+            # terminate the run: otherwise it escapes to the worker thread, the terminal event is
+            # never sent, and the run wedges in "queued" while the UI hangs on "loading model".
+            logger.exception("Run %s failed with an unhandled error", ctx.run_id)
+            emitter.emit(ErrorEvent(run_id=ctx.run_id, message=str(error) or type(error).__name__))
 
     def _plan(self, graph: Graph, target: str, state: RunState) -> list[str]:
         validate(graph, target, self._registry)

--- a/core/src/inline_core/graph/executor.py
+++ b/core/src/inline_core/graph/executor.py
@@ -14,7 +14,7 @@ from ..errors import CancelledError, GraphValidationError, InlineCoreError
 from ..runtime.context import ExecutionContext
 from ..runtime.progress import CancelledEvent, ErrorEvent, NodeDoneEvent, RunDoneEvent
 from ..runtime.run import NodeRuntimeState, RunState, RunStatus, StateTrackingEmitter
-from .cache import NodeCache, is_cache_eligible, node_cache_key
+from .cache import NodeCache, asset_content_hashes, is_cache_eligible, node_cache_key
 from .registry import Registry
 from .schema import Graph, Node
 from .topo import topo_sort, upstream_closure
@@ -36,10 +36,13 @@ class Executor:
             order = self._plan(graph, target, state)
             state.status = RunStatus.RUNNING
             outputs: dict[str, dict[str, Any]] = {}
+            # Hash the input files once so the node cache is content-addressed: a re-rendered
+            # control map (or any replaced input) invalidates even when its path is unchanged.
+            asset_hashes = asset_content_hashes(graph)
             for node_id in order:
                 if ctx.cancel.cancelled:
                     raise CancelledError("Run cancelled.")
-                self._run_node(graph, node_id, outputs, run_ctx)
+                self._run_node(graph, node_id, outputs, run_ctx, asset_hashes)
             emitter.emit(RunDoneEvent(run_id=ctx.run_id))
         except CancelledError:
             emitter.emit(CancelledEvent(run_id=ctx.run_id))
@@ -68,6 +71,7 @@ class Executor:
         node_id: str,
         outputs: dict[str, dict[str, Any]],
         ctx: ExecutionContext,
+        asset_hashes: dict[str, str],
     ) -> None:
         node = graph.node(node_id)
         runner = self._registry.runner(node.type)
@@ -75,8 +79,7 @@ class Executor:
 
         key: str | None = None
         if runner.produces_takes and is_cache_eligible(node, self._registry):
-            # TODO(phase1): pass real asset content hashes so identity is content-addressed.
-            key = node_cache_key(graph, node_id, self._registry, asset_hashes={})
+            key = node_cache_key(graph, node_id, self._registry, asset_hashes=asset_hashes)
             cached = self._cache.get(key)
             if cached is not None:
                 ctx.emitter.emit(

--- a/core/src/inline_core/graph/schema.py
+++ b/core/src/inline_core/graph/schema.py
@@ -26,6 +26,7 @@ class PortKind(str, Enum):
     LORA = "lora"
     CONDITIONING = "conditioning"
     LATENT = "latent"
+    CONTROL = "control"
 
 
 def port_satisfies(source: PortKind, target: PortKind) -> bool:
@@ -33,7 +34,10 @@ def port_satisfies(source: PortKind, target: PortKind) -> bool:
     if source == target:
         return True
     # a single image satisfies a list input (a one-element list)
-    return source is PortKind.IMAGE and target is PortKind.IMAGE_LIST
+    if source is PortKind.IMAGE and target is PortKind.IMAGE_LIST:
+        return True
+    # a control input accepts any image output (the control map is just an image)
+    return source is PortKind.IMAGE and target is PortKind.CONTROL
 
 
 @dataclass(frozen=True)

--- a/core/src/inline_core/models/controlspace.py
+++ b/core/src/inline_core/models/controlspace.py
@@ -1,0 +1,26 @@
+"""Requirements for the client-side "Control Space" node: just the suggested ControlNet model, so
+the node can offer a one-click download when ``models/controlnet/`` is empty. Torch-free (pure
+filesystem), so it registers even on a runtime-less install - a download only needs the models dir.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ..config import models_dir
+from .requirements import ModelComponent
+from .zimage.requirements import controlnet_component
+
+
+class ControlSpaceProvider:
+    """The ControlNet a Control Space render needs downstream - offered as a suggested download."""
+
+    def components(self, params: dict[str, object] | None = None) -> list[ModelComponent]:
+        return [controlnet_component()]
+
+    def download_target(self, component: ModelComponent) -> Path:
+        return models_dir() / component.category
+
+    def estimate(self, policy: Any) -> dict[str, Any] | None:
+        return None

--- a/core/src/inline_core/models/krea2/depth_control.py
+++ b/core/src/inline_core/models/krea2/depth_control.py
@@ -1,0 +1,149 @@
+"""Krea 2 depth control: the public ``Patil/Krea-2-depth-controlnet`` control-LoRA, ported onto the
+diffusers ``Krea2Transformer2DModel``.
+
+The adapter is a rank-64 LoRA on every transformer block **plus a full replacement input
+projection** (``first.weight [6144, 128]``): the base projection takes 64 packed latent channels,
+expanded to 128 so a VAE-encoded depth latent rides alongside the noisy latent, concatenated on the
+channel dim. The base stays frozen and the depth latent is constant across the whole denoise.
+
+The checkpoint uses the reference krea-2 names (``blocks.N.attn.wq``, ``first``); ``convert_key``
+already remaps those to diffusers names (``transformer_blocks.N.attn.to_q``, ``img_in``), the same
+rename the base checkpoint needs. Wrapping ``img_in`` lets the depth concat happen transparently
+inside the pipeline's own denoise loop - no fork of ``Krea2Pipeline.__call__``. Reference:
+github.com/Tanmaypatil123/Krea-2-controlnet.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from ...errors import ComponentError
+from .convert import convert_key
+from .img2img import encode_image
+
+
+class LoRALinear(nn.Module):
+    """``y = W x + scale * (x A^T) B^T``. Base frozen; ``scale`` is the live control strength."""
+
+    def __init__(self, base: nn.Linear, rank: int, scale: float = 1.0) -> None:
+        super().__init__()
+        self.base = base
+        self.scale = scale
+        self.A = nn.Parameter(torch.zeros(rank, base.in_features, dtype=torch.float32))
+        self.B = nn.Parameter(torch.zeros(base.out_features, rank, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        lora = (x @ self.A.T.to(x.dtype)) @ self.B.T.to(x.dtype)
+        return self.base(x) + lora * self.scale
+
+
+class ControlInputLayer(nn.Module):
+    """Replaces ``img_in``: input width doubled (64 -> 128) to accept
+    ``[noisy latent ; depth latent]`` concatenated on the channel dim. The depth latent is stashed
+    on ``self.ctrl`` once per run and broadcast over the batch (so CFG's doubled batch lines up)."""
+
+    def __init__(self, pretrained: nn.Linear) -> None:
+        super().__init__()
+        self._in = pretrained.in_features
+        # The checkpoint always carries the full trained input projection (both the base and depth
+        # halves), so zeros are enough here - and this avoids dequantizing a possibly-int8 base.
+        self.weight = nn.Parameter(torch.zeros(pretrained.out_features, self._in * 2))
+        self.bias = nn.Parameter(torch.zeros(pretrained.out_features))
+        self.ctrl: torch.Tensor | None = None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.ctrl is None:  # a control pipe always has ctrl set before a run; zeros = no depth
+            ctrl = x.new_zeros((*x.shape[:-1], self._in))
+        else:
+            ctrl = self.ctrl.to(device=x.device, dtype=x.dtype)
+            if ctrl.shape[0] != x.shape[0]:
+                ctrl = ctrl.expand(x.shape[0], -1, -1)
+        combined = torch.cat([x, ctrl], dim=-1)
+        return F.linear(combined, self.weight.to(x.dtype), self.bias.to(x.dtype))
+
+
+def _get(root: Any, path: str) -> Any:
+    for part in path.split("."):
+        root = root[int(part)] if part.isdigit() else getattr(root, part)
+    return root
+
+
+def _set(root: Any, path: str, value: Any) -> None:
+    parts = path.split(".")
+    parent = _get(root, ".".join(parts[:-1])) if len(parts) > 1 else root
+    last = parts[-1]
+    if last.isdigit():
+        parent[int(last)] = value
+    else:
+        setattr(parent, last, value)
+
+
+def _module_paths(state: dict[str, torch.Tensor]) -> list[str]:
+    """The block-linear module paths the adapter references (``img_in`` handled separately)."""
+    paths: list[str] = []
+    for key in state:
+        if key.startswith("img_in."):
+            continue
+        stem = key.rsplit(".", 1)[0]  # drop the trailing .A / .B
+        if stem not in paths:
+            paths.append(stem)
+    return paths
+
+
+def install_depth_control(transformer: Any, lora_file: str) -> None:
+    """Wrap ``img_in`` + every block linear the LoRA touches, then load the trained weights in.
+
+    Idempotent per pipeline: only called on a cache miss, so a cached control pipe keeps its work.
+    ``set_control`` / ``set_control_strength`` are the per-run knobs on top of it.
+    """
+    import safetensors.torch
+
+    st: Any = safetensors.torch
+    raw: dict[str, Any] = st.load_file(lora_file)
+    state = {convert_key(k): v for k, v in raw.items()}
+    a_shapes = [t.shape[0] for k, t in state.items() if k.endswith(".A")]
+    if not a_shapes:
+        raise ComponentError("Krea 2 depth control file has no LoRA tensors; not the adapter.")
+    rank = a_shapes[0]
+
+    device = next(transformer.parameters()).device
+    transformer.img_in = ControlInputLayer(transformer.img_in).to(device)
+    for path in _module_paths(state):
+        _set(transformer, path, LoRALinear(_get(transformer, path), rank).to(device))
+
+    missing, unexpected = transformer.load_state_dict(state, strict=False)
+    if unexpected:
+        raise ComponentError(
+            f"Krea 2 depth control-LoRA has {len(unexpected)} tensors that do not map onto the "
+            f"model (e.g. {', '.join(unexpected[:3])}). It may be for a different Krea 2 build."
+        )
+    # The expanded input projection is zero-initialised, so it MUST come from the checkpoint.
+    if "img_in.weight" in missing or "img_in.bias" in missing:
+        raise ComponentError(
+            "Krea 2 depth control-LoRA is missing its input projection (img_in); not the adapter."
+        )
+
+
+def set_control_strength(transformer: Any, scale: float) -> None:
+    """Dial the block LoRA delta (the depth ``img_in`` expansion always applies). No rebuild."""
+    for module in transformer.modules():
+        if isinstance(module, LoRALinear):
+            module.scale = scale
+
+
+def set_control(transformer: Any, ctrl_latent: torch.Tensor | None) -> None:
+    img_in = transformer.img_in
+    if isinstance(img_in, ControlInputLayer):
+        img_in.ctrl = ctrl_latent
+
+
+def encode_depth_latent(
+    pipe: Any, depth_image: Any, *, width: int, height: int, device: str, generator: Any
+) -> torch.Tensor:
+    """The depth map as a packed Krea 2 latent, ready to concat onto the noisy latent - the same VAE
+    encode + pack the img2img path uses, so the two latents share a layout."""
+    return encode_image(pipe, depth_image, width, height, device, generator)

--- a/core/src/inline_core/models/krea2/img2img.py
+++ b/core/src/inline_core/models/krea2/img2img.py
@@ -54,14 +54,14 @@ def img2img_kwargs(
     schedule.set_timesteps(sigmas=raw, mu=mu, device=device)
     sigma = schedule.sigmas[start].to(device)
 
-    latents = _encode_image(pipe, image, width, height, device, generator)
+    latents = encode_image(pipe, image, width, height, device, generator)
     noise = torch.randn(
         latents.shape, generator=generator, device=latents.device, dtype=latents.dtype
     )
     return {"latents": (1.0 - sigma) * latents + sigma * noise, "sigmas": raw[start:].tolist()}
 
 
-def _encode_image(
+def encode_image(
     pipe: Any, image: Any, width: int, height: int, device: str, generator: Any
 ) -> Any:
     """The input image as packed, normalized Krea 2 latents. The Qwen-Image VAE is a video codec, so

--- a/core/src/inline_core/models/krea2/requirements.py
+++ b/core/src/inline_core/models/krea2/requirements.py
@@ -27,6 +27,11 @@ VAE_FILE = "qwen_image_vae_diffusers.safetensors"
 VAE_REPO_FILE = "vae/diffusion_pytorch_model.safetensors"
 TEXT_ENCODER_FILE = "qwen3vl_4b_bf16.safetensors"
 
+#: The public Krea 2 depth control-LoRA (rank-64 + expanded input projection). It lands in
+#: ``controlnet/`` alongside any Z-Image controlnet; resolution is name-scoped so the two never mix.
+DEPTH_CONTROL_REPO = "Patil/Krea-2-depth-controlnet"
+DEPTH_CONTROL_FILE = "depth-control-lora.safetensors"
+
 #: variant -> the file the popup downloads for that node.
 DIFFUSION_FILES = {
     "turbo": "krea2_turbo_bf16.safetensors",
@@ -98,6 +103,57 @@ def resolve_diffusion(variant: str, params: dict[str, object] | None = None) -> 
     return krea[0] if krea else None
 
 
+def resolve_depth_control(params: dict[str, object] | None = None) -> Path | None:
+    """The depth control-LoRA file, or None. Opt-in like Z-Image control: resolves only from
+    ``INLINE_KREA2_CONTROL`` or an explicit ``depth_controlnet`` dropdown pick (never auto)."""
+    env = os.environ.get("INLINE_KREA2_CONTROL", "").strip()
+    if env:
+        path = Path(env)
+        return path if path.exists() else None
+    chosen = str((params or {}).get("depth_controlnet") or "").strip()
+    if not chosen:
+        return None
+    picked = models_dir() / "controlnet" / chosen
+    return picked if picked.is_file() else None
+
+
+def auto_depth_control() -> Path | None:
+    """The depth control-LoRA to use when a control map is wired but none was picked - the exact
+    downloaded file, else a krea+depth-named weight. None if absent. Only consulted when a control
+    input is actually connected, so depth control stays opt-in and never touches a plain run."""
+    root = models_dir() / "controlnet"
+    if not root.is_dir():
+        return None
+    exact = root / DEPTH_CONTROL_FILE
+    if exact.is_file():
+        return exact
+    for path in sorted(root.iterdir()):
+        name = path.name.lower()
+        if path.is_file() and path.suffix.lower() in _WEIGHT_SUFFIXES:
+            if "krea" in name and "depth" in name:
+                return path
+    return None
+
+
+def depth_control_present() -> bool:
+    return auto_depth_control() is not None
+
+
+def depth_control_component() -> ModelComponent:
+    """The suggested depth control-LoRA download, offered on both Krea 2 nodes. Optional: it never
+    blocks a plain run."""
+    return ModelComponent(
+        id="depth_controlnet",
+        label="Depth control-LoRA",
+        category="controlnet",
+        present=depth_control_present(),
+        filename=DEPTH_CONTROL_FILE,
+        repo=DEPTH_CONTROL_REPO,
+        repo_file=DEPTH_CONTROL_FILE,
+        optional=True,
+    )
+
+
 def resolve_vae(params: dict[str, object] | None = None) -> Path | None:
     return _resolve_shared("vae", "vae", VAE_FILE, params)
 
@@ -160,6 +216,8 @@ def krea2_requirements(
             repo=VAE_REPO,
             repo_file=VAE_REPO_FILE,
         ),
+        # Suggested, not required: offered in the popup so a depth map has an adapter to run with.
+        depth_control_component(),
     ]
 
 
@@ -182,11 +240,15 @@ def _file_bytes(path: object) -> int:
 
 
 def footprint_bytes(
-    diffusion: object = None, vae: object = None, text_encoder: object = None
+    diffusion: object = None,
+    vae: object = None,
+    text_encoder: object = None,
+    controlnet: object = None,
 ) -> dict[str, int]:
     """On-disk sizes keyed to match ``ModelFootprint``. Torch-free (a plain ``stat``)."""
     return {
         "diffusion_bytes": _file_bytes(diffusion),
         "text_encoder_bytes": _file_bytes(text_encoder),
         "vae_bytes": _file_bytes(vae),
+        "controlnet_bytes": _file_bytes(controlnet),
     }

--- a/core/src/inline_core/models/krea2/requirements.py
+++ b/core/src/inline_core/models/krea2/requirements.py
@@ -61,6 +61,18 @@ def _env_path(kind: str) -> Path | None:
     return path if path.exists() else None
 
 
+def foreign_model_message(path: str) -> str | None:
+    """A clear error when a diffusion file plainly belongs to another architecture (a Z-Image file
+    picked for a Krea 2 node) - name-based, best-effort, to avoid silently distorted output."""
+    name = Path(path).name.lower()
+    if ("z_image" in name or "z-image" in name) and "krea" not in name:
+        return (
+            f"'{Path(path).name}' is a Z-Image model, but this is a Krea 2 node. Pick a "
+            "krea2_*.safetensors in the Diffusion file dropdown (or clear it to auto-select)."
+        )
+    return None
+
+
 def resolve_diffusion(variant: str, params: dict[str, object] | None = None) -> Path | None:
     """The Krea 2 transformer file for this node: the dropdown pick, the env override, the exact
     recommended file, else any krea2 file matching the variant. A user holding both RAW and Turbo

--- a/core/src/inline_core/models/krea2/runner.py
+++ b/core/src/inline_core/models/krea2/runner.py
@@ -32,6 +32,7 @@ from ...runtime.store import TakeStore
 from .. import loaders
 from .. import pipeline_runtime as rt
 from ..sampling import SamplingFamily, apply_sampling, sampling_param_fields
+from . import depth_control as dc
 from . import requirements as reqs
 from .img2img import img2img_kwargs
 
@@ -63,6 +64,7 @@ def _descriptor(variant: str) -> NodeDescriptor:
             Port("text_encoder", "Text encoder", PortKind.TEXT_ENCODER, required=False),
             Port("lora", "LoRA", PortKind.LORA, required=False),
             Port("image", "Image (img2img)", PortKind.IMAGE, required=False),
+            Port("control_image", "Depth control", PortKind.CONTROL, required=False),
         ),
         outputs=(Port("image", "Image", PortKind.IMAGE),),
         params=(
@@ -78,6 +80,17 @@ def _descriptor(variant: str) -> NodeDescriptor:
             ParamField(
                 "strength", "Denoise strength", Widget.NUMBER, 0.6, min=0.0, max=1.0, step=0.05,
                 advanced=True,
+            ),
+            # Depth control: wire a depth map into Control and pick the depth control-LoRA.
+            # Empty = plain generation. Strength dials the block LoRA; the depth structure always
+            # enters through the expanded input projection.
+            ParamField(
+                "depth_controlnet", "Depth control-LoRA", Widget.SELECT, "",
+                options_from="controlnet",
+            ),
+            ParamField(
+                "control_strength", "Control strength", Widget.NUMBER, 1.0,
+                min=0.0, max=2.0, step=0.05,
             ),
             ParamField("seed", "Seed (-1 = random)", Widget.SEED, -1),
             ParamField(
@@ -130,7 +143,21 @@ class Krea2Runner(NodeRunner):
         sampler = str(params["sampler"])
         scheduler = str(params["scheduler"])
         image_ref = rt.first(inputs.get("image"))
-        img2img = image_ref is not None
+
+        # Depth control (opt-in): a depth map wired into Control + the depth control-LoRA picked.
+        # Auto-picks the adapter when a map is wired but none was chosen, so wiring just works.
+        control_ref = rt.first(inputs.get("control_image"))
+        depth_lora = reqs.resolve_depth_control(params)
+        if control_ref is not None and depth_lora is None:
+            depth_lora = reqs.auto_depth_control()
+            if depth_lora is not None:
+                logger.info("Depth control wired, none picked; auto-using %s", depth_lora.name)
+        use_control = control_ref is not None and depth_lora is not None
+        if control_ref is not None and depth_lora is None:
+            logger.warning("Depth control wired but no control-LoRA found in models/controlnet/.")
+        # Depth control starts from noise (the depth latent is the structure signal), so it and
+        # img2img are mutually exclusive - control wins when both are wired.
+        img2img = image_ref is not None and not use_control
 
         model_ref = rt.component_ref(inputs, "model", "diffusion", self._label)
         vae_ref = rt.component_ref(inputs, "vae", "vae", self._label)
@@ -141,7 +168,7 @@ class Krea2Runner(NodeRunner):
         missing = [
             c.label
             for c in reqs.krea2_requirements(self._variant, params)
-            if not c.present and c.id not in wired
+            if not c.present and not c.optional and c.id not in wired
         ]
         if missing:
             raise ComponentError(
@@ -161,8 +188,9 @@ class Krea2Runner(NodeRunner):
             reqs.resolve_text_encoder(params), "text encoder"
         )
 
+        control_file = str(depth_lora) if use_control else None
         self._policy.set_footprint(
-            ModelFootprint(**reqs.footprint_bytes(source, vae_file, te_file))
+            ModelFootprint(**reqs.footprint_bytes(source, vae_file, te_file, control_file))
         )
         fit = self._policy.fit_estimate()
         if fit is not None and not fit.fits:
@@ -185,6 +213,7 @@ class Krea2Runner(NodeRunner):
                 text=te_file,
                 quant=self._policy.quantization(),
                 loras=loras,
+                controlnet=control_file,
                 cancel_check=lambda: rt.raise_if_cancelled(ctx),
             )
         except CancelledError:
@@ -233,6 +262,19 @@ class Krea2Runner(NodeRunner):
                     device=gen_device,
                 )
             )
+        control_strength = float(params.get("control_strength", 1.0))
+        if use_control:
+            # The surgery is baked into the cached pipe; the depth latent and strength are per-run.
+            ctrl_latent = dc.encode_depth_latent(
+                pipe,
+                rt.load_image(control_ref, self._label),
+                width=width,
+                height=height,
+                device=gen_device,
+                generator=generator,
+            )
+            dc.set_control(pipe.transformer, ctrl_latent)
+            dc.set_control_strength(pipe.transformer, control_strength)
         # img2img starts partway down the schedule, so it runs fewer steps than `steps`.
         total_steps = len(call["sigmas"]) if "sigmas" in call else steps
 
@@ -297,6 +339,14 @@ class Krea2Runner(NodeRunner):
                 "seed": seed,
                 **({"strength": float(params.get("strength", 0.6))} if img2img else {}),
                 **(
+                    {
+                        "depth_controlnet": str(depth_lora),
+                        "control_strength": control_strength,
+                    }
+                    if use_control
+                    else {}
+                ),
+                **(
                     {"loras": [{"file": lo.file, "strength": lo.strength} for lo in loras]}
                     if loras
                     else {}
@@ -331,6 +381,7 @@ def _load_pipeline(
     text: str,
     quant: Quantization = Quantization.NONE,
     loras: tuple[LoraRef, ...] = (),
+    controlnet: str | None = None,
     cancel_check: Callable[[], None] | None = None,
 ) -> Any:
     key = rt.PipelineKey(
@@ -341,6 +392,7 @@ def _load_pipeline(
         variant=variant,
         quant=quant.value,
         loras=loaders.lora_cache_key(loras),
+        controlnet=controlnet or "",
     )
     with rt.PIPELINES.lock:
         cached = rt.PIPELINES.get(key)
@@ -370,6 +422,10 @@ def _load_pipeline(
         )
         rt.configure_pipeline(pipe, policy)
         rt.capture_base_scheduler_config(pipe)
+        if controlnet:
+            # Depth control mutates the transformer (expanded input projection + block LoRA), so it
+            # is baked into this cache entry - a plain run keys to a different, unmodified pipe.
+            dc.install_depth_control(pipe.transformer, controlnet)
         rt.PIPELINES.put(key, pipe)
         logger.info("Krea 2 pipeline ready in %.1fs total", time.perf_counter() - started)
         return pipe

--- a/core/src/inline_core/models/krea2/runner.py
+++ b/core/src/inline_core/models/krea2/runner.py
@@ -153,6 +153,9 @@ class Krea2Runner(NodeRunner):
         source = model_ref.file if model_ref else _require(
             reqs.resolve_diffusion(self._variant, params), "diffusion model"
         )
+        foreign = reqs.foreign_model_message(source)
+        if foreign:
+            raise ComponentError(foreign)
         vae_file = vae_ref.file if vae_ref else _require(reqs.resolve_vae(params), "VAE")
         te_file = te_ref.file if te_ref else _require(
             reqs.resolve_text_encoder(params), "text encoder"

--- a/core/src/inline_core/models/loaders.py
+++ b/core/src/inline_core/models/loaders.py
@@ -337,8 +337,15 @@ def lora_cache_key(loras: tuple[LoraRef, ...]) -> tuple[str, ...]:
     return tuple(f"{lora.file}@{lora.strength}" for lora in loras)
 
 
+#: Component kinds whose cache key carries a real quantization (the others always store NONE, so
+#: comparing their quant slot against the plan's would evict them every time.)
+_QUANTIZED_KINDS = ("diffusion", "text_encoder")
+
+
 def unload_components(
-    keep_files: set[str] | None = None, keep_loras: tuple[str, ...] | None = None
+    keep_files: set[str] | None = None,
+    keep_loras: tuple[str, ...] | None = None,
+    keep_quant: str | None = None,
 ) -> None:
     """Drop cached components whose source file is NOT in ``keep_files``, freeing their VRAM/RAM.
 
@@ -351,7 +358,11 @@ def unload_components(
     ``keep_loras`` (the LoRA-stack suffix being loaded, from ``lora_cache_key``) additionally evicts
     a kept file's diffusion transformer when it carries a *different* stack: fusing a LoRA into an
     already-resident checkpoint would otherwise keep the unfused transformer AND the fused one - two
-    full-size models on the card. Left None, eviction is file-only (the pre-LoRA behaviour)."""
+    full-size models on the card. Left None, eviction is file-only (the pre-LoRA behaviour).
+
+    ``keep_quant`` does the same across quantizations: the fit plan re-quantizes when the footprint
+    changes (adding a ControlNet flips a resident load to int8), and the same file at two quants is
+    two cache entries, so without this the int8 and full-size transformers both stay resident."""
     keep = keep_files or set()
     with _CACHE_LOCK:
         stale = []
@@ -359,6 +370,8 @@ def unload_components(
             if k[2] not in keep:
                 stale.append(k)
             elif keep_loras is not None and k[1] == "diffusion" and tuple(k[6:]) != keep_loras:
+                stale.append(k)
+            elif keep_quant is not None and k[1] in _QUANTIZED_KINDS and k[4] != keep_quant:
                 stale.append(k)
         for k in stale:
             comp = _CACHE.pop(k)
@@ -414,6 +427,84 @@ def load_diffusion(
         *lora_cache_key(loras),
     )
     return _cached(key, build)
+
+
+#: The Fun ControlNet Union geometry (15 control layers on even base layers, 2 refiners, 33-channel
+#: control latent) - shared by the 2.0/2.1/2601/2602 full-size files. Bundled because a dropped-in
+#: single file has no config beside it and ``from_single_file`` would otherwise reach for the
+#: reference repo's ``config.json`` - a fetch the engine forbids (``local_files_only``), so an
+#: offline load raised "does not appear to have a file named config.json". The **lite** variants
+#: apply control to 3 layers instead and need their own config; `_controlnet_layer_count` rejects
+#: them with a clear message rather than a raw tensor-shape error.
+ZIMAGE_CONTROLNET_CONFIG = {
+    "add_control_noise_refiner": "control_noise_refiner",
+    "all_f_patch_size": [1],
+    "all_patch_size": [2],
+    "control_in_dim": 33,
+    "control_layers_places": [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28],
+    "control_refiner_layers_places": [0, 1],
+    "dim": 3840,
+    "n_heads": 30,
+    "n_kv_heads": 30,
+    "n_refiner_layers": 2,
+    "norm_eps": 1e-05,
+    "qk_norm": True,
+}
+
+
+def _controlnet_layer_count(file: str) -> int:
+    """How many control layers a ControlNet checkpoint carries, read from its header alone (no
+    weights). 0 when the file can't be inspected - the strict load then reports the mismatch."""
+    try:
+        from safetensors import safe_open
+
+        with safe_open(file, "pt") as handle:
+            prefix = "control_layers."
+            return len(
+                {k.split(".")[1] for k in handle.keys() if k.startswith(prefix)}  # noqa: SIM118
+            )
+    except Exception:  # noqa: BLE001 - a probe must never be the thing that fails a load
+        return 0
+
+
+def load_zimage_controlnet(file: str, dtype: Any, device: str | None = None) -> Any:
+    """The Z-Image ControlNet transformer from a single ``.safetensors`` (e.g. the Fun Union model).
+
+    Built from the bundled config and filled by ``assign=``, so nothing is ever fetched and the
+    weights land straight on ``device`` (never a full-size CPU copy first). The pipeline grafts the
+    shared transformer layers via ``from_transformer`` at build time. Small next to the base
+    transformer, so it is never quantized."""
+
+    def build() -> Any:
+        from accelerate import init_empty_weights
+        from diffusers import ZImageControlNetModel
+        from safetensors.torch import load_file
+
+        expected = len(ZIMAGE_CONTROLNET_CONFIG["control_layers_places"])
+        found = _controlnet_layer_count(file)
+        if found and found != expected:
+            raise ComponentError(
+                f"This ControlNet applies control to {found} layers, but Inline Core only bundles "
+                f"the {expected}-layer Z-Image Fun ControlNet geometry (the 'lite' variants use "
+                "fewer). Use a full-size Fun Union/Tile file."
+            )
+        with init_empty_weights():
+            model = ZImageControlNetModel.from_config(ZIMAGE_CONTROLNET_CONFIG)
+        state = load_file(file, device=device or "cpu")
+        state = {key: value.to(dtype) for key, value in state.items()}
+        # assign= replaces the meta parameters outright; a plain copy_ into meta storage errors.
+        model.load_state_dict(state, strict=True, assign=True)
+        state.clear()
+        _release_transient()
+        return model.eval()
+
+    # Never quantized, but the key still carries a quant slot so every kind shares one layout (the
+    # eviction sweep indexes into it positionally).
+    return _cached(
+        ("z-image", "controlnet", file, _dtype_key(dtype), Quantization.NONE.value,
+         _device_key(device)),
+        build,
+    )
 
 
 def load_vae(arch: str, file: str, dtype: Any, device: str | None = None) -> Any:
@@ -778,6 +869,7 @@ def assemble_zimage_pipeline(
     vae_dtype: Any = None,
     device: str | None = None,
     loras: tuple[LoraRef, ...] = (),
+    controlnet_file: str | None = None,
     cancel_check: Callable[[], None] | None = None,
 ) -> Any:
     """Build a Z-Image pipeline from three local single files. Components are cached individually,
@@ -792,7 +884,7 @@ def assemble_zimage_pipeline(
     second load bails after the current component instead of only at the first denoise step. It
     cannot break into a single component's blocking read (the transformer dominates), but it stops
     the run before loading the VAE + text encoder + placing + denoising."""
-    from diffusers import ZImageImg2ImgPipeline, ZImagePipeline
+    from diffusers import ZImageControlNetPipeline, ZImageImg2ImgPipeline, ZImagePipeline
 
     arch = _ZIMAGE.key
     transformer = load_diffusion(arch, diffusion_file, dtype, quant, device=device, loras=loras)
@@ -808,6 +900,19 @@ def assemble_zimage_pipeline(
     )
     _release_transient()
     scheduler = load_scheduler(arch)
+    if controlnet_file:
+        # ControlNet runs text-to-image + control (no img2img in this path). The pipeline __init__
+        # grafts the shared transformer layers onto the ControlNet via from_transformer.
+        controlnet = load_zimage_controlnet(controlnet_file, dtype, device=device)
+        _release_transient()
+        return ZImageControlNetPipeline(
+            scheduler=scheduler,
+            vae=vae,
+            text_encoder=text_encoder,
+            tokenizer=tokenizer,
+            transformer=transformer,
+            controlnet=controlnet,
+        )
     cls = ZImageImg2ImgPipeline if img2img else ZImagePipeline
     return cls(
         scheduler=scheduler,

--- a/core/src/inline_core/models/pipeline_runtime.py
+++ b/core/src/inline_core/models/pipeline_runtime.py
@@ -123,7 +123,9 @@ def _configure_gpu_speed(pipe: Any, placement: Placement) -> None:
 @dataclass(frozen=True)
 class PipelineKey:
     """Identifies one built pipeline. ``variant`` separates shapes built from the same weights
-    (t2i vs i2i); ``loras`` is order- and strength-sensitive because fusing is not commutative."""
+    (t2i vs i2i); ``loras`` is order- and strength-sensitive because fusing is not commutative.
+    ``controlnet`` is a *separate* field rather than part of ``variant`` so eviction can see it -
+    a control pipeline holds several GB of extra weights that must not survive a plain run."""
 
     arch: str
     diffusion: str
@@ -132,10 +134,16 @@ class PipelineKey:
     variant: str
     quant: str
     loras: tuple[str, ...] = ()
+    controlnet: str = ""
 
     @property
     def files(self) -> tuple[str, str, str]:
         return (self.diffusion, self.vae, self.text_encoder)
+
+    @property
+    def component_files(self) -> set[str]:
+        """Every weight file this pipeline holds - what a component sweep must keep alive."""
+        return set(self.files) | ({self.controlnet} if self.controlnet else set())
 
 
 class PipelineCache:
@@ -157,21 +165,37 @@ class PipelineCache:
         self._entries[key] = pipe
 
     def evict_stale(self, key: PipelineKey) -> None:
-        """Drop every pipeline that is not this key's (arch, files, LoRA stack), then free the
-        components behind them. Both variants of the surviving key are kept, so an i2i build can
-        still reuse a cached t2i base. Call under ``lock``."""
+        """Drop every pipeline that is not this key's (arch, files, LoRA stack, ControlNet, quant),
+        then free the components behind them. Only ``variant`` is allowed to differ, so an i2i build
+        still reuses a cached t2i base. Call under ``lock``.
+
+        ControlNet and quant are part of the match because both change what is *resident*, not just
+        the pipeline's shape: a surviving control pipeline pins its several-GB ControlNet (and its
+        transformer at the other quantization) while the new one loads on top, which OOMs the card.
+        """
         import gc
 
         from . import loaders
 
         for k in list(self._entries):
             keep = (
-                k.arch == key.arch and k.files == key.files and k.loras == key.loras
+                k.arch == key.arch
+                and k.files == key.files
+                and k.loras == key.loras
+                and k.controlnet == key.controlnet
+                and k.quant == key.quant
             )
             if not keep:
                 del self._entries[k]
+        # Drop the component-cache references too, THEN collect. Order matters: a diffusion
+        # transformer holds reference cycles, so it only frees on a gc - and stays referenced by the
+        # component cache until unload_components pops it. Collecting before that (the old order)
+        # freed the pipeline wrappers but left the multi-GB weights pinned, so empty_cache couldn't
+        # reclaim them and the next build (plain after control, a different quant) stacked -> OOM.
+        loaders.unload_components(
+            keep_files=key.component_files, keep_loras=key.loras, keep_quant=key.quant
+        )
         gc.collect()
-        loaders.unload_components(keep_files=set(key.files), keep_loras=key.loras)
         free_vram()
 
 

--- a/core/src/inline_core/models/pipeline_runtime.py
+++ b/core/src/inline_core/models/pipeline_runtime.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import math
 import os
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
@@ -26,7 +27,7 @@ from ..graph.loader_runners import ComponentRef, LoraRef
 from ..graph.schema import Node
 from ..runtime.context import ExecutionContext
 from ..runtime.progress import Phase, ProgressEvent
-from ..takes import AssetRef
+from ..takes import AssetRef, Take
 
 logger = logging.getLogger("inline_core.models")
 
@@ -371,15 +372,24 @@ def free_vram() -> None:
 
 
 def smaller_resolutions(width: int, height: int) -> list[str]:
-    """Square sizes strictly smaller than the current image, so an OOM hint only ever suggests
-    something that actually cuts peak memory."""
-    ladder = [1024, 768, 512, 384, 256]
-    current = max(width, height)
-    smaller = [f"{s}x{s}" for s in ladder if s < current]
-    if smaller:
-        return smaller[:2]
-    half = max(64, (current // 2 // 8) * 8)
-    return [f"{half}x{half}"]
+    """Sizes that keep the requested aspect ratio but cut pixel count, which is what drives peak
+    memory. Suggesting off a ladder of squares got both halves wrong: 1024x1024 is only 4% fewer
+    pixels than 896x1216 (so it OOMs too), and it silently turns a portrait into a square."""
+    pixels = width * height
+    out: list[str] = []
+    for area in (0.7, 0.5, 0.35):
+        scale = math.sqrt(area)
+        w = max(64, round(width * scale / 64) * 64)
+        h = max(64, round(height * scale / 64) * 64)
+        label = f"{w}x{h}"
+        if w * h < pixels and label not in out:
+            out.append(label)
+        if len(out) == 2:
+            break
+    if out:
+        return out
+    half = f"{max(64, width // 2 // 64 * 64)}x{max(64, height // 2 // 64 * 64)}"
+    return [half] if half != f"{width}x{height}" else []  # already at the floor: nothing to suggest
 
 
 def oom_message(
@@ -406,11 +416,14 @@ def oom_message(
             "distilled to "
             "run CFG-free - set Guidance to 0 to halve the memory. Or "
         )
-    suggestions = " or ".join(smaller_resolutions(width, height))
+    smaller = smaller_resolutions(width, height)
+    # Suggestions keep the requested aspect: someone who asked for a portrait wants a smaller
+    # portrait, not a square.
+    try_hint = f" (you're at {width}x{height} - try {' or '.join(smaller)})" if smaller else ""
     lower = "lower" if cfg_hint else "Lower"
     return (
         f"Ran out of GPU memory generating a {width}x{height} image. {cfg_hint}{lower} the "
-        f"resolution (you're at {width}x{height} - try {suggestions}) or pick a smaller model."
+        f"resolution{try_hint} or pick a smaller model."
     )
 
 
@@ -471,7 +484,11 @@ def load_image(ref: Any, label: str) -> Any:
 
     if isinstance(ref, AssetRef) and ref.ref == "path" and ref.path:
         return Image.open(ref.path).convert("RGB")
-    raise ComponentError(f"{label} img2img needs a readable image path input.")
+    # An upstream node's render feeds a Take, not an AssetRef - e.g. Apply ControlNet's control map
+    # into a gen node's Control input. Open its file.
+    if isinstance(ref, Take) and ref.uri:
+        return Image.open(ref.uri).convert("RGB")
+    raise ComponentError(f"{label} needs a readable image input.")
 
 
 def first(values: list[Any] | None) -> Any:

--- a/core/src/inline_core/models/preprocess/__init__.py
+++ b/core/src/inline_core/models/preprocess/__init__.py
@@ -1,0 +1,5 @@
+"""ControlNet preprocessing nodes (Apply ControlNet: image -> pose/depth/canny control map)."""
+
+from .runner import CONTROL_APPLY, register_control_apply
+
+__all__ = ["CONTROL_APPLY", "register_control_apply"]

--- a/core/src/inline_core/models/preprocess/requirements.py
+++ b/core/src/inline_core/models/preprocess/requirements.py
@@ -1,0 +1,59 @@
+"""What Apply ControlNet needs on disk: controlnet_aux's annotator weights, offered as suggested
+downloads so the node can prefetch them into ``models/annotators/`` instead of the hidden HF cache.
+Torch-free (pure filesystem), so it answers the model popup even on a runtime-less install.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ...config import models_dir
+from ..requirements import ModelComponent
+
+ANNOTATOR_REPO = "lllyasviel/Annotators"
+ANNOTATOR_DIR = "annotators"
+
+# controlnet_aux loads these flat from a local dir: OpenPose needs the body/hand/face files, depth
+# needs the MiDaS checkpoint. Canny needs no weights. (id, label, filename).
+_ANNOTATORS = (
+    ("openpose-body", "OpenPose body", "body_pose_model.pth"),
+    ("openpose-hand", "OpenPose hand", "hand_pose_model.pth"),
+    ("openpose-face", "OpenPose face", "facenet.pth"),
+    ("midas-depth", "MiDaS depth", "dpt_hybrid-midas-501f0c75.pt"),
+)
+
+
+def _present(filename: str) -> bool:
+    return (models_dir() / ANNOTATOR_DIR / filename).is_file()
+
+
+def annotator_components() -> list[ModelComponent]:
+    # Suggested (optional): the maps also work by auto-fetching into the HF cache on first run, so a
+    # missing detector is a soft suggestion, never a blocking "models missing".
+    return [
+        ModelComponent(
+            id=cid,
+            label=label,
+            category=ANNOTATOR_DIR,
+            present=_present(fn),
+            filename=fn,
+            repo=ANNOTATOR_REPO,
+            repo_file=fn,
+            optional=True,
+        )
+        for cid, label, fn in _ANNOTATORS
+    ]
+
+
+class PreprocessProvider:
+    """Apply ControlNet's detector weights, prefetched once into ``models/annotators/``."""
+
+    def components(self, params: dict[str, object] | None = None) -> list[ModelComponent]:
+        return annotator_components()
+
+    def download_target(self, component: ModelComponent) -> Path:
+        return models_dir() / component.category
+
+    def estimate(self, policy: Any) -> dict[str, Any] | None:
+        return None

--- a/core/src/inline_core/models/preprocess/runner.py
+++ b/core/src/inline_core/models/preprocess/runner.py
@@ -35,14 +35,16 @@ CONTROL_APPLY = NodeDescriptor(
     icon="wand",
     output_kind=MediaKind.IMAGE,
     inputs=(Port("image", "Image", PortKind.IMAGE, required=True),),
-    outputs=(Port("image", "Control map", PortKind.IMAGE),),
+    # A control map, not a plain image: kind CONTROL so it only feeds a gen node's Control input,
+    # never the img2img Image input (that would run image-to-image from the black map, not control).
+    outputs=(Port("image", "Control map", PortKind.CONTROL),),
     params=(
         ParamField(
             "type", "Type", Widget.SELECT, "pose",
             options=(
                 Option("pose", "OpenPose (pose)"),
-                Option("depth", "Depth"),
-                Option("canny", "Canny (edges)"),
+                Option("depth", "MiDaS (depth)"),
+                Option("canny", "Canny edges (no model)"),
             ),
         ),
         ParamField(

--- a/core/src/inline_core/models/preprocess/runner.py
+++ b/core/src/inline_core/models/preprocess/runner.py
@@ -1,0 +1,125 @@
+"""Apply ControlNet: turn an input image into a control map (pose / depth / canny) for a ControlNet.
+
+A single preprocessing node, ``control/apply``. controlnet_aux ships in the ``runtime`` extra but is
+imported inside the detector build on purpose - kept out of module top so the node's descriptor is
+served even on a runtime-less install; running it then fails with a clear "install the runtime
+extra" error rather than the node silently vanishing. The detector weights download once into the HF
+cache on first use (opt-in, the same fetch-once posture the auto-captioner uses)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ...config import models_dir
+from ...errors import ComponentError
+from ...graph.descriptor import NodeDescriptor, Option, ParamField, Port, Widget
+from ...graph.runners import NodeResult, NodeRunner
+from ...graph.schema import Node, PortKind
+from ...media import MediaKind
+from ...runtime.context import ExecutionContext
+from ...runtime.progress import Phase
+from ...runtime.store import TakeStore
+from .. import pipeline_runtime as rt
+
+logger = logging.getLogger("inline_core.preprocess")
+
+#: controlnet_aux's annotator weights (OpenPose, MiDaS depth, ...). Canny needs no weights.
+_ANNOTATOR_REPO = "lllyasviel/Annotators"
+_LABEL = "Apply ControlNet"
+
+CONTROL_APPLY = NodeDescriptor(
+    type="control/apply",
+    title="Apply ControlNet",
+    category="Control",
+    icon="wand",
+    output_kind=MediaKind.IMAGE,
+    inputs=(Port("image", "Image", PortKind.IMAGE, required=True),),
+    outputs=(Port("image", "Control map", PortKind.IMAGE),),
+    params=(
+        ParamField(
+            "type", "Type", Widget.SELECT, "pose",
+            options=(
+                Option("pose", "OpenPose (pose)"),
+                Option("depth", "Depth"),
+                Option("canny", "Canny (edges)"),
+            ),
+        ),
+        ParamField(
+            "detect_resolution", "Detail resolution", Widget.NUMBER, 512,
+            min=256, max=1536, step=64, advanced=True,
+        ),
+    ),
+)
+
+
+def register_control_apply(registry: Any, store: TakeStore, policy: Any) -> None:
+    """Register the Apply ControlNet node. Called best-effort by server.bootstrap. ``policy`` is
+    accepted for a uniform signature but unused - preprocessing runs on CPU."""
+    del policy
+    registry.register(CONTROL_APPLY, ControlApplyRunner(store))
+
+
+# Detectors are heavy to build (weights load / download), so build once and reuse across runs.
+_DETECTORS: dict[str, Any] = {}
+
+
+def _annotator_source(*files: str) -> str:
+    # Prefer weights the user prefetched into models/annotators/ (controlnet_aux loads them flat
+    # from a local dir); else the HF repo, which auto-fetches once into the HF cache. All files must
+    # be present for the local dir, or from_pretrained would fail on the missing one.
+    local = models_dir() / "annotators"
+    if all((local / f).is_file() for f in files):
+        return str(local)
+    return _ANNOTATOR_REPO
+
+
+def _detector(kind: str) -> Any:
+    cached = _DETECTORS.get(kind)
+    if cached is not None:
+        return cached
+    try:
+        from controlnet_aux import CannyDetector, MidasDetector, OpenposeDetector
+    except ImportError as error:
+        raise ComponentError(
+            "Apply ControlNet needs controlnet_aux (ships in the runtime extra). Reinstall it: "
+            "uv pip install -e '.[runtime]'."
+        ) from error
+    if kind == "canny":
+        det: Any = CannyDetector()
+    elif kind == "depth":
+        det = MidasDetector.from_pretrained(_annotator_source("dpt_hybrid-midas-501f0c75.pt"))
+    elif kind == "pose":
+        det = OpenposeDetector.from_pretrained(
+            _annotator_source("body_pose_model.pth", "hand_pose_model.pth", "facenet.pth")
+        )
+    else:
+        raise ComponentError(f"Unknown control type {kind!r}. Use pose, depth or canny.")
+    _DETECTORS[kind] = det
+    return det
+
+
+class ControlApplyRunner(NodeRunner):
+    produces_takes = True
+
+    def __init__(self, store: TakeStore) -> None:
+        self._store = store
+
+    def run(self, node: Node, inputs: dict[str, list[Any]], ctx: ExecutionContext) -> NodeResult:
+        image_ref = rt.first(inputs.get("image"))
+        if image_ref is None:
+            raise ComponentError("Apply ControlNet needs an input image.")
+        image = rt.load_image(image_ref, _LABEL)
+        params = {**CONTROL_APPLY.defaults(), **node.params}
+        kind = str(params.get("type") or "pose")
+        res = int(params.get("detect_resolution") or 512)
+
+        ctx.emitter.emit(rt.progress_event(ctx, node, Phase.LOADING, 0.0, status=f"{kind} map…"))
+        rt.raise_if_cancelled(ctx)
+        detector = _detector(kind)
+        logger.info("Apply ControlNet: %s map at %dpx", kind, res)
+        control = detector(image, detect_resolution=res, image_resolution=res)
+
+        ctx.emitter.emit(rt.progress_event(ctx, node, Phase.SAVE, 1.0, status="Saving…"))
+        take = self._store.save(ctx.run_id, node.id, control, {"type": kind})
+        return NodeResult(outputs={"image": take}, takes=[take])

--- a/core/src/inline_core/models/preprocess/runner.py
+++ b/core/src/inline_core/models/preprocess/runner.py
@@ -43,6 +43,7 @@ CONTROL_APPLY = NodeDescriptor(
             "type", "Type", Widget.SELECT, "pose",
             options=(
                 Option("pose", "OpenPose (pose)"),
+                Option("depth_anything", "Depth-Anything V2 (depth, for Krea 2)"),
                 Option("depth", "MiDaS (depth)"),
                 Option("canny", "Canny edges (no model)"),
             ),
@@ -89,6 +90,8 @@ def _detector(kind: str) -> Any:
         ) from error
     if kind == "canny":
         det: Any = CannyDetector()
+    elif kind == "depth_anything":
+        det = _DepthAnythingDetector()
     elif kind == "depth":
         det = MidasDetector.from_pretrained(_annotator_source("dpt_hybrid-midas-501f0c75.pt"))
     elif kind == "pose":
@@ -99,6 +102,50 @@ def _detector(kind: str) -> Any:
         raise ComponentError(f"Unknown control type {kind!r}. Use pose, depth or canny.")
     _DETECTORS[kind] = det
     return det
+
+
+class _DepthAnythingDetector:
+    """Depth-Anything-V2-Large depth, the estimator the Krea 2 depth control-LoRA trained on.
+    Returns a grayscale RGB depth map (near = white), per-image normalized. Auto-fetches into the HF
+    cache on first use, the same fetch-once posture as the controlnet_aux detectors."""
+
+    _MODEL_ID = "depth-anything/Depth-Anything-V2-Large-hf"
+
+    _processor: Any
+    _model: Any
+
+    def __init__(self) -> None:
+        try:
+            import transformers
+        except ImportError as error:
+            raise ComponentError(
+                "Depth-Anything needs transformers (ships in the runtime extra). Reinstall it: "
+                "uv pip install -e '.[runtime]'."
+            ) from error
+        tf: Any = transformers
+        self._processor = tf.AutoImageProcessor.from_pretrained(self._MODEL_ID)
+        self._model = tf.AutoModelForDepthEstimation.from_pretrained(self._MODEL_ID).eval()
+
+    def __call__(
+        self, image: Any, detect_resolution: int = 512, image_resolution: int = 512
+    ) -> Any:
+        # Depth-Anything's processor governs its own input size, so the resolution knobs (meant for
+        # the controlnet_aux detectors) are accepted for a uniform call but not used here.
+        del detect_resolution, image_resolution
+        import numpy as np
+        import torch
+        import torch.nn.functional as F
+        from PIL import Image
+
+        with torch.no_grad():
+            inputs = self._processor(images=[image], return_tensors="pt")
+            depth: Any = self._model(**inputs).predicted_depth[None].float()
+            depth = F.interpolate(
+                depth, size=(image.height, image.width), mode="bilinear", align_corners=False
+            )[0, 0]
+            depth = (depth - depth.min()) / (depth.max() - depth.min() + 1e-6)
+        array = (depth.cpu().numpy() * 255).astype(np.uint8)
+        return Image.fromarray(array).convert("RGB")
 
 
 class ControlApplyRunner(NodeRunner):

--- a/core/src/inline_core/models/requirements.py
+++ b/core/src/inline_core/models/requirements.py
@@ -27,6 +27,9 @@ class ModelComponent:
     filename: str  # the single file that lands flat in models/<category>/ (a dropdown entry)
     repo: str  # HF repo the popup downloads from
     repo_file: str  # exact repo-relative path fetched from ``repo``
+    # A suggested (not required) component - e.g. the opt-in ControlNet. It never counts toward
+    # "models missing" or "Download all"; the UI offers it as a separate suggestion.
+    optional: bool = False
 
     @property
     def local_path(self) -> str:

--- a/core/src/inline_core/models/zimage/requirements.py
+++ b/core/src/inline_core/models/zimage/requirements.py
@@ -168,6 +168,23 @@ def resolve_controlnet(params: dict[str, object] | None = None) -> Path | None:
     return picked if picked.is_file() else None
 
 
+def auto_controlnet() -> Path | None:
+    """The best ControlNet to use when a control map is wired but none was explicitly picked - so
+    wiring a Control Space / Apply ControlNet just works. Prefers a Z-Image-named file, then a
+    distilled/turbo build (fewer sampling steps), else the first available. None if the folder is
+    empty. (Only consulted when a control input is actually connected - control stays opt-in.)"""
+    root = models_dir() / "controlnet"
+    if not root.is_dir():
+        return None
+    files = sorted(
+        p for p in root.iterdir() if p.is_file() and p.suffix.lower() in _WEIGHT_SUFFIXES
+    )
+    named = [p for p in files if "z" in p.name.lower() and "image" in p.name.lower()]
+    pool = named or files
+    distilled = [p for p in pool if any(t in p.name.lower() for t in ("8step", "8-step", "2602"))]
+    return (distilled or pool or [None])[0]
+
+
 def resolve_text_encoder(params: dict[str, object] | None = None) -> Path | None:
     """The text-encoder single file (dropdown pick / ``INLINE_ZIMAGE_TEXT_ENCODER`` / the split
     ``qwen_3_4b.safetensors``)."""

--- a/core/src/inline_core/models/zimage/requirements.py
+++ b/core/src/inline_core/models/zimage/requirements.py
@@ -28,11 +28,15 @@ from ..requirements import ModelComponent
 #: and with extension-declared requirements. Re-exported here so existing importers keep working.
 __all__ = [
     "BASE_REPO",
+    "CONTROLNET_FILE",
+    "CONTROLNET_REPO",
     "DIFFUSION_FILE",
     "SPLIT_REPO",
     "TEXT_ENCODER_FILE",
     "VAE_FILE",
     "ModelComponent",
+    "controlnet_component",
+    "controlnet_present",
     "diffusion_root",
     "download_target",
     "find_weight_file",
@@ -136,6 +140,21 @@ def resolve_vae(params: dict[str, object] | None = None) -> Path | None:
     return _category_file("vae", VAE_FILE, "INLINE_ZIMAGE_VAE", (params or {}).get("vae"))
 
 
+def resolve_controlnet(params: dict[str, object] | None = None) -> Path | None:
+    """The ControlNet weight file, or None. Control is opt-in, so - unlike the base components -
+    this never auto-picks: it resolves only from ``INLINE_ZIMAGE_CONTROLNET`` or an explicit
+    dropdown choice in ``models/controlnet/``."""
+    env = os.environ.get("INLINE_ZIMAGE_CONTROLNET", "").strip()
+    if env:
+        path = Path(env)
+        return path if path.exists() else None
+    chosen = str((params or {}).get("controlnet") or "").strip()
+    if not chosen:
+        return None
+    picked = models_dir() / "controlnet" / chosen
+    return picked if picked.is_file() else None
+
+
 def resolve_text_encoder(params: dict[str, object] | None = None) -> Path | None:
     """The text-encoder single file (dropdown pick / ``INLINE_ZIMAGE_TEXT_ENCODER`` / the split
     ``qwen_3_4b.safetensors``)."""
@@ -192,6 +211,35 @@ def _split_component(
     )
 
 
+#: The recommended Z-Image ControlNet: the distilled 8-step Union model (pose/depth/canny in one
+#: file), the variant verified to work on Turbo. Suggested, not required - control is opt-in.
+CONTROLNET_REPO = "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1"
+CONTROLNET_FILE = "Z-Image-Turbo-Fun-Controlnet-Union-2.1-2602-8steps.safetensors"
+
+
+def controlnet_present() -> bool:
+    """True if any weight file is in ``models/controlnet/`` (the user's, or a popup download)."""
+    root = models_dir() / "controlnet"
+    if not root.is_dir():
+        return False
+    return any(p.is_file() and p.suffix.lower() in _WEIGHT_SUFFIXES for p in root.iterdir())
+
+
+def controlnet_component() -> ModelComponent:
+    """The suggested ControlNet Union download - offered on the Z-Image and Control Space nodes so a
+    control map can actually steer generation. Optional: it never blocks a plain run."""
+    return ModelComponent(
+        id="controlnet",
+        label="ControlNet (Union, 8-step)",
+        category="controlnet",
+        present=controlnet_present(),
+        filename=CONTROLNET_FILE,
+        repo=CONTROLNET_REPO,
+        repo_file=CONTROLNET_FILE,
+        optional=True,
+    )
+
+
 def zimage_requirements(params: dict[str, object] | None = None) -> list[ModelComponent]:
     """The three Z-Image components with live presence, for the node's model popup.
 
@@ -224,6 +272,8 @@ def zimage_requirements(params: dict[str, object] | None = None) -> list[ModelCo
             filename=TEXT_ENCODER_FILE,
             present=is_pipeline or resolve_text_encoder(params) is not None,
         ),
+        # Suggested, not required: offered in the popup so a control map has a model to run against.
+        controlnet_component(),
     ]
 
 
@@ -250,13 +300,19 @@ def _file_bytes(path: object) -> int:
 
 
 def footprint_bytes(
-    diffusion: object = None, vae: object = None, text_encoder: object = None
+    diffusion: object = None,
+    vae: object = None,
+    text_encoder: object = None,
+    controlnet: object = None,
 ) -> dict[str, int]:
-    """On-disk byte sizes of the three single-file components, keyed to match ``ModelFootprint``'s
-    fields. Torch-free (a plain ``stat``) so the policy/UI can size the load without the runtime.
-    Pass the already-resolved paths (which honor wired handles); a missing/folder path is 0."""
+    """On-disk byte sizes of the single-file components, keyed to match ``ModelFootprint``'s fields.
+    Torch-free (a plain ``stat``) so the policy/UI can size the load without the runtime. Pass the
+    already-resolved paths (which honor wired handles); a missing/folder path is 0. ``controlnet``
+    is only set when control is actually in play - it is several GB and must not be charged to a
+    plain run."""
     return {
         "diffusion_bytes": _file_bytes(diffusion),
         "text_encoder_bytes": _file_bytes(text_encoder),
         "vae_bytes": _file_bytes(vae),
+        "controlnet_bytes": _file_bytes(controlnet),
     }

--- a/core/src/inline_core/models/zimage/requirements.py
+++ b/core/src/inline_core/models/zimage/requirements.py
@@ -73,6 +73,19 @@ def diffusion_root() -> Path:
     return models_dir() / "diffusion_models"
 
 
+def foreign_model_message(path: str) -> str | None:
+    """A clear error when a diffusion file plainly belongs to another architecture (a Krea file
+    picked for a Z-Image node) - name-based, best-effort. Loading the wrong transformer through
+    Z-Image's VAE/text-encoder/ControlNet silently produces distorted output, so fail loudly."""
+    name = Path(path).name.lower()
+    if "krea" in name and "image" not in name:
+        return (
+            f"'{Path(path).name}' is a Krea model, but this is a Z-Image node. Pick a "
+            "z_image_*.safetensors in the Diffusion file dropdown (or clear it to auto-select)."
+        )
+    return None
+
+
 def find_weight_file(root: Path) -> Path | None:
     """The single diffusion weight file to load: prefer a z-image-named file, else the first one."""
     if not root.is_dir():

--- a/core/src/inline_core/models/zimage/runner.py
+++ b/core/src/inline_core/models/zimage/runner.py
@@ -57,6 +57,9 @@ ZIMAGE = NodeDescriptor(
         Port("text_encoder", "Text encoder", PortKind.TEXT_ENCODER, required=False),
         Port("lora", "LoRA", PortKind.LORA, required=False),
         Port("image", "Image (img2img)", PortKind.IMAGE, required=False),
+        # A control map (pose/depth/canny) from Apply ControlNet or Control Space. Needs a
+        # ControlNet model picked below; runs the ControlNet pipeline (text-to-image + control).
+        Port("control_image", "Control", PortKind.CONTROL, required=False),
     ),
     outputs=(Port("image", "Image", PortKind.IMAGE),),
     params=(
@@ -72,6 +75,15 @@ ZIMAGE = NodeDescriptor(
         ParamField(
             "strength", "Denoise strength", Widget.NUMBER, 0.6, min=0.0, max=1.0, step=0.05,
             advanced=True,
+        ),
+        # ControlNet: pick a model from models/controlnet/ and wire a control map into the Control
+        # input. "" = off (plain generation). The Union model gives pose/depth/canny in one file.
+        ParamField(
+            "controlnet", "ControlNet", Widget.SELECT, "", options_from="controlnet",
+        ),
+        ParamField(
+            "controlnet_conditioning_scale", "Control strength", Widget.NUMBER, 0.75,
+            min=0.0, max=1.0, step=0.05,
         ),
         ParamField("seed", "Seed (-1 = random)", Widget.SEED, -1),
         # Advanced: pick a specific file per component. "" = auto (the single file in that folder).
@@ -116,7 +128,15 @@ class ZImageRunner(NodeRunner):
         sampler = str(params["sampler"])
         scheduler = str(params["scheduler"])
         image_ref = rt.first(inputs.get("image"))
-        img2img = image_ref is not None
+        control_ref = rt.first(inputs.get("control_image"))
+        # Keep the Path|None: path_or_none() collapses None to "", which would make the
+        # `is not None` check below always true and load a ControlNet from an empty path.
+        controlnet_path = reqs.resolve_controlnet(params)
+        use_control = control_ref is not None and controlnet_path is not None
+        if control_ref is not None and controlnet_path is None:
+            logger.warning("Control image wired but no ControlNet model picked; ignoring control.")
+        # ControlNet is text-to-image + control; an img2img init image is ignored under control.
+        img2img = image_ref is not None and not use_control
 
         # Wired component handles from load/* subnodes override the dropdowns.
         model_ref = rt.component_ref(inputs, "model", "diffusion", _LABEL)
@@ -150,7 +170,11 @@ class ZImageRunner(NodeRunner):
 
         # Size-aware placement: hand the policy the on-disk sizes so it fits dtype/quant/offload to
         # THIS GPU, then refuse an impossible load up front rather than OOM-killing the server.
-        self._policy.set_footprint(_footprint(mode, source, vae_file, te_file))
+        self._policy.set_footprint(
+            _footprint(
+                mode, source, vae_file, te_file, str(controlnet_path) if use_control else "",
+            )
+        )
         fit = self._policy.fit_estimate()
         if fit is not None and not fit.fits:
             raise ComponentError(rt.wont_fit_message(fit))
@@ -172,6 +196,7 @@ class ZImageRunner(NodeRunner):
                 text=te_file,
                 quant=self._policy.quantization(),
                 loras=loras,
+                controlnet=str(controlnet_path) if use_control else None,
                 cancel_check=lambda: rt.raise_if_cancelled(ctx),
             )
         except CancelledError:
@@ -216,6 +241,11 @@ class ZImageRunner(NodeRunner):
         if img2img:
             call["image"] = rt.load_image(image_ref, _LABEL)
             call["strength"] = float(params.get("strength", 0.6))
+        if use_control:
+            call["control_image"] = rt.load_image(control_ref, _LABEL)
+            call["controlnet_conditioning_scale"] = float(
+                params.get("controlnet_conditioning_scale", 0.75)
+            )
 
         # Rebuild the scheduler for the chosen sampler/scheduler from the pipe's pristine base
         # config (immutable across cache hits).
@@ -273,6 +303,14 @@ class ZImageRunner(NodeRunner):
                 "seed": seed,
                 **({"strength": call["strength"]} if img2img else {}),
                 **(
+                    {
+                        "controlnet": str(controlnet_path),
+                        "controlnet_conditioning_scale": call["controlnet_conditioning_scale"],
+                    }
+                    if use_control
+                    else {}
+                ),
+                **(
                     {"loras": [{"file": lo.file, "strength": lo.strength} for lo in loras]}
                     if loras
                     else {}
@@ -301,8 +339,11 @@ def _load_pipeline(
     text: str,
     quant: Quantization = Quantization.NONE,
     loras: tuple[LoraRef, ...] = (),
+    controlnet: str | None = None,
     cancel_check: Callable[[], None] | None = None,
 ) -> Any:
+    # A control build is its own cached pipeline, keyed on the control file in its own field so
+    # eviction can tell it apart from the plain t2i/i2i pipelines built from the same base weights.
     key = rt.PipelineKey(
         arch=_ARCH,
         diffusion=source,
@@ -311,6 +352,7 @@ def _load_pipeline(
         variant="i2i" if img2img else "t2i",
         quant=quant.value,
         loras=loaders.lora_cache_key(loras),
+        controlnet=controlnet or "",
     )
     with rt.PIPELINES.lock:
         cached = rt.PIPELINES.get(key)
@@ -354,6 +396,7 @@ def _load_pipeline(
                 vae_dtype=vae_dtype,
                 device=load_device,
                 loras=loras,
+                controlnet=controlnet,
                 cancel_check=cancel_check,
             )
             logger.info(
@@ -386,12 +429,18 @@ def _build_pipeline(
     vae_dtype: Any = None,
     device: str | None = None,
     loras: tuple[LoraRef, ...] = (),
+    controlnet: str | None = None,
     cancel_check: Callable[[], None] | None = None,
 ) -> Any:
     """Build a Z-Image pipeline **offline**, from either a whole diffusers folder (``mode ==
     "pipeline"``) or three single ``.safetensors`` files (``mode == "single_file"``, the fast path
     the docs describe). ``quant`` applies to the single-file path only."""
     if mode == "pipeline":
+        if controlnet:
+            raise ComponentError(
+                "ControlNet needs the single-file diffusion layout (a file in diffusion_models/), "
+                "not a whole-pipeline folder. Switch the model or remove the ControlNet."
+            )
         if quant is not Quantization.NONE:
             logger.warning(
                 "Smart-memory quantization (%s) is not applied to a whole-pipeline folder; use the "
@@ -421,15 +470,16 @@ def _build_pipeline(
         vae_dtype=vae_dtype,
         device=device,
         loras=loras,
+        controlnet_file=controlnet,
         cancel_check=cancel_check,
     )
 
 
-def _footprint(mode: str, source: str, vae: str, text: str) -> ModelFootprint:
+def _footprint(mode: str, source: str, vae: str, text: str, controlnet: str = "") -> ModelFootprint:
     """On-disk component sizes for the fit estimate. Single-file mode only - a whole pipeline folder
     isn't sized here, so the policy falls back to its VRAM buckets."""
     diffusion = source if mode == "single_file" else ""
-    return ModelFootprint(**reqs.footprint_bytes(diffusion, vae, text))
+    return ModelFootprint(**reqs.footprint_bytes(diffusion, vae, text, controlnet))
 
 
 # --- prompt encoding ----------------------------------------------------------------------------

--- a/core/src/inline_core/models/zimage/runner.py
+++ b/core/src/inline_core/models/zimage/runner.py
@@ -81,9 +81,11 @@ ZIMAGE = NodeDescriptor(
         ParamField(
             "controlnet", "ControlNet", Widget.SELECT, "", options_from="controlnet",
         ),
+        # Cap 2.0, not 1.0: at strength 1 the ControlNet follows the gross pose (standing/sitting/
+        # orientation) but not fine limbs (arms up/out); ~1.2-1.5 is the sweet spot for a pose.
         ParamField(
-            "controlnet_conditioning_scale", "Control strength", Widget.NUMBER, 0.75,
-            min=0.0, max=1.0, step=0.05,
+            "controlnet_conditioning_scale", "Control strength", Widget.NUMBER, 1.0,
+            min=0.0, max=2.0, step=0.05,
         ),
         ParamField("seed", "Seed (-1 = random)", Widget.SEED, -1),
         # Advanced: pick a specific file per component. "" = auto (the single file in that folder).
@@ -132,9 +134,15 @@ class ZImageRunner(NodeRunner):
         # Keep the Path|None: path_or_none() collapses None to "", which would make the
         # `is not None` check below always true and load a ControlNet from an empty path.
         controlnet_path = reqs.resolve_controlnet(params)
+        if control_ref is not None and controlnet_path is None:
+            # A control map is wired but no model picked (the picker defaults to none) - auto-use
+            # the best available ControlNet so wiring a control just works.
+            controlnet_path = reqs.auto_controlnet()
+            if controlnet_path is not None:
+                logger.info("Control wired, none picked; auto-using %s", controlnet_path.name)
         use_control = control_ref is not None and controlnet_path is not None
         if control_ref is not None and controlnet_path is None:
-            logger.warning("Control image wired but no ControlNet model picked; ignoring control.")
+            logger.warning("Control wired but no ControlNet found in models/controlnet/.")
         # ControlNet is text-to-image + control; an img2img init image is ignored under control.
         img2img = image_ref is not None and not use_control
 

--- a/core/src/inline_core/models/zimage/runner.py
+++ b/core/src/inline_core/models/zimage/runner.py
@@ -155,7 +155,9 @@ class ZImageRunner(NodeRunner):
 
         # No hidden downloads: a required component that is neither wired nor on disk fails fast.
         missing = [
-            c.label for c in reqs.zimage_requirements(params) if not c.present and c.id not in wired
+            c.label
+            for c in reqs.zimage_requirements(params)
+            if not c.present and not c.optional and c.id not in wired
         ]
         if missing:
             raise ComponentError(

--- a/core/src/inline_core/models/zimage/runner.py
+++ b/core/src/inline_core/models/zimage/runner.py
@@ -163,6 +163,10 @@ class ZImageRunner(NodeRunner):
             if resolved is None:  # defensive: the missing-check above already covers this
                 raise ComponentError("Z-Image diffusion model not found in diffusion_models/.")
             mode, source = resolved
+        if mode == "single_file":
+            foreign = reqs.foreign_model_message(source)
+            if foreign:
+                raise ComponentError(foreign)
         # In single-file mode the VAE + text-encoder are their own files; a whole-pipeline folder
         # carries them, so these go unused unless explicitly wired.
         vae_file = vae_ref.file if vae_ref else rt.path_or_none(reqs.resolve_vae(params))

--- a/core/src/inline_core/server/bootstrap.py
+++ b/core/src/inline_core/server/bootstrap.py
@@ -46,6 +46,12 @@ def _register_builtins(
     requirements: RequirementsRegistry,
 ) -> list[str]:
     registered: list[str] = []
+    # Torch-free: the Control Space node is client-side, so its ControlNet download suggestion is
+    # offered even on a runtime-less install (registered unconditionally, unlike the model runners).
+    from ..models.controlspace import ControlSpaceProvider
+
+    requirements.register("controlSpace", ControlSpaceProvider())
+    registered.append("controlSpace")
     try:
         from ..models.zimage.provider import ZImageProvider
         from ..models.zimage.runner import register_zimage
@@ -72,6 +78,16 @@ def _register_builtins(
 
         register_zimage_primitives(registry, store, policy)
         registered.append("primitives:z-image")
+    except ImportError:
+        pass
+    try:
+        from ..models.preprocess.requirements import PreprocessProvider
+        from ..models.preprocess.runner import register_control_apply
+
+        register_control_apply(registry, store, policy)
+        # Torch-free: the annotator downloads are offered even when the runtime extra is absent.
+        requirements.register("control/apply", PreprocessProvider())
+        registered.append("control/apply")
     except ImportError:
         pass
     return registered

--- a/core/src/inline_core/studio/fal.py
+++ b/core/src/inline_core/studio/fal.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import logging
 import re
 import uuid
 from pathlib import Path
@@ -19,6 +20,10 @@ from typing import Any
 
 from . import frames as fr
 from . import moodboard as mb
+from .image_meta import embed_recipe_png
+from .recipe import build_recipe
+
+logger = logging.getLogger("inline_core.studio.fal")
 
 _QUEUE_BASE = "https://queue.fal.run"
 
@@ -343,12 +348,36 @@ class FalGeneration:
         self, client: Any, frame_id: str, ref: dict[str, str], request_id: str, params: dict
     ) -> str:
         folder: Path = self._store.folder()
+        conn = self._store.conn()
         data = await client.get(ref["url"])
         data.raise_for_status()
         rel = f"takes/{uuid.uuid4()}{ref['ext']}"
         (folder / "takes").mkdir(parents=True, exist_ok=True)
-        (folder / rel).write_bytes(data.content)
-        take = fr.add_take(
-            self._store.conn(), frame_id, rel, ref["kind"], params, comfy_prompt_id=request_id
-        )
+        dst = folder / rel
+        # Embed the recipe into fal PNG outputs so a shared image can rebuild its graph. Only PNG
+        # carries a tEXt chunk (jpg/webp/video can't); the take stores params in the DB regardless.
+        is_png = ref["kind"] == "image" and ref["ext"].lower() == ".png"
+        if not (is_png and self._embed_recipe(conn, frame_id, data.content, dst)):
+            dst.write_bytes(data.content)
+        take = fr.add_take(conn, frame_id, rel, ref["kind"], params, comfy_prompt_id=request_id)
         return take["id"]
+
+    def _embed_recipe(self, conn: Any, frame_id: str, content: bytes, dst: Path) -> bool:
+        """Write `content` to `dst` with the fal frame's recipe embedded. False (caller writes raw)
+        if the frame has no canvas item or embedding fails - metadata must never fail a render."""
+        try:
+            item_id = next(
+                (i["id"] for i in mb.list_board(conn)["items"] if i.get("frameId") == frame_id),
+                None,
+            )
+            if item_id is None:
+                return False
+            recipe = build_recipe(conn, item_id)
+            tmp = dst.with_suffix(dst.suffix + ".raw")
+            tmp.write_bytes(content)
+            embed_recipe_png(tmp, dst, recipe)
+            tmp.unlink(missing_ok=True)
+            return True
+        except Exception:  # noqa: BLE001
+            logger.warning("Recipe embed failed for fal frame %s; saving raw", frame_id)
+            return False

--- a/core/src/inline_core/studio/generation.py
+++ b/core/src/inline_core/studio/generation.py
@@ -12,6 +12,7 @@ returns immediately; progress arrives over ``/events``.
 from __future__ import annotations
 
 import asyncio
+import logging
 import shutil
 import time
 import uuid
@@ -28,6 +29,10 @@ from ..runtime.progress import (
 )
 from . import moodboard as mb
 from .graph_build import build_workflow_graph
+from .image_meta import embed_recipe_png
+from .recipe import build_recipe
+
+logger = logging.getLogger("inline_core.studio.generation")
 
 _EXT = {"image": ".png", "video": ".mp4", "audio": ".mp3"}
 
@@ -131,23 +136,39 @@ class CoreGeneration:
         )
 
     def _save_take(self, item_id: str, take: Any) -> None:
-        """Copy a take's bytes into the project's takes/ dir and set its Core node's output."""
+        """Copy a take's bytes into the project's takes/ dir and set its Core node's output. Image
+        PNGs are re-saved with an embedded recipe (the params + upstream subgraph that made them) so
+        the file is self-describing; the params/prompt are also recorded on the node's output entry
+        so flipping through a node's take history can restore that image's settings."""
         folder: Path = self._store.folder()
+        conn = self._store.conn()
         kind = _kind_str(take.kind)
         src = Path(take.uri)
         ext = src.suffix or _EXT.get(kind, ".png")
         rel = f"takes/{uuid.uuid4()}{ext}"
         (folder / "takes").mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(src, folder / rel)
-        # take.node_id is the canvas item that produced it (node ids == item ids). Stamp createdAt
-        # (ms) so the Outputs gallery can interleave these with frame takes newest-first.
+        # take.node_id is the canvas item that produced it (node ids == item ids).
+        recipe = build_recipe(conn, take.node_id)
+        dst = folder / rel
+        embedded = False
+        if kind == "image" and ext.lower() == ".png":
+            try:
+                embed_recipe_png(src, dst, recipe)
+                embedded = True
+            except Exception:  # noqa: BLE001 - never fail a render over metadata; fall back to copy
+                logger.warning("Recipe embed failed for %s; copying without metadata", take.id)
+        if not embedded:
+            shutil.copyfile(src, dst)
+        # Stamp createdAt (ms) so the Outputs gallery interleaves these with frame takes.
         mb.set_core_node_output(
-            self._store.conn(),
+            conn,
             take.node_id,
             {
                 "takeId": take.id,
                 "filePath": rel,
                 "kind": kind,
                 "createdAt": int(time.time() * 1000),
+                "params": dict(getattr(take, "params", {}) or {}),
+                "prompt": recipe.get("prompt", ""),
             },
         )

--- a/core/src/inline_core/studio/graph_build.py
+++ b/core/src/inline_core/studio/graph_build.py
@@ -113,6 +113,75 @@ def _item_to_node(
     return None
 
 
+def _facing_hint(item: dict[str, Any]) -> dict[str, str] | None:
+    """The facing prompt text a Control Space node carries, if it is enabled and non-empty."""
+    scene = (item.get("data") or {}).get("controlScene") or {}
+    if scene.get("applyPromptHint") is False:
+        return None
+    hint = scene.get("promptHint")
+    if not isinstance(hint, dict):
+        return None
+    positive = str(hint.get("positive") or "").strip()
+    negative = str(hint.get("negative") or "").strip()
+    return {"positive": positive, "negative": negative} if positive or negative else None
+
+
+def _apply_facing_hints(nodes: list[dict[str, Any]], by_id: dict[str, dict[str, Any]]) -> None:
+    """Fold a wired Control Space node's facing into the gen node's prompt and negative prompt.
+
+    A control map has no channel that can say "this character faces away" - the pose ControlNet only
+    sees a face-less skeleton, which is ambiguous, so the model falls back on its prior and renders
+    the head turned back. The text encoder is the only place facing can be stated, so it is stated
+    there. The prompt is rewired to a derived text node rather than editing the shared
+    ``input/text`` in place, so a second gen node reading the same prompt node is unaffected.
+    """
+    by_node = {n["id"]: n for n in nodes}
+    for node in list(nodes):
+        item = by_id.get(node["id"])
+        if item is None or item.get("type") != "core":
+            continue
+        inputs: dict[str, dict[str, str]] = node.get("inputs") or {}
+        hint: dict[str, str] | None = None
+        for edge in inputs.values():
+            source_item = by_id.get(edge["from"])
+            # Only when the control map itself made it into the graph - an unresolvable map means no
+            # ControlNet runs, and a lone "from behind" in the prompt would be a lie.
+            if edge["from"] not in by_node:
+                continue
+            if source_item is not None and source_item.get("type") == "controlSpace":
+                hint = _facing_hint(source_item)
+                if hint is not None:
+                    break
+        if hint is None:
+            continue
+        # Idempotent: a take's recipe records the params the run actually used, so restoring a take
+        # writes an injected hint back onto the node. Appending again would stack it every render.
+        if hint["negative"]:
+            params = node.setdefault("params", {})
+            existing = str(params.get("negative_prompt") or "").strip()
+            if hint["negative"] not in existing:
+                params["negative_prompt"] = (
+                    f"{existing}, {hint['negative']}" if existing else hint["negative"]
+                )
+        prompt_edge = inputs.get("prompt")
+        source = by_node.get(prompt_edge["from"]) if prompt_edge else None
+        # Only a plain text source can be extended; a node-produced prompt is left alone.
+        if not hint["positive"] or source is None or source["type"] != "input/text":
+            continue
+        text = str((source.get("params") or {}).get("text") or "").strip()
+        if hint["positive"] in text:
+            continue
+        derived_id = f"{node['id']}::facing"
+        nodes.append(
+            {
+                "id": derived_id,
+                "type": "input/text",
+                "params": {"text": f"{text}, {hint['positive']}" if text else hint["positive"]},
+            }
+        )
+        inputs["prompt"] = {"from": derived_id, "output": "text"}
+
+
 def _upstream_closure(target: str, connectors: list[dict[str, Any]]) -> set[str]:
     seen: set[str] = set()
     stack = [target]
@@ -151,4 +220,5 @@ def build_workflow_graph(
         node = _item_to_node(item, connectors, by_id, resolve_asset_path, resolve_frame_path)
         if node is not None:
             nodes.append(node)
+    _apply_facing_hints(nodes, by_id)
     return {"schemaVersion": 1, "nodes": nodes}, target_item_id

--- a/core/src/inline_core/studio/graph_build.py
+++ b/core/src/inline_core/studio/graph_build.py
@@ -26,8 +26,9 @@ from . import moodboard as mb
 def _source_output_port(source: dict[str, Any] | None, source_handle: str | None) -> str:
     if source and source["type"] == "prompt":
         return "text"
-    # An asset, a rendered frame, or a Load Assets loader all become an ``input/image`` source node.
-    if source and source["type"] in ("asset", "frame", "loader"):
+    # An asset, a rendered frame, a Load Assets loader, or a Control Space render all become an
+    # ``input/image`` source node.
+    if source and source["type"] in ("asset", "frame", "loader", "controlSpace"):
         return "image"
     return source_handle or "out"  # a 'core' item's handles already are Core port ids
 
@@ -79,6 +80,18 @@ def _item_to_node(
     if item["type"] == "loader":
         asset_ids = data.get("assetIds") or []
         path = resolve_asset_path(asset_ids[0]) if asset_ids else None
+        if not path:
+            return None
+        return {
+            "id": item["id"],
+            "type": "input/image",
+            "params": {"asset": {"ref": "path", "path": path}},
+        }
+    # A Control Space node feeds its rendered OpenPose control map (a library asset) as a frozen
+    # image source, wired into a gen node's control input.
+    if item["type"] == "controlSpace":
+        asset_id = data.get("controlAssetId")
+        path = resolve_asset_path(asset_id) if asset_id else None
         if not path:
             return None
         return {

--- a/core/src/inline_core/studio/handlers.py
+++ b/core/src/inline_core/studio/handlers.py
@@ -169,6 +169,7 @@ def register_studio_handlers(
     reg("moodboard:addDirector", lambda x, y: mb.add_director(conn(), x, y))
     reg("moodboard:addTrim", lambda x, y: mb.add_trim(conn(), x, y))
     reg("moodboard:addLoader", lambda x, y: mb.add_loader(conn(), x, y))
+    reg("moodboard:addControlSpace", lambda x, y: mb.add_control_space(conn(), x, y))
     reg("moodboard:addPrompt", lambda x, y: mb.add_prompt(conn(), x, y))
     reg("moodboard:addCoreNode", lambda t, x, y: mb.add_core_node(conn(), t, x, y))
     reg(

--- a/core/src/inline_core/studio/handlers.py
+++ b/core/src/inline_core/studio/handlers.py
@@ -14,6 +14,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from .. import __version__
 from . import assets as ax
 from . import config as cfg
 from . import fal as _fal
@@ -41,7 +42,8 @@ def register_studio_handlers(
     timeline: Any = None,
     training: Any = None,
     model_downloads: Any = None,
-    app_version: str = "1.0.0",
+    # Empty falls back to the installed package version; the launcher footer shows this.
+    app_version: str = "",
 ) -> None:
     def reg(channel: str, fn: Callable[..., Any]) -> None:
         async def handler(args: list[Any]) -> Any:
@@ -71,7 +73,7 @@ def register_studio_handlers(
     reg("project:mediaDirs", store.media_dirs)
     reg("project:export", lambda _path: None)  # zip export: pending (see plan)
     reg("dialog:pickDirectory", lambda *_: str(cfg.workspace_dir()))
-    reg("app:version", lambda: app_version)
+    reg("app:version", lambda: app_version or __version__)
     reg("settings:get", store.get_settings)
     reg("settings:setCoreUrl", store.set_core_url)
     reg("core:status", core_status)

--- a/core/src/inline_core/studio/image_meta.py
+++ b/core/src/inline_core/studio/image_meta.py
@@ -1,0 +1,36 @@
+"""Embed / read the Inline recipe inside a generated PNG's metadata (a tEXt chunk keyed
+``inline-studio``), so an exported or shared image is self-describing: dropping it back into Inline
+Studio rebuilds the graph that made it. Pillow is a runtime dependency; imports stay inside the
+functions so a Pillow-less install degrades to a plain copy rather than failing to import.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+RECIPE_KEY = "inline-studio"
+
+
+def embed_recipe_png(src: Path, dst: Path, recipe: dict[str, Any]) -> None:
+    """Copy ``src`` to ``dst`` as a PNG carrying ``recipe`` in an ``inline-studio`` tEXt chunk."""
+    from PIL import Image, PngImagePlugin
+
+    with Image.open(src) as im:
+        info = PngImagePlugin.PngInfo()
+        info.add_text(RECIPE_KEY, json.dumps(recipe, separators=(",", ":")))
+        im.save(dst, format="PNG", pnginfo=info)
+
+
+def read_recipe_png(path: Path) -> dict[str, Any] | None:
+    """The embedded recipe dict, or None when the PNG carries none (or can't be read)."""
+    from PIL import Image
+
+    try:
+        with Image.open(path) as im:
+            raw = getattr(im, "text", {}).get(RECIPE_KEY) or (im.info or {}).get(RECIPE_KEY)
+        parsed = json.loads(raw) if raw else None
+        return parsed if isinstance(parsed, dict) else None
+    except Exception:  # noqa: BLE001 - a bad/foreign PNG simply carries no recipe
+        return None

--- a/core/src/inline_core/studio/models.py
+++ b/core/src/inline_core/studio/models.py
@@ -54,7 +54,8 @@ class ModelDownloads:
         components = self._components(node_type)
         return {
             "components": [_component_json(c) for c in components],
-            "allPresent": all(c.present for c in components),
+            # Suggested (optional) components never count as missing; control is opt-in.
+            "allPresent": all(c.present for c in components if not getattr(c, "optional", False)),
             "estimate": self._estimate(node_type),
         }
 
@@ -83,7 +84,9 @@ class ModelDownloads:
             return
         components = self._components(node_type)
         if component_id == "all":
-            targets = [c for c in components if not c.present]
+            # "Download all" grabs required-missing only; a suggested component (e.g. a multi-GB
+            # ControlNet) is fetched only when asked for by its own id.
+            targets = [c for c in components if not c.present and not getattr(c, "optional", False)]
         else:
             targets = [c for c in components if c.id == component_id]
         for comp in targets:
@@ -192,6 +195,7 @@ def _component_json(component: Any) -> dict[str, Any]:
         "localPath": component.local_path,
         "repo": component.repo,
         "source": _source_label(component),
+        "optional": bool(getattr(component, "optional", False)),
     }
 
 

--- a/core/src/inline_core/studio/moodboard.py
+++ b/core/src/inline_core/studio/moodboard.py
@@ -311,6 +311,14 @@ def add_loader(conn: sqlite3.Connection, x: float, y: float) -> dict[str, Any]:
     )
 
 
+def add_control_space(conn: sqlite3.Connection, x: float, y: float) -> dict[str, Any]:
+    # A "Control Space" node holds a rendered OpenPose control map (data.controlAssetId, set on
+    # save) and a serialized 3D scene (data.controlScene); graph_build feeds the map downstream.
+    return _insert_item(
+        conn, item_type="controlSpace", x=x, y=y, width=240, height=240, data={}
+    )
+
+
 def add_prompt(conn: sqlite3.Connection, x: float, y: float) -> dict[str, Any]:
     return _insert_item(
         conn, item_type="prompt", x=x, y=y, width=240, height=120, data={"promptText": ""}

--- a/core/src/inline_core/studio/recipe.py
+++ b/core/src/inline_core/studio/recipe.py
@@ -1,0 +1,97 @@
+"""Author a reproducible recipe for a generated take: the params it used, its prompt, and the raw
+canvas subgraph (items + connectors of the target's upstream closure) so the image can rebuild the
+graph that made it when dropped back in - even in someone else's project.
+
+Reuses graph_build's closure walk. Unlike ``build_workflow_graph`` this keeps the *raw moodboard*
+items (type / minimal data / position), not the flattened engine graph, because the client rebuilds
+canvas nodes from it. Per-item data is trimmed to the rebuild-relevant fields so the recipe stays
+small and never nests another node's take history (which itself carries recipes).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from . import moodboard as mb
+from .graph_build import _upstream_closure
+
+RECIPE_VERSION = 1
+
+
+def _clean_data(item: dict[str, Any]) -> dict[str, Any]:
+    """The rebuild-relevant subset of an item's data - never the take history (`core.outputs`)."""
+    kind = item["type"]
+    data = item.get("data") or {}
+    if kind == "core":
+        core = data.get("core") or {}
+        return {"core": {"type": core.get("type"), "params": core.get("params") or {}}}
+    if kind == "prompt":
+        return {"promptText": data.get("promptText") or ""}
+    if kind == "controlSpace":
+        out: dict[str, Any] = {}
+        if data.get("controlAssetId"):
+            out["controlAssetId"] = data["controlAssetId"]
+        if data.get("controlScene"):
+            out["controlScene"] = data["controlScene"]
+        return out
+    if kind == "loader":
+        return {"assetIds": data.get("assetIds") or []}
+    if kind in ("text", "layer", "director", "trim"):
+        return data  # small styling/label data, kept verbatim
+    return {}
+
+
+def _prompt_for(target_id: str, connectors: list[dict[str, Any]], items: dict[str, Any]) -> str:
+    """The text of the prompt node wired into the target's ``prompt`` input (for quick display)."""
+    for c in connectors:
+        if c["toItemId"] == target_id and (c.get("data") or {}).get("targetHandle") == "prompt":
+            src = items.get(c["fromItemId"])
+            if src and src["type"] == "prompt":
+                return str((src.get("data") or {}).get("promptText") or "")
+    return ""
+
+
+def build_recipe(conn: sqlite3.Connection, target_item_id: str) -> dict[str, Any]:
+    """The recipe for the take produced by ``target_item_id`` (a canvas item id == node id)."""
+    board = mb.list_board(conn)
+    items = {i["id"]: i for i in board["items"]}
+    connectors = board["connectors"]
+    closure = _upstream_closure(target_item_id, connectors)
+
+    recipe_items = [
+        {
+            "id": item["id"],
+            "type": item["type"],
+            "data": _clean_data(item),
+            "x": item["x"],
+            "y": item["y"],
+            "width": item["width"],
+            "height": item["height"],
+            "assetId": item.get("assetId"),
+            "frameId": item.get("frameId"),
+        }
+        for node_id in closure
+        if (item := items.get(node_id)) is not None
+    ]
+    recipe_connectors = [
+        {
+            "fromItemId": c["fromItemId"],
+            "toItemId": c["toItemId"],
+            "data": c.get("data") or {},
+        }
+        for c in connectors
+        if c["fromItemId"] in closure and c["toItemId"] in closure
+    ]
+
+    target = items.get(target_item_id) or {}
+    core = (target.get("data") or {}).get("core") or {}
+    return {
+        "version": RECIPE_VERSION,
+        "app": "inline-studio",
+        "target": target_item_id,
+        "coreType": core.get("type"),
+        "params": core.get("params") or {},
+        "prompt": _prompt_for(target_item_id, connectors, items),
+        "graph": {"items": recipe_items, "connectors": recipe_connectors},
+    }

--- a/core/src/inline_core/studio/recipe.py
+++ b/core/src/inline_core/studio/recipe.py
@@ -13,10 +13,22 @@ from __future__ import annotations
 import sqlite3
 from typing import Any
 
+from . import frames as fr
 from . import moodboard as mb
 from .graph_build import _upstream_closure
 
 RECIPE_VERSION = 1
+
+
+def _item_data(conn: sqlite3.Connection, item: dict[str, Any]) -> dict[str, Any]:
+    """The rebuild-relevant data for a recipe item. A fal gen node is a `frame` whose model + params
+    live in the frames table, so it's looked up; everything else trims its own `data`."""
+    if item["type"] == "frame" and item.get("frameId"):
+        frame = fr.get_frame(conn, item["frameId"])
+        if frame.get("provider") == "fal" and frame.get("modelId"):
+            return {"fal": {"modelId": frame["modelId"], "params": frame.get("params") or {}}}
+        return {}  # a rendered-frame image source - rebuilt structurally (media doesn't transfer)
+    return _clean_data(item)
 
 
 def _clean_data(item: dict[str, Any]) -> dict[str, Any]:
@@ -63,7 +75,7 @@ def build_recipe(conn: sqlite3.Connection, target_item_id: str) -> dict[str, Any
         {
             "id": item["id"],
             "type": item["type"],
-            "data": _clean_data(item),
+            "data": _item_data(conn, item),
             "x": item["x"],
             "y": item["y"],
             "width": item["width"],

--- a/core/tests/helpers.py
+++ b/core/tests/helpers.py
@@ -22,6 +22,7 @@ FAKE_MODEL = NodeDescriptor(
     inputs=(
         Port("prompt", "Prompt", PortKind.TEXT, required=True),
         Port("image", "Init image", PortKind.IMAGE, required=False),
+        Port("control", "Control", PortKind.CONTROL, required=False),
     ),
     outputs=(Port("image", "Image", PortKind.IMAGE),),
     params=(

--- a/core/tests/test_cache.py
+++ b/core/tests/test_cache.py
@@ -52,6 +52,26 @@ def test_seed_eligibility() -> None:
     assert not is_cache_eligible(_graph({}).node("m1"), registry)
 
 
+def test_control_wired_disables_cache() -> None:
+    """A gen node with a control map wired re-runs every time (never cached), so iterating on a pose
+    always applies the current control - even at a fixed seed."""
+    registry = make_registry()
+    with_control = parse_graph(
+        {
+            "schemaVersion": 1,
+            "nodes": [
+                {"id": "c", "type": "input/image",
+                 "params": {"asset": {"ref": "path", "path": "/c.png"}}},
+                {"id": "m1", "type": "fake/model", "params": {"seed": 7},
+                 "inputs": {"control": {"from": "c", "output": "image"}}},
+            ],
+        }
+    )
+    assert not is_cache_eligible(with_control.node("m1"), registry)
+    # Same node, fixed seed, but no control wired -> eligible as before.
+    assert is_cache_eligible(_graph({"seed": 7}).node("m1"), registry)
+
+
 def _image_graph(path: str) -> Graph:
     """A gen node fed by an input/image source node pointing at `path` (mirrors graph_build)."""
     return parse_graph(

--- a/core/tests/test_cache.py
+++ b/core/tests/test_cache.py
@@ -4,7 +4,11 @@ from typing import Any
 
 from helpers import make_registry
 
-from inline_core.graph.cache import is_cache_eligible, node_cache_key
+from inline_core.graph.cache import (
+    asset_content_hashes,
+    is_cache_eligible,
+    node_cache_key,
+)
 from inline_core.graph.schema import Graph, parse_graph
 
 
@@ -46,3 +50,47 @@ def test_seed_eligibility() -> None:
     assert is_cache_eligible(_graph({"seed": 7}).node("m1"), registry)
     assert not is_cache_eligible(_graph({"seed": -1}).node("m1"), registry)
     assert not is_cache_eligible(_graph({}).node("m1"), registry)
+
+
+def _image_graph(path: str) -> Graph:
+    """A gen node fed by an input/image source node pointing at `path` (mirrors graph_build)."""
+    return parse_graph(
+        {
+            "schemaVersion": 1,
+            "nodes": [
+                {"id": "img", "type": "input/image",
+                 "params": {"asset": {"ref": "path", "path": path}}},
+                {"id": "m1", "type": "fake/model", "params": {"seed": 7},
+                 "inputs": {"image": {"from": "img", "output": "image"}}},
+            ],
+        }
+    )
+
+
+def test_asset_content_hashes_hash_file_bytes(tmp_path) -> None:
+    f = tmp_path / "map.png"
+    f.write_bytes(b"first")
+    g = _image_graph(str(f))
+    h1 = asset_content_hashes(g)
+    assert set(h1) == {"img"}
+    f.write_bytes(b"second-different")
+    assert asset_content_hashes(g)["img"] != h1["img"]  # same path, new bytes -> new hash
+    # A missing file is skipped (its path still keys the node via params).
+    assert asset_content_hashes(_image_graph(str(tmp_path / "gone.png"))) == {}
+
+
+def test_cache_key_invalidates_when_a_control_map_is_rerendered(tmp_path) -> None:
+    """A re-rendered control map at the SAME path must change the downstream gen node's cache key -
+    otherwise a fixed-seed run serves a stale image (the reported bug)."""
+    registry = make_registry()
+    f = tmp_path / "pose.png"
+    g = _image_graph(str(f))
+
+    f.write_bytes(b"pose-A")
+    key_a = node_cache_key(g, "m1", registry, asset_content_hashes(g))
+    f.write_bytes(b"pose-B")
+    key_b = node_cache_key(g, "m1", registry, asset_content_hashes(g))
+    assert key_a != key_b
+
+    # With the empty map (the old behaviour) the stale key would have collided.
+    assert node_cache_key(g, "m1", registry, {}) == node_cache_key(g, "m1", registry, {})

--- a/core/tests/test_executor.py
+++ b/core/tests/test_executor.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from helpers import build_ctx, build_graph, make_registry
+from helpers import FAKE_MODEL, build_ctx, build_graph, make_registry
 
 from inline_core.graph.cache import InMemoryCache
 from inline_core.graph.executor import Executor
+from inline_core.graph.runners import NodeResult, NodeRunner
 from inline_core.runtime.progress import (
     CollectingEmitter,
+    ErrorEvent,
     NodeDoneEvent,
     ProgressEvent,
     RunDoneEvent,
@@ -29,6 +31,29 @@ def test_executor_runs_and_streams() -> None:
     assert state.fraction == 1.0
     assert state.nodes["m1"].state is NodeState.DONE
     assert len(state.takes) == 1
+
+
+def test_executor_surfaces_a_runner_crash_as_an_error_event() -> None:
+    """A runner raising a non-InlineCoreError (e.g. a diffusers/HF load failure) must terminate the
+    run with an ErrorEvent - not escape the executor and wedge the run in "queued"."""
+
+    class BoomRunner(NodeRunner):
+        produces_takes = True
+
+        def run(self, node, inputs, ctx) -> NodeResult:  # type: ignore[no-untyped-def]
+            raise RuntimeError("boom: bad controlnet path")
+
+    registry = make_registry()
+    registry.register(FAKE_MODEL, BoomRunner())
+    emitter = CollectingEmitter()
+    state = RunState(run_id="run1", target="m1")
+
+    executor = Executor(registry, InMemoryCache())
+    executor.run(build_graph(), "m1", build_ctx(emitter, "run1"), state)  # must not raise
+
+    errors = [e for e in emitter.events if isinstance(e, ErrorEvent)]
+    assert errors and "boom" in errors[0].message
+    assert not any(isinstance(e, RunDoneEvent) for e in emitter.events)
 
 
 def test_executor_reuses_cache_on_second_run() -> None:

--- a/core/tests/test_krea2_depth_control.py
+++ b/core/tests/test_krea2_depth_control.py
@@ -1,0 +1,104 @@
+"""Krea 2 depth control: the surgery that ports the public depth control-LoRA onto the diffusers
+transformer. The offline-checkable contracts are the key remap (so ``load_state_dict`` has no
+unexpected keys on the real 450-tensor checkpoint) and the input-projection expansion shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from inline_core.models.krea2.convert import convert_key
+
+# reference (krea-2) block-linear name -> diffusers name, the eight modules the adapter wraps.
+_TARGETS = {
+    "attn.wq": "attn.to_q",
+    "attn.wk": "attn.to_k",
+    "attn.wv": "attn.to_v",
+    "attn.wo": "attn.to_out.0",
+    "attn.gate": "attn.to_gate",
+    "mlp.gate": "ff.gate",
+    "mlp.up": "ff.up",
+    "mlp.down": "ff.down",
+}
+_LAYERS = 28  # Krea 2 has 28 main transformer blocks
+
+
+def _reference_keys() -> list[str]:
+    """Every tensor name in the real checkpoint: 28 blocks x 8 targets x {A,B} + the input proj."""
+    keys = ["first.weight", "first.bias"]
+    for i in range(_LAYERS):
+        for name in _TARGETS:
+            keys += [f"blocks.{i}.{name}.A", f"blocks.{i}.{name}.B"]
+    return keys
+
+
+def _expected_diffusers_keys() -> set[str]:
+    keys = {"img_in.weight", "img_in.bias"}
+    for i in range(_LAYERS):
+        for name in _TARGETS.values():
+            keys |= {f"transformer_blocks.{i}.{name}.A", f"transformer_blocks.{i}.{name}.B"}
+    return keys
+
+
+def test_every_depth_lora_key_maps_onto_the_diffusers_transformer() -> None:
+    """The whole checkpoint remaps cleanly - no key would land as ``unexpected`` at load time."""
+    reference = _reference_keys()
+    assert len(reference) == _LAYERS * len(_TARGETS) * 2 + 2 == 450
+    expected = _expected_diffusers_keys()
+    assert {convert_key(k) for k in reference} == expected
+
+
+def test_module_paths_excludes_input_projection() -> None:
+    dc = pytest.importorskip("inline_core.models.krea2.depth_control")
+    state = {
+        "img_in.weight": 0,
+        "img_in.bias": 0,
+        "transformer_blocks.0.attn.to_q.A": 0,
+        "transformer_blocks.0.attn.to_q.B": 0,
+        "transformer_blocks.0.attn.to_out.0.A": 0,
+        "transformer_blocks.0.ff.up.B": 0,
+    }
+    assert dc._module_paths(state) == [
+        "transformer_blocks.0.attn.to_q",
+        "transformer_blocks.0.attn.to_out.0",
+        "transformer_blocks.0.ff.up",
+    ]
+
+
+def test_control_input_layer_doubles_width_and_broadcasts_over_batch() -> None:
+    dc = pytest.importorskip("inline_core.models.krea2.depth_control")
+    import torch
+    import torch.nn as nn
+
+    layer = dc.ControlInputLayer(nn.Linear(64, 6144))
+    assert tuple(layer.weight.shape) == (6144, 128)  # 64 noise + 64 depth
+
+    layer.ctrl = torch.zeros(1, 5, 64)  # depth latent (batch 1)
+    out = layer(torch.zeros(2, 5, 64))  # CFG-doubled noisy latent -> ctrl broadcast to batch 2
+    assert tuple(out.shape) == (2, 5, 6144)
+
+
+def test_control_input_layer_zeros_when_no_depth_set() -> None:
+    dc = pytest.importorskip("inline_core.models.krea2.depth_control")
+    import torch
+    import torch.nn as nn
+
+    layer = dc.ControlInputLayer(nn.Linear(64, 6144))
+    assert layer.ctrl is None
+    out = layer(torch.zeros(1, 5, 64))  # no depth -> concat zeros, still a valid forward
+    assert tuple(out.shape) == (1, 5, 6144)
+
+
+def test_set_control_strength_updates_every_lora(monkeypatch: pytest.MonkeyPatch) -> None:
+    dc = pytest.importorskip("inline_core.models.krea2.depth_control")
+    import torch.nn as nn
+
+    class _Tiny(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.a = dc.LoRALinear(nn.Linear(8, 8), rank=4)
+            self.b = dc.LoRALinear(nn.Linear(8, 8), rank=4)
+
+    model = _Tiny()
+    dc.set_control_strength(model, 0.5)
+    assert model.a.scale == 0.5 and model.b.scale == 0.5

--- a/core/tests/test_krea2_requirements.py
+++ b/core/tests/test_krea2_requirements.py
@@ -84,7 +84,9 @@ def test_requirements_report_presence_per_component(monkeypatch, tmp_path):
 
     components = {c.id: c for c in reqs.krea2_requirements("turbo")}
 
-    assert [c.id for c in reqs.krea2_requirements("turbo")] == ["diffusion", "text_encoder", "vae"]
+    assert [c.id for c in reqs.krea2_requirements("turbo")] == [
+        "diffusion", "text_encoder", "vae", "depth_controlnet",
+    ]
     assert components["diffusion"].present
     assert components["text_encoder"].present
     assert not components["vae"].present
@@ -112,4 +114,35 @@ def test_footprint_sizes_the_files_that_exist(monkeypatch, tmp_path):
 
     sizes = reqs.footprint_bytes(model, None, "")
 
-    assert sizes == {"diffusion_bytes": 2048, "text_encoder_bytes": 0, "vae_bytes": 0}
+    assert sizes == {
+        "diffusion_bytes": 2048,
+        "text_encoder_bytes": 0,
+        "vae_bytes": 0,
+        "controlnet_bytes": 0,
+    }
+
+
+def test_depth_control_is_opt_in_and_never_auto_resolved(monkeypatch, tmp_path):
+    """A wired-but-unpicked depth map falls to ``auto_depth_control``; resolve stays explicit."""
+    root = _models_root(monkeypatch, tmp_path)
+    (root / "controlnet").mkdir()
+    monkeypatch.delenv("INLINE_KREA2_CONTROL", raising=False)
+
+    lora = root / "controlnet" / reqs.DEPTH_CONTROL_FILE
+    lora.write_bytes(b"")
+    # Present on disk, but resolve won't pick it without an explicit dropdown choice.
+    assert reqs.resolve_depth_control() is None
+    assert reqs.resolve_depth_control({"depth_controlnet": reqs.DEPTH_CONTROL_FILE}) == lora
+    # auto is what the runner consults once a control map is actually wired.
+    assert reqs.auto_depth_control() == lora
+    assert reqs.depth_control_present() is True
+
+
+def test_auto_depth_control_ignores_a_z_image_controlnet(monkeypatch, tmp_path):
+    """The Z-Image ControlNet shares ``controlnet/``; auto must not grab it for a Krea 2 node."""
+    root = _models_root(monkeypatch, tmp_path)
+    (root / "controlnet").mkdir()
+    (root / "controlnet" / "Z-Image-Turbo-Fun-Controlnet-Union.safetensors").write_bytes(b"")
+
+    assert reqs.auto_depth_control() is None
+    assert reqs.depth_control_present() is False

--- a/core/tests/test_krea2_runner.py
+++ b/core/tests/test_krea2_runner.py
@@ -55,7 +55,8 @@ def use_fake_pipe(monkeypatch: pytest.MonkeyPatch) -> _FakePipe:
     pipe = _FakePipe()
     monkeypatch.setattr(
         rk, "_load_pipeline",
-        lambda policy, *, variant, source, vae, text, quant=None, loras=(), cancel_check=None: pipe,
+        lambda policy, *, variant, source, vae, text, quant=None, loras=(), controlnet=None,
+        cancel_check=None: pipe,
     )
     monkeypatch.setattr(rk.reqs, "krea2_requirements", lambda variant, params=None: [])
     monkeypatch.setattr(rk.reqs, "resolve_diffusion", lambda variant, params=None: "krea2.st")
@@ -80,7 +81,7 @@ def test_register_adds_both_nodes() -> None:
     assert registry.has("krea/krea-2-raw")
     descriptor = registry.get("krea/krea-2-turbo")
     assert [p.id for p in descriptor.inputs] == [
-        "prompt", "model", "vae", "text_encoder", "lora", "image",
+        "prompt", "model", "vae", "text_encoder", "lora", "image", "control_image",
     ]
     assert descriptor.input("prompt").required
     assert descriptor.output_kind is not None
@@ -144,7 +145,7 @@ def test_a_missing_prompt_is_a_clear_error(use_fake_pipe: _FakePipe) -> None:
 
 def test_missing_models_point_at_the_popup(monkeypatch: pytest.MonkeyPatch) -> None:
     component = types.SimpleNamespace(
-        id="diffusion", label="Diffusion model (TURBO)", present=False
+        id="diffusion", label="Diffusion model (TURBO)", present=False, optional=False
     )
     monkeypatch.setattr(rk.reqs, "krea2_requirements", lambda variant, params=None: [component])
     runner = rk.Krea2Runner(_FakeStore(), MemoryPolicy(), "turbo")

--- a/core/tests/test_loaders.py
+++ b/core/tests/test_loaders.py
@@ -94,3 +94,38 @@ def test_unload_components_evicts_all_but_kept_files():
     remaining = {k[2] for k in loaders._CACHE}
     assert remaining == {"/models/ae.safetensors", "/models/qwen.safetensors"}
     loaders._CACHE.clear()
+
+
+def test_unload_components_evicts_the_same_file_at_another_quantization():
+    """Adding a ControlNet flips the fit plan from resident to int8, so the same transformer file
+    is cached twice. Without a quant-aware sweep both stay resident - two full-size models."""
+    loaders._CACHE.clear()
+    int8 = ("z-image", "diffusion", "/m.safetensors", "fp16", "int8", "cuda:0")
+    plain = ("z-image", "diffusion", "/m.safetensors", "fp16", "none", "cuda:0")
+    encoder = ("z-image", "text_encoder", "/qwen.safetensors", "fp16", "int8", "cuda:0")
+    loaders._CACHE.update({int8: object(), plain: object(), encoder: object()})
+
+    loaders.unload_components(
+        keep_files={"/m.safetensors", "/qwen.safetensors"}, keep_quant="none"
+    )
+
+    assert plain in loaders._CACHE
+    assert int8 not in loaders._CACHE
+    assert encoder not in loaders._CACHE  # the encoder quantizes too
+    loaders._CACHE.clear()
+
+
+def test_unload_components_keeps_never_quantized_kinds_across_a_quant_switch():
+    """The VAE and the ControlNet always key as NONE whatever the plan, so a quant-aware sweep must
+    not read their slot as a mismatch and drop them on every control run."""
+    loaders._CACHE.clear()
+    vae = ("z-image", "vae", "/ae.safetensors", "fp32", "none", "cuda:0")
+    controlnet = ("z-image", "controlnet", "/union.safetensors", "fp16", "none", "cuda:0")
+    loaders._CACHE.update({vae: object(), controlnet: object()})
+
+    loaders.unload_components(
+        keep_files={"/ae.safetensors", "/union.safetensors"}, keep_quant="int8"
+    )
+
+    assert vae in loaders._CACHE and controlnet in loaders._CACHE
+    loaders._CACHE.clear()

--- a/core/tests/test_model_requirements.py
+++ b/core/tests/test_model_requirements.py
@@ -37,6 +37,31 @@ def _component(present: bool = False) -> ModelComponent:
     )
 
 
+def test_optional_component_is_a_suggestion_not_a_missing_requirement() -> None:
+    """A suggested (optional) component that isn't on disk must not flip ``allPresent`` to False,
+    and "Download all" must skip it - control is opt-in, so it never blocks a plain run."""
+    optional = ModelComponent(
+        id="controlnet", label="ControlNet", category="controlnet", present=False,
+        filename="cn.safetensors", repo="acme/cn", repo_file="cn.safetensors", optional=True,
+    )
+    registry = RequirementsRegistry()
+    registry.register("acme/thing", _StubProvider([_component(present=True), optional]))
+    downloads = ModelDownloads(events=None, requirements=registry)
+
+    payload = downloads.requirements("acme/thing")
+    assert payload["allPresent"] is True  # required present; the optional one is ignored
+    cn = next(c for c in payload["components"] if c["id"] == "controlnet")
+    assert cn["optional"] is True and cn["present"] is False
+
+
+def test_control_space_provider_offers_the_controlnet_suggestion() -> None:
+    from inline_core.models.controlspace import ControlSpaceProvider
+
+    components = ControlSpaceProvider().components()
+    assert [c.id for c in components] == ["controlnet"]
+    assert components[0].optional is True
+
+
 def test_unregistered_node_type_reports_no_requirements() -> None:
     """The pre-refactor behaviour for any non-Z-Image node, now the general case."""
     downloads = ModelDownloads(events=None, requirements=RequirementsRegistry())

--- a/core/tests/test_pipeline_cache.py
+++ b/core/tests/test_pipeline_cache.py
@@ -1,0 +1,82 @@
+"""PipelineCache.evict_stale: switching what's resident (a different quant or a ControlNet) must
+drop the previous pipeline so two multi-GB models never coexist, while an i2i build still reuses its
+cached t2i base. Torch-free: the VRAM helpers are stubbed."""
+
+from __future__ import annotations
+
+import inline_core.models.pipeline_runtime as rt
+from inline_core.models.pipeline_runtime import PipelineCache, PipelineKey
+
+
+def _key(**over) -> PipelineKey:
+    base = dict(
+        arch="z-image",
+        diffusion="/m.safetensors",
+        vae="/ae.safetensors",
+        text_encoder="/qwen.safetensors",
+        variant="t2i",
+        quant="none",
+        loras=(),
+        controlnet="",
+    )
+    base.update(over)
+    return PipelineKey(**base)
+
+
+def _stub(monkeypatch) -> list[dict]:
+    """Record unload_components calls; neutralise free_vram (no torch)."""
+    calls: list[dict] = []
+    from inline_core.models import loaders
+
+    monkeypatch.setattr(
+        loaders,
+        "unload_components",
+        lambda **kw: calls.append(kw),
+    )
+    monkeypatch.setattr(rt, "free_vram", lambda: None)
+    return calls
+
+
+def test_control_run_evicts_the_plain_pipeline(monkeypatch) -> None:
+    calls = _stub(monkeypatch)
+    cache = PipelineCache()
+    plain = _key()  # NONE quant, no controlnet
+    cache.put(plain, object())
+
+    control = _key(quant="int8", controlnet="/union.safetensors")
+    cache.evict_stale(control)
+
+    assert cache.get(plain) is None  # the resident full-precision pipeline is gone
+    # And the component sweep is told to keep only the control build's files at its quant.
+    assert calls and calls[0]["keep_quant"] == "int8"
+    assert "/union.safetensors" in calls[0]["keep_files"]
+
+
+def test_plain_run_evicts_the_control_pipeline(monkeypatch) -> None:
+    _stub(monkeypatch)
+    cache = PipelineCache()
+    control = _key(quant="int8", controlnet="/union.safetensors")
+    cache.put(control, object())
+
+    cache.evict_stale(_key())  # back to a plain NONE-quant run
+    assert cache.get(control) is None
+
+
+def test_i2i_build_keeps_its_cached_t2i_base(monkeypatch) -> None:
+    _stub(monkeypatch)
+    cache = PipelineCache()
+    t2i = _key(variant="t2i")
+    cache.put(t2i, object())
+
+    cache.evict_stale(_key(variant="i2i"))  # same weights/quant/controlnet, only shape differs
+    assert cache.get(t2i) is not None  # reused, not evicted
+
+
+def test_a_different_lora_stack_is_evicted(monkeypatch) -> None:
+    _stub(monkeypatch)
+    cache = PipelineCache()
+    a = _key(loras=("lora-a@1.0",))
+    cache.put(a, object())
+
+    cache.evict_stale(_key(loras=("lora-b@1.0",)))
+    assert cache.get(a) is None

--- a/core/tests/test_recipe.py
+++ b/core/tests/test_recipe.py
@@ -1,0 +1,80 @@
+"""The generation recipe: authoring the upstream subgraph + params + prompt for a take, and the PNG
+tEXt round-trip that makes an image self-describing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from inline_core.studio import moodboard as mb
+from inline_core.studio.recipe import RECIPE_VERSION, build_recipe
+from inline_core.studio.store import StudioStore
+
+
+def _store(tmp_path) -> StudioStore:
+    store = StudioStore(tmp_path / "app", tmp_path / "ws")
+    store.create_project("Recipe")
+    return store
+
+
+def test_build_recipe_captures_params_prompt_and_upstream_subgraph(tmp_path) -> None:
+    store = _store(tmp_path)
+    conn = store.conn()
+    z = mb.add_core_node(conn, "alibaba/z-image-turbo", 400, 200)
+    mb.update_item(conn, z["id"], {"data": {"core": {"type": "alibaba/z-image-turbo",
+                                                     "params": {"steps": 8, "seed": 42}}}})
+    prompt = mb.add_prompt(conn, 80, 200)
+    mb.update_item(conn, prompt["id"], {"data": {"promptText": "a neon fox"}})
+    mb.create_connector(conn, prompt["id"], z["id"], "out", "prompt")
+
+    recipe = build_recipe(conn, z["id"])
+    assert recipe["version"] == RECIPE_VERSION and recipe["app"] == "inline-studio"
+    assert recipe["target"] == z["id"] and recipe["coreType"] == "alibaba/z-image-turbo"
+    assert recipe["params"] == {"steps": 8, "seed": 42}
+    assert recipe["prompt"] == "a neon fox"
+    ids = {i["id"]: i for i in recipe["graph"]["items"]}
+    assert set(ids) == {z["id"], prompt["id"]}
+    assert ids[prompt["id"]]["data"] == {"promptText": "a neon fox"}
+    # The take history of an upstream node must NOT be embedded (no recursive bloat).
+    assert "outputs" not in ids[z["id"]]["data"]["core"]
+    assert len(recipe["graph"]["connectors"]) == 1
+
+
+def test_recipe_omits_disconnected_nodes(tmp_path) -> None:
+    store = _store(tmp_path)
+    conn = store.conn()
+    z = mb.add_core_node(conn, "alibaba/z-image-turbo", 400, 200)
+    mb.add_prompt(conn, 80, 500)  # a stray prompt, not wired to z
+    recipe = build_recipe(conn, z["id"])
+    assert [i["id"] for i in recipe["graph"]["items"]] == [z["id"]]
+
+
+def test_png_recipe_round_trip(tmp_path) -> None:
+    pytest.importorskip("PIL")
+    from PIL import Image
+
+    from inline_core.studio.image_meta import RECIPE_KEY, embed_recipe_png, read_recipe_png
+
+    src = tmp_path / "src.png"
+    Image.new("RGB", (8, 8), (10, 20, 30)).save(src)
+    recipe = {"version": 1, "app": "inline-studio", "prompt": "hi", "graph": {"items": []}}
+    dst = tmp_path / "out.png"
+    embed_recipe_png(src, dst, recipe)
+
+    assert read_recipe_png(dst) == recipe
+    # A foreign PNG carries no recipe.
+    assert read_recipe_png(src) is None
+    # And the chunk really is in the file's text metadata.
+    with Image.open(dst) as im:
+        assert RECIPE_KEY in im.text
+
+
+def test_read_recipe_png_tolerates_a_missing_or_bad_file(tmp_path) -> None:
+    from inline_core.studio.image_meta import read_recipe_png
+
+    assert read_recipe_png(tmp_path / "nope.png") is None
+    bad = tmp_path / "bad.png"
+    bad.write_bytes(b"not a png")
+    assert read_recipe_png(bad) is None
+    assert read_recipe_png(Path(bad)) is None

--- a/core/tests/test_recipe.py
+++ b/core/tests/test_recipe.py
@@ -50,6 +50,26 @@ def test_recipe_omits_disconnected_nodes(tmp_path) -> None:
     assert [i["id"] for i in recipe["graph"]["items"]] == [z["id"]]
 
 
+def test_build_recipe_captures_a_fal_gen_node(tmp_path) -> None:
+    """A fal gen node is a frame; its model + params live in the frames table, so the recipe must
+    look them up (not read the item's empty data) - that is what lets a shared fal PNG rebuild."""
+    store = _store(tmp_path)
+    conn = store.conn()
+    gen = mb.add_gen_node(
+        conn, "fal-ai/flux/dev", 400, 200, kind="image", params={"num_images": 2}, title="Flux"
+    )
+    prompt = mb.add_prompt(conn, 80, 200)
+    mb.update_item(conn, prompt["id"], {"data": {"promptText": "a fox"}})
+    mb.create_connector(conn, prompt["id"], gen["id"], "out", "prompt")
+
+    recipe = build_recipe(conn, gen["id"])
+    assert recipe["prompt"] == "a fox"
+    ids = {i["id"]: i for i in recipe["graph"]["items"]}
+    fal = ids[gen["id"]]["data"]["fal"]
+    assert fal["modelId"] == "fal-ai/flux/dev"
+    assert fal["params"] == {"num_images": 2}
+
+
 def test_png_recipe_round_trip(tmp_path) -> None:
     pytest.importorskip("PIL")
     from PIL import Image

--- a/core/tests/test_studio_generation.py
+++ b/core/tests/test_studio_generation.py
@@ -79,6 +79,44 @@ def test_build_workflow_graph_loader_into_zimage_image(tmp_path) -> None:
     assert by_id[z["id"]]["inputs"]["image"] == {"from": loader["id"], "output": "image"}
 
 
+def test_build_workflow_graph_control_space_into_zimage_control(tmp_path) -> None:
+    """A Control Space node's rendered OpenPose map, wired into Z-Image's control_image port,
+    becomes an input/image source node targeting that named input."""
+    store = _store(tmp_path)
+    conn = store.conn()
+    conn.execute(
+        "INSERT INTO assets (id, project_id, name, file_path, kind, created_at) "
+        "VALUES ('pose1', ?, 'pose', 'assets/pose.png', 'image', 0)",
+        (mb._project_id(conn),),
+    )
+    z = mb.add_core_node(conn, "alibaba/z-image-turbo", 400, 200)
+    cs = mb.add_control_space(conn, 80, 200)
+    assert cs["type"] == "controlSpace"
+    mb.update_item(conn, cs["id"], {"data": {"controlAssetId": "pose1"}})
+    mb.create_connector(conn, cs["id"], z["id"], "out", "control_image")
+
+    graph, _ = build_workflow_graph(conn, store.folder(), z["id"])
+    by_id = {n["id"]: n for n in graph["nodes"]}
+    cs_node = by_id[cs["id"]]
+    assert cs_node["type"] == "input/image"
+    assert cs_node["params"]["asset"]["path"] == str(store.folder() / "assets/pose.png")
+    # The map lands on the control_image input, not the plain image input.
+    assert by_id[z["id"]]["inputs"]["control_image"] == {"from": cs["id"], "output": "image"}
+
+
+def test_build_workflow_graph_control_space_without_render_is_dropped(tmp_path) -> None:
+    """A Control Space node with no rendered map yet emits no source node (no dangling edge)."""
+    store = _store(tmp_path)
+    conn = store.conn()
+    z = mb.add_core_node(conn, "alibaba/z-image-turbo", 400, 200)
+    cs = mb.add_control_space(conn, 80, 200)
+    mb.create_connector(conn, cs["id"], z["id"], "out", "control_image")
+
+    graph, _ = build_workflow_graph(conn, store.folder(), z["id"])
+    by_id = {n["id"]: n for n in graph["nodes"]}
+    assert cs["id"] not in by_id
+
+
 class _Events:
     def __init__(self) -> None:
         self.sent: list[tuple[str, dict]] = []

--- a/core/tests/test_studio_graph_build.py
+++ b/core/tests/test_studio_graph_build.py
@@ -1,0 +1,111 @@
+"""Canvas -> Core graph serialization, and the Control Space facing hint folded into the prompt."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from inline_core.studio import moodboard as mb
+from inline_core.studio.graph_build import build_workflow_graph
+from inline_core.studio.schema import apply_schema
+
+BACK_HINT = {
+    "positive": "seen from behind, back view, back of the head",
+    "negative": "face visible, looking at the camera",
+}
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    apply_schema(c)
+    c.execute("INSERT INTO project (id, name, created_at, updated_at) VALUES ('p', 'Proj', 0, 0)")
+    c.execute(
+        "INSERT INTO assets (id, project_id, name, file_path, kind, created_at) "
+        "VALUES ('a1', 'p', 'map', 'assets/map.png', 'image', 0)"
+    )
+    return c
+
+
+def _board(
+    conn: sqlite3.Connection, scene: dict[str, Any] | None, prompt_text: str = "a woman standing"
+) -> tuple[str, str]:
+    """A prompt + a Control Space map wired into a gen node. Returns (gen id, prompt id)."""
+    control = mb.add_control_space(conn, 0, 0)
+    mb.update_item(conn, control["id"], {"data": {"controlAssetId": "a1", "controlScene": scene}})
+    prompt = mb.add_prompt(conn, 0, 0)
+    mb.update_item(conn, prompt["id"], {"data": {"promptText": prompt_text}})
+    gen = mb.add_core_node(conn, "alibaba/z-image-turbo", 0, 0)
+    mb.create_connector(conn, prompt["id"], gen["id"], "text", "prompt")
+    mb.create_connector(conn, control["id"], gen["id"], "image", "control_image")
+    return gen["id"], prompt["id"]
+
+
+def _nodes(conn: sqlite3.Connection, target: str) -> dict[str, dict[str, Any]]:
+    graph, _ = build_workflow_graph(conn, Path("/tmp"), target)
+    return {n["id"]: n for n in graph["nodes"]}
+
+
+def test_back_facing_control_space_states_the_facing_in_the_prompt(conn) -> None:
+    gen_id, prompt_id = _board(conn, {"facing": ["back"], "promptHint": BACK_HINT})
+    nodes = _nodes(conn, gen_id)
+
+    # The prompt is rewired to a derived text node; the shared prompt node is left untouched.
+    source = nodes[gen_id]["inputs"]["prompt"]["from"]
+    assert source != prompt_id
+    assert nodes[source]["params"]["text"] == f"a woman standing, {BACK_HINT['positive']}"
+    assert nodes[prompt_id]["params"]["text"] == "a woman standing"
+    assert nodes[gen_id]["params"]["negative_prompt"] == BACK_HINT["negative"]
+
+
+def test_the_hint_appends_to_an_existing_negative_prompt(conn) -> None:
+    gen_id, _ = _board(conn, {"facing": ["back"], "promptHint": BACK_HINT})
+    item_id = next(i["id"] for i in mb.list_items(conn) if i["type"] == "core")
+    core = {"type": "alibaba/z-image-turbo", "params": {"negative_prompt": "blur"}}
+    mb.update_item(conn, item_id, {"data": {"core": core}})
+    negative = _nodes(conn, gen_id)[gen_id]["params"]["negative_prompt"]
+    assert negative == f"blur, {BACK_HINT['negative']}"
+
+
+def test_the_hint_never_stacks_when_a_restored_take_already_carries_it(conn) -> None:
+    """Restoring a take writes the injected params onto the node; re-running must not re-add."""
+    gen_id, prompt_id = _board(conn, {"facing": ["back"], "promptHint": BACK_HINT})
+    item_id = next(i["id"] for i in mb.list_items(conn) if i["type"] == "core")
+    core = {"type": "krea/krea-2-turbo", "params": {"negative_prompt": BACK_HINT["negative"]}}
+    mb.update_item(conn, item_id, {"data": {"core": core}})
+    mb.update_item(
+        conn, prompt_id, {"data": {"promptText": f"a woman standing, {BACK_HINT['positive']}"}}
+    )
+    nodes = _nodes(conn, gen_id)
+    assert nodes[gen_id]["params"]["negative_prompt"] == BACK_HINT["negative"]
+    assert nodes[gen_id]["inputs"]["prompt"]["from"] == prompt_id  # no second derived node
+
+
+@pytest.mark.parametrize(
+    "scene",
+    [
+        {"facing": ["front"], "promptHint": None},
+        {"facing": ["back"], "promptHint": BACK_HINT, "applyPromptHint": False},
+        {"facing": ["back", "front"]},
+        None,
+    ],
+)
+def test_no_hint_leaves_the_prompt_alone(conn, scene) -> None:
+    gen_id, prompt_id = _board(conn, scene)
+    nodes = _nodes(conn, gen_id)
+    assert nodes[gen_id]["inputs"]["prompt"]["from"] == prompt_id
+    assert not nodes[gen_id]["params"].get("negative_prompt")
+
+
+def test_an_unresolvable_control_map_adds_nothing(conn) -> None:
+    """No control image in the graph means no ControlNet ran - the facing claim would be a lie."""
+    gen_id, prompt_id = _board(conn, {"facing": ["back"], "promptHint": BACK_HINT})
+    control_id = next(i["id"] for i in mb.list_items(conn) if i["type"] == "controlSpace")
+    mb.update_item(conn, control_id, {"data": {"controlScene": {"promptHint": BACK_HINT}}})
+    nodes = _nodes(conn, gen_id)
+    assert nodes[gen_id]["inputs"]["prompt"]["from"] == prompt_id
+    assert not nodes[gen_id]["params"].get("negative_prompt")

--- a/core/tests/test_studio_models.py
+++ b/core/tests/test_studio_models.py
@@ -37,6 +37,25 @@ def test_requirements_empty_for_unknown_node_type():
     }
 
 
+def test_apply_controlnet_offers_annotator_weights_as_suggested_downloads(monkeypatch, tmp_path):
+    """control/apply's provider lists the controlnet_aux detector weights - all optional, so an empty
+    models/annotators/ never reads as "models missing", and each carries its HF repo file."""
+    monkeypatch.setenv("INLINE_MODELS_DIR", str(tmp_path))
+    from inline_core.models.preprocess.requirements import ANNOTATOR_REPO, PreprocessProvider
+    from inline_core.models.requirements import RequirementsRegistry
+
+    reg = RequirementsRegistry()
+    reg.register("control/apply", PreprocessProvider())
+    view = ModelDownloads(events=None, requirements=reg).requirements("control/apply")
+
+    files = {c["localPath"] for c in view["components"]}
+    assert "annotators/body_pose_model.pth" in files
+    assert "annotators/dpt_hybrid-midas-501f0c75.pt" in files
+    assert all(c["optional"] for c in view["components"])
+    assert all(c["repo"] == ANNOTATOR_REPO for c in view["components"])
+    assert view["allPresent"] is True  # optional-only -> never blocks the node
+
+
 def test_download_retries_anonymously_when_a_cached_token_is_invalid(tmp_path, monkeypatch):
     """A stale/invalid cached HF token 401s even on a public repo (masked as "not found"). The
     download must drop the token and retry anonymously, not fail."""
@@ -87,4 +106,5 @@ def test_component_json_shape():
         "repo": "Comfy-Org/z_image",
         # "which model" is the repo + the exact file this component pulls.
         "source": "Comfy-Org/z_image/ae.safetensors",
+        "optional": False,
     }

--- a/core/tests/test_studio_rpc.py
+++ b/core/tests/test_studio_rpc.py
@@ -110,3 +110,14 @@ def test_fal_run_without_key_errors_via_event(client) -> None:
     # Fal run is fire-and-forget (ok immediately); the missing-key error arrives as an event.
     res = rpc(client, "generation:run", "frame-x", {"endpoint": "fal-ai/x", "body": {}})
     assert res["ok"] is True
+
+
+def test_app_version_reports_the_installed_package_version(client) -> None:
+    """The launcher footer reads this channel. It used to return a hardcoded "1.0.0" default that
+    no call site ever overrode, so the UI showed 1.0.0 for every release."""
+    from inline_core import __version__
+
+    reported = rpc(client, "app:version")["value"]
+    assert reported == __version__
+    assert reported != "1.0.0"
+    assert reported.count(".") == 2  # a real semver, not a placeholder

--- a/core/tests/test_studio_rpc.py
+++ b/core/tests/test_studio_rpc.py
@@ -72,6 +72,7 @@ def test_full_project_and_canvas_flow(client) -> None:
         "sample",
         "vae/decode",
         "vae/encode",
+        "control/apply",
     }
     assert rpc(client, "core:status")["value"]["running"] is True
 

--- a/core/tests/test_zimage_resolve.py
+++ b/core/tests/test_zimage_resolve.py
@@ -80,9 +80,13 @@ def test_no_repo_fallback_when_nothing_local(monkeypatch, tmp_path):
 def test_requirements_all_missing_on_empty_root(monkeypatch, tmp_path):
     _models_root(monkeypatch, tmp_path)
     components = reqs.zimage_requirements()
-    assert {c.id for c in components} == {"diffusion", "vae", "text_encoder"}
+    # The three required base components (from the split repo) + the optional ControlNet suggestion.
+    required = [c for c in components if not c.optional]
+    assert {c.id for c in required} == {"diffusion", "vae", "text_encoder"}
     assert all(not c.present for c in components)
-    assert all(c.repo == reqs.BASE_REPO for c in components)
+    assert all(c.repo == reqs.BASE_REPO for c in required)
+    controlnet = next(c for c in components if c.optional)
+    assert controlnet.id == "controlnet" and controlnet.repo == reqs.CONTROLNET_REPO
 
 
 def test_pipeline_dir_satisfies_vae_and_text_encoder(monkeypatch, tmp_path):

--- a/core/tests/test_zimage_runner.py
+++ b/core/tests/test_zimage_runner.py
@@ -252,6 +252,23 @@ def test_resolve_seed() -> None:
     assert 0 <= rt.resolve_seed("not-a-number") <= rt._SEED_MAX
 
 
+def test_load_image_accepts_take_and_asset_path(tmp_path: Any) -> None:
+    """Apply ControlNet feeds its control map in as a Take (not an AssetRef) - both must load."""
+    from PIL import Image
+
+    from inline_core.media import MediaKind
+    from inline_core.takes import AssetRef, Take
+
+    p = tmp_path / "map.png"
+    Image.new("RGB", (8, 8), "white").save(p)
+
+    take = Take(id="t", run_id="r", node_id="n", kind=MediaKind.IMAGE, uri=str(p), hash="h")
+    assert rt.load_image(take, "Z-Image").size == (8, 8)
+    assert rt.load_image(AssetRef(ref="path", path=str(p)), "Z-Image").size == (8, 8)
+    with pytest.raises(ComponentError, match="readable image"):
+        rt.load_image("nope", "Z-Image")
+
+
 def test_missing_models_fail_fast(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
     """An empty models dir must error clearly (pointing at the popup), never trigger a download."""
     monkeypatch.setenv("INLINE_MODELS_DIR", str(tmp_path))  # empty root -> everything missing
@@ -473,15 +490,38 @@ def test_shrink_vae_tiles_noop_when_already_small() -> None:
     assert vae.tile_latent_min_size == 32
 
 
-def test_smaller_resolutions_only_suggests_smaller() -> None:
-    """The OOM hint must never suggest a size >= the current one (the reported 512->768/512 bug)."""
-    assert rt.smaller_resolutions(1024, 1024) == ["768x768", "512x512"]
-    assert rt.smaller_resolutions(512, 512) == ["384x384", "256x256"]
-    assert rt.smaller_resolutions(256, 256) == ["128x128"]  # past the ladder -> halve
-    # never suggests the current size or larger
-    for size in (2048, 1024, 768, 512, 384, 256, 200, 128):
-        for s in rt.smaller_resolutions(size, size):
-            assert int(s.split("x")[0]) < size
+def _wh(label: str) -> tuple[int, int]:
+    w, h = label.split("x")
+    return int(w), int(h)
+
+
+def test_smaller_resolutions_cuts_pixels_not_just_the_long_edge() -> None:
+    """The hint must cut peak memory, which tracks pixel count - the reported 896x1216 bug, where
+    the square ladder suggested 1024x1024: 4% fewer pixels, and it OOMed too."""
+    for w, h in ((896, 1216), (1024, 1024), (1216, 832), (512, 512), (768, 1024)):
+        for label in rt.smaller_resolutions(w, h):
+            sw, sh = _wh(label)
+            assert sw * sh < w * h, f"{label} is not smaller than {w}x{h}"
+            assert sw * sh <= 0.8 * w * h, f"{label} barely cuts {w}x{h}"
+
+
+def test_smaller_resolutions_keeps_the_requested_aspect() -> None:
+    """A portrait request stays portrait - being told to render a square is not an answer."""
+    for w, h in ((896, 1216), (832, 1216), (1216, 832)):
+        for label in rt.smaller_resolutions(w, h):
+            sw, sh = _wh(label)
+            assert abs(sw / sh - w / h) < 0.12, f"{label} drifts from {w}x{h}'s aspect"
+            assert sw % 64 == 0 and sh % 64 == 0
+
+    # The size this box actually generates at is what a 896x1216 OOM should point you to.
+    assert "768x1024" in rt.smaller_resolutions(896, 1216)
+
+
+def test_smaller_resolutions_never_suggests_the_current_size() -> None:
+    for w, h in ((2048, 2048), (1024, 1024), (512, 512), (256, 256), (128, 128), (64, 64)):
+        assert f"{w}x{h}" not in rt.smaller_resolutions(w, h)
+    assert rt.smaller_resolutions(64, 64) == []  # at the floor: no suggestion beats none
+    assert "try" not in rt.oom_message(64, 64)
 
 
 # --- pipeline-cache eviction --------------------------------------------------------------------

--- a/core/tests/test_zimage_runner.py
+++ b/core/tests/test_zimage_runner.py
@@ -61,7 +61,7 @@ def use_fake_pipe(monkeypatch: pytest.MonkeyPatch) -> _FakePipe:
         rz,
         "_load_pipeline",
         lambda policy, *, img2img, source, mode, vae, text, quant=None, loras=(),
-        cancel_check=None: pipe,
+        controlnet=None, cancel_check=None: pipe,
     )
     # These tests mock the pipeline, so bypass the "models present on disk" gate.
     monkeypatch.setattr(rz.reqs, "zimage_requirements", lambda params=None: [])
@@ -85,7 +85,7 @@ def test_register_adds_descriptor_and_runner() -> None:
     descriptor = registry.get("alibaba/z-image-turbo")
     assert descriptor.output_kind is not None
     assert [p.id for p in descriptor.inputs] == [
-        "prompt", "model", "vae", "text_encoder", "lora", "image",
+        "prompt", "model", "vae", "text_encoder", "lora", "image", "control_image",
     ]
     assert descriptor.input("prompt").required
     # The component handles + lora + image are all optional (wire a Load node, or the dropdowns).
@@ -126,7 +126,7 @@ def test_wired_component_handles_override_dropdowns(monkeypatch: pytest.MonkeyPa
 
     def _fake_load(
         policy: Any, *, img2img: bool, source: str, mode: str, vae: str, text: str,
-        quant: Any = None, loras: Any = (), cancel_check: Any = None,
+        quant: Any = None, loras: Any = (), controlnet: Any = None, cancel_check: Any = None,
     ) -> Any:
         captured.update(source=source, mode=mode, vae=vae, text=text)
         return _FakePipe()
@@ -197,7 +197,7 @@ def test_cancel_during_sampling_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         rz, "_load_pipeline",
         lambda policy, *, img2img, source, mode, vae, text, quant=None, loras=(),
-        cancel_check=None: (_CancellingPipe()),
+        controlnet=None, cancel_check=None: (_CancellingPipe()),
     )
     monkeypatch.setattr(rz.reqs, "zimage_requirements", lambda params=None: [])
     monkeypatch.setattr(rz.reqs, "resolve_diffusion", lambda params=None: ("single_file", "fake"))
@@ -482,3 +482,59 @@ def test_smaller_resolutions_only_suggests_smaller() -> None:
     for size in (2048, 1024, 768, 512, 384, 256, 200, 128):
         for s in rt.smaller_resolutions(size, size):
             assert int(s.split("x")[0]) < size
+
+
+# --- pipeline-cache eviction --------------------------------------------------------------------
+
+
+def _key(**over: Any) -> rt.PipelineKey:
+    base = dict(
+        arch="z-image", diffusion="/m.safetensors", vae="/ae.safetensors",
+        text_encoder="/qwen.safetensors", variant="t2i", quant="none",
+    )
+    return rt.PipelineKey(**{**base, **over})
+
+
+def test_evict_stale_drops_a_control_pipeline_when_a_plain_run_follows() -> None:
+    """The QA bug: a control build was keyed only through ``variant`` ("ctrl:<file>"), and eviction
+    matched on files alone - so the ControlNet pipeline survived a following plain run, pinning its
+    several-GB ControlNet while the plain transformer loaded on top, and the card OOMed."""
+    cache = rt.PipelineCache()
+    control = _key(quant="int8", controlnet="/union.safetensors")
+    cache.put(control, object())
+
+    cache.evict_stale(_key())  # the plain t2i run that follows
+
+    assert cache.get(control) is None
+
+
+def test_evict_stale_keeps_the_t2i_base_for_an_img2img_build() -> None:
+    """Only ``variant`` may differ: the i2i build still reuses the cached t2i base (from_pipe)."""
+    cache = rt.PipelineCache()
+    base = _key(variant="t2i")
+    cache.put(base, object())
+
+    cache.evict_stale(_key(variant="i2i"))
+
+    assert cache.get(base) is not None
+
+
+def test_evict_stale_keeps_an_identical_control_pipeline() -> None:
+    """A repeat control run must hit the cache, not rebuild 6 GB of ControlNet."""
+    cache = rt.PipelineCache()
+    control = _key(quant="int8", controlnet="/union.safetensors")
+    cache.put(control, object())
+
+    cache.evict_stale(control)
+
+    assert cache.get(control) is not None
+
+
+def test_control_key_keeps_the_controlnet_component_alive() -> None:
+    """The ControlNet file is not one of the three ``files``, so the component sweep must be told
+    about it explicitly or every control run reloads it from disk."""
+    key = _key(controlnet="/union.safetensors")
+    assert key.component_files == {
+        "/m.safetensors", "/ae.safetensors", "/qwen.safetensors", "/union.safetensors"
+    }
+    assert _key().component_files == {"/m.safetensors", "/ae.safetensors", "/qwen.safetensors"}

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -194,6 +194,33 @@ wheels = [
 ]
 
 [[package]]
+name = "controlnet-aux"
+version = "0.0.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "einops" },
+    { name = "filelock" },
+    { name = "huggingface-hub" },
+    { name = "importlib-metadata" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opencv-python-headless" },
+    { name = "pillow" },
+    { name = "scikit-image" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "timm" },
+    { name = "torch", version = "2.6.0+cu124", source = { registry = "https://download.pytorch.org/whl/cu124" }, marker = "sys_platform == 'win32'" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "torchvision", version = "0.21.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
+    { name = "torchvision", version = "0.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/ad/2eb8cd9a8e17e35b9e5d39ad29afdde8fe810bda85e6e59117050519955d/controlnet_aux-0.0.10.tar.gz", hash = "sha256:31dc265a54448bdcee033a130b47423c80587fa35ccac752113af1b4d48f5183", size = 215016, upload-time = "2025-05-08T10:38:30.845Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/3b/e1608b5bca98bcdaa2c74286fcc0457f3c0a8c99e25e3e4065c184f92c7f/controlnet_aux-0.0.10-py3-none-any.whl", hash = "sha256:cad3480d62c7df1ae569258a659c88d730873323d2adbb9f6f7aebd87917df3b", size = 290398, upload-time = "2025-05-08T10:38:28.952Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -338,6 +365,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -491,6 +526,20 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio"
+version = "2.37.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/62/aa770a9307508d2a2a2c62d536a49347bffe9e55322db27838d3c93d0b07/imageio-2.37.4.tar.gz", hash = "sha256:e45cbc5e83502047fb138f7f585f7f105a136a57eea5f4b3cfc6ce1b52720bd3", size = 390173, upload-time = "2026-07-20T05:26:11.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/2d/ca050652104bab2cf55e569db2a178b1b61cb041fef28307f2db383f6d9f/imageio-2.37.4-py3-none-any.whl", hash = "sha256:1ab2e22c8debf700f24c3ac43e8f95f3b3a8110c83b93411e97b4b0b2cd1c7e6", size = 318000, upload-time = "2026-07-20T05:26:09.874Z" },
+]
+
+[[package]]
 name = "imageio-ffmpeg"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -539,12 +588,14 @@ dependencies = [
 all = [
     { name = "accelerate" },
     { name = "bitsandbytes", marker = "sys_platform != 'darwin'" },
+    { name = "controlnet-aux" },
     { name = "diffusers" },
     { name = "einops" },
     { name = "fastapi" },
     { name = "huggingface-hub" },
     { name = "imageio-ffmpeg" },
     { name = "nvidia-ml-py" },
+    { name = "onnxruntime" },
     { name = "peft" },
     { name = "pillow" },
     { name = "psutil" },
@@ -570,8 +621,10 @@ parallel = [
 ]
 runtime = [
     { name = "accelerate" },
+    { name = "controlnet-aux" },
     { name = "diffusers" },
     { name = "huggingface-hub" },
+    { name = "onnxruntime" },
     { name = "safetensors" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -601,6 +654,8 @@ requires-dist = [
     { name = "accelerate", marker = "extra == 'runtime'", specifier = ">=0.30" },
     { name = "bitsandbytes", marker = "sys_platform != 'darwin' and extra == 'all'", specifier = ">=0.43" },
     { name = "bitsandbytes", marker = "sys_platform != 'darwin' and extra == 'training'", specifier = ">=0.43" },
+    { name = "controlnet-aux", marker = "extra == 'all'", specifier = ">=0.0.7" },
+    { name = "controlnet-aux", marker = "extra == 'runtime'", specifier = ">=0.0.7" },
     { name = "diffusers", marker = "extra == 'all'", specifier = ">=0.39" },
     { name = "diffusers", marker = "extra == 'runtime'", specifier = ">=0.39" },
     { name = "einops", marker = "extra == 'all'", specifier = ">=0.7" },
@@ -616,6 +671,8 @@ requires-dist = [
     { name = "nvidia-ml-py", marker = "extra == 'all'", specifier = ">=12" },
     { name = "nvidia-ml-py", marker = "extra == 'parallel'", specifier = ">=12" },
     { name = "nvidia-ml-py", marker = "extra == 'training'", specifier = ">=12" },
+    { name = "onnxruntime", marker = "extra == 'all'", specifier = ">=1.17" },
+    { name = "onnxruntime", marker = "extra == 'runtime'", specifier = ">=1.17" },
     { name = "peft", marker = "extra == 'all'", specifier = ">=0.11" },
     { name = "peft", marker = "extra == 'training'", specifier = ">=0.11" },
     { name = "pillow", marker = "extra == 'all'", specifier = ">=10" },
@@ -656,6 +713,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "lazy-loader"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
 ]
 
 [[package]]
@@ -1080,6 +1149,64 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/4d/5014667e2a3a77d6e1b74cc3d88948d06163b8e0a33a84c85073322b5dec/onnxruntime-1.28.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:f5c5daabd28aad610f83fdcf32acec8fb57e6adc6c6a39fe2a3c755db957b410", size = 19130506, upload-time = "2026-07-25T01:22:34.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/97/b7ce1bc8bb6048b5fe9129f55d6506dc19499068ef2e0a0af1ae3c8aa4e7/onnxruntime-1.28.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8d66f9ceb29909c70839e4e4fb3435c7b490050d8f162bd5f3aba4ca01ee517f", size = 17039880, upload-time = "2026-07-25T01:21:37.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/17/4e5ecd8764f87573c495d834ce79e61ecca47f7a01d1e444a606e570edcb/onnxruntime-1.28.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a166b78ee04f3a37fa1ef82034b6a3ce96d9684e582d4d30b296de83e9998bb5", size = 19193162, upload-time = "2026-07-25T01:21:59.151Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/10/3d946d5d5f2cdcc3c8da36cae63190c516d16349edaffd944bda60ca4c3e/onnxruntime-1.28.0-cp311-cp311-win_amd64.whl", hash = "sha256:0d650aeee29368414367b65529e90afe4bf1bab76254789063b8b2f7ea3013c8", size = 13752539, upload-time = "2026-07-25T01:22:24.524Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/74/1c440be7af1e026280b139caa1be5d11bd4dc368011ddbe8f5362b58e12f/onnxruntime-1.28.0-cp311-cp311-win_arm64.whl", hash = "sha256:0faf85fb447a663c9cdadc39bd6b19bdf7bedded6699e45731b9b36c46fd993d", size = 13449940, upload-time = "2026-07-25T01:22:14.97Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f8/dcbe7700dca82fa540035abd3c868fe5ad0f86af00b9a3db7c2e27d15c7d/onnxruntime-1.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:26ff0fdd06efb6c155bae95387a09db1a2be89c7a03e4d0bffd5a171cc2826da", size = 19141362, upload-time = "2026-07-25T01:22:36.965Z" },
+    { url = "https://files.pythonhosted.org/packages/28/5b/1d77e62097fdbe07e2dc827f389b1c4c0c275f6fab0369a8f46d2461af27/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e81a23df16e7acb9d51b06d30cc098e49315ef9180f97bc2221d167b4b04d9c", size = 17050628, upload-time = "2026-07-25T01:21:40.481Z" },
+    { url = "https://files.pythonhosted.org/packages/95/df/5486ab03e9be288d5268867054c8b04bebcf95bfd12e801c05cc67703dab/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a83bdb70d143cede762b677789bf2a7acca54b3fb82565601d5c30695aa933c", size = 19214257, upload-time = "2026-07-25T01:22:01.695Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3b/986ca67c274932ba9ac5332fb10de56f643dfd433c74e33f8ae8f847cf24/onnxruntime-1.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:c35064f9b3c43c81c5d5d282091401d0f1ff22796d93ccade4ea2ece5e137ab8", size = 13755036, upload-time = "2026-07-25T01:22:26.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/46/059dba81d46c6ba88e0c2d1c64321ac8098847d678423300a183d42ecbd6/onnxruntime-1.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:e02feeb0165c5f13b4cc954738078d59b90128516ac12b671ee24a530242bf02", size = 13454462, upload-time = "2026-07-25T01:22:17.38Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/3807e2b17d9eb71d3cb78ed2ba76869b05c637c9b9d6112e636098b0c97a/onnxruntime-1.28.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:31410f544674f534c2f27348af52ef81682ca9c8719154bf4d48f0ef23823b1e", size = 19141759, upload-time = "2026-07-25T01:21:53.765Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/23/b46045c3bf67a9cf54c12f5df0f018a422c65fbb9d6072b10071bebfaae2/onnxruntime-1.28.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f649dd6f6452d12a8059888aa489fe519e062e18793dac72b9efa0f9fdb64135", size = 17049339, upload-time = "2026-07-25T01:21:43.005Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b6/8c5396e7894e77c5a7d1e026f3acb9dd39c4b5644e412e37a0055eaa3bc5/onnxruntime-1.28.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54fa221d669282bd8f582708ce4c96010a7e9fb0661f9006b37fe2fedafb73fe", size = 19214329, upload-time = "2026-07-25T01:22:04.133Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f1/51225c202edba4dfc94e1ea03f3d78f1aaf307da75fd792c0ce1946b2514/onnxruntime-1.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:1a1a19175464665c9b8d50bc916f216cc0b569110045b7bbca8f9f290b186f58", size = 13755033, upload-time = "2026-07-25T01:22:29.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/db/f59f715edfdd96a051f32b5ef0e680a20a8755d4ecd75f63090e960e347a/onnxruntime-1.28.0-cp313-cp313-win_arm64.whl", hash = "sha256:cfab507abe09d6ffeb817eee07944d452fdc0b00fdcef34cab4db10a45e378c7", size = 13454175, upload-time = "2026-07-25T01:22:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/47/28/810314fa88647af9f4cdaf438a30ad1cfebebb53ded55499232d7a0094e6/onnxruntime-1.28.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac301f53b1930402fc46c368e268acfed02f3207272aaff05070d7e09f96f031", size = 17057307, upload-time = "2026-07-25T01:21:45.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/cc/9e9f193cc0f29f263a8f09ec08487aed6c96ee856d5fd77da32a425c1949/onnxruntime-1.28.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7f022a1103cae591c75fc4565589a515f2ddd14a6ac8e8a05812dfeda142e28", size = 19222954, upload-time = "2026-07-25T01:22:06.952Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/eb/952314c451d9463e5c9aed9978eec76cf32930d407d9ab8700dd0f4ea1ea/onnxruntime-1.28.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:8adff67a3f28257b37cfe945a7e952e4122666aa8c91a0380862e9fd4c2ed19f", size = 19143748, upload-time = "2026-07-25T01:21:56.297Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/139180b4dd810329aaa42c238b4e6383c906202d98609ae29d66eb7c32b1/onnxruntime-1.28.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc2565e487b4896fb988d6383577d875d958e071fc5f6c3550bd5d02ae98264b", size = 17051950, upload-time = "2026-07-25T01:21:48.606Z" },
+    { url = "https://files.pythonhosted.org/packages/03/88/9432428273356ad3c8aa01f52c1b3e7f53c4c0192748f41ad983872b436b/onnxruntime-1.28.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6afdc83f1317c136e92fc29f5ee9f058de59d87c0b22cee3fdbfbaa0ccc2098a", size = 19214924, upload-time = "2026-07-25T01:22:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/e2/6feb3a43517aaf2b1bf7e46897ba5eb81a29717f7d7901420614d5ee4653/onnxruntime-1.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:f2a3b9e30ce880d4ca54999cb313569e36da4f62eefe25f87be18f43e9a3a4d5", size = 14093738, upload-time = "2026-07-25T01:22:31.629Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8f/83974a1e201dc2e58e5e7111bcaeb1ca2413e9c41f505d26419ee9e3dddf/onnxruntime-1.28.0-cp314-cp314-win_arm64.whl", hash = "sha256:07fb3cbe990d6bf0ab3c22bfbbfb0e314151266046ea6edb4a07f556b4258c5f", size = 13821117, upload-time = "2026-07-25T01:22:22.387Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/83/00e606bc25c756d76a267370c39b7516ad52f9cf134d7ff2bff8b6108bc4/onnxruntime-1.28.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e562d6e36a749f6764481c0ddb0f2af3d0b5a3c164291361d08803c557f369af", size = 17055518, upload-time = "2026-07-25T01:21:51.08Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a9/68707e1ce345cbdbcd4df65932ebc82a673e917d63eda0007ebcff948691/onnxruntime-1.28.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f6e92367ddce1e4d33cf295024f40192be6c6171a09208f515ba169ced06c8e", size = 19222976, upload-time = "2026-07-25T01:22:12.474Z" },
+]
+
+[[package]]
+name = "opencv-python-headless"
+version = "5.0.0.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/99/76b7c80252aa83c1af16393454aafd125a0287101afe8deb0a6821af0e30/opencv_python_headless-5.0.0.93.tar.gz", hash = "sha256:b82f9831daab90b725c7c1ee1b36cb5732c367096ac76d119e64e14eb70d5f3c", size = 81817738, upload-time = "2026-07-02T07:01:06.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/7c/8c8097891c509d98cd128493835c95631c80be6a8f37ed9d25716c2e16f1/opencv_python_headless-5.0.0.93-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:030ca5e0837a2963ab36ef896baa9767eb8d2b83353fb28af5a521e40dd8756f", size = 48322581, upload-time = "2026-07-02T05:50:34.207Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8c/eab2ad388c3cbab2a350c10c2ef19ce6bd099240afc31789032c996bab52/opencv_python_headless-5.0.0.93-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:1e55af3abfb462eeeabe5c775f12bdb36216d8a93a3583d69e6bd6e1d6ba7d00", size = 34782894, upload-time = "2026-07-02T05:51:39.856Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/78/afca939f40ffe2b2380bfa86f812b2f7d4acc5a27b27dc41b49cad7ce7b4/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10818d91510e05c04568ae12b5cd120779c70c01bf897b001a6221fe430df80f", size = 36521085, upload-time = "2026-07-02T06:55:24.429Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/97/8170e9819764c47e436c130d3ff6cfb73b58f923eae9d3a03d8982b04aec/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09a872a157c1376ab922a69bbf22f9a95bcc7b658a9d8b436a60212b02b2eeb4", size = 56563598, upload-time = "2026-07-02T06:55:47.355Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/98/1a28a7101e31801042b3098871a74b76c61581d328ef40774ff4edb53a56/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:840bd717c21e5c11cadadc022a823315ea417f961213d06b4df010e019eb16f4", size = 39648433, upload-time = "2026-07-02T06:56:04.255Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/21/f6ef335f6e65724aa78b8d792b48d40a48c381715f1e62f5a5049e09d07e/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ed709fdf9aa0bd1f2ed8549e71d19449b03a675bb581eb292285f6861953be37", size = 61204038, upload-time = "2026-07-02T06:56:41.823Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8f/b8756467ea991449a293797f6b3fa80fcfdd29598a0a60d1cd5715b96e61/opencv_python_headless-5.0.0.93-cp37-abi3-win32.whl", hash = "sha256:c6bcd96b185975ea240d22cfdb15a1f6d080cc95264cfbe2621f21bb144d89b9", size = 35411237, upload-time = "2026-07-02T05:50:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/88/763b967f7efd7226b82c9fae16d560cba049b1f0c036647e65c610fd636e/opencv_python_headless-5.0.0.93-cp37-abi3-win_amd64.whl", hash = "sha256:829717b6a95554f273e49e357cee3b3a2a26b6f4842fbc1bed2b45bdd8f87e0e", size = 43825962, upload-time = "2026-07-02T05:50:09.627Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1203,6 +1330,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -1634,6 +1776,75 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-image"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "imageio" },
+    { name = "lazy-loader" },
+    { name = "networkx" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "tifffile", version = "2026.7.14", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/16/8a407688b607f86f81f8c649bf0d68a2a6d67375f18c2d660aba20f5b648/scikit_image-0.26.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b1ede33a0fb3731457eaf53af6361e73dd510f449dac437ab54573b26788baf0", size = 12355510, upload-time = "2025-12-20T17:10:31.628Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f9/7efc088ececb6f6868fd4475e16cfafc11f242ce9ab5fc3557d78b5da0d4/scikit_image-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7af7aa331c6846bd03fa28b164c18d0c3fd419dbb888fb05e958ac4257a78fdd", size = 12056334, upload-time = "2025-12-20T17:10:34.559Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/1e/bc7fb91fb5ff65ef42346c8b7ee8b09b04eabf89235ab7dbfdfd96cbd1ea/scikit_image-0.26.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ea6207d9e9d21c3f464efe733121c0504e494dbdc7728649ff3e23c3c5a4953", size = 13297768, upload-time = "2025-12-20T17:10:37.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/2a/e71c1a7d90e70da67b88ccc609bd6ae54798d5847369b15d3a8052232f9d/scikit_image-0.26.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74aa5518ccea28121f57a95374581d3b979839adc25bb03f289b1bc9b99c58af", size = 13711217, upload-time = "2025-12-20T17:10:40.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/59/9637ee12c23726266b91296791465218973ce1ad3e4c56fc81e4d8e7d6e1/scikit_image-0.26.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d5c244656de905e195a904e36dbc18585e06ecf67d90f0482cbde63d7f9ad59d", size = 14337782, upload-time = "2025-12-20T17:10:43.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/5c/a3e1e0860f9294663f540c117e4bf83d55e5b47c281d475cc06227e88411/scikit_image-0.26.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:21a818ee6ca2f2131b9e04d8eb7637b5c18773ebe7b399ad23dcc5afaa226d2d", size = 14805997, upload-time = "2025-12-20T17:10:45.93Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c6/2eeacf173da041a9e388975f54e5c49df750757fcfc3ee293cdbbae1ea0a/scikit_image-0.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:9490360c8d3f9a7e85c8de87daf7c0c66507960cf4947bb9610d1751928721c7", size = 11878486, upload-time = "2025-12-20T17:10:48.246Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a4/a852c4949b9058d585e762a66bf7e9a2cd3be4795cd940413dfbfbb0ce79/scikit_image-0.26.0-cp311-cp311-win_arm64.whl", hash = "sha256:0baa0108d2d027f34d748e84e592b78acc23e965a5de0e4bb03cf371de5c0581", size = 11346518, upload-time = "2025-12-20T17:10:50.575Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e8/e13757982264b33a1621628f86b587e9a73a13f5256dad49b19ba7dc9083/scikit_image-0.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d454b93a6fa770ac5ae2d33570f8e7a321bb80d29511ce4b6b78058ebe176e8c", size = 12376452, upload-time = "2025-12-20T17:10:52.796Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/be/f8dd17d0510f9911f9f17ba301f7455328bf13dae416560126d428de9568/scikit_image-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3409e89d66eff5734cd2b672d1c48d2759360057e714e1d92a11df82c87cba37", size = 12061567, upload-time = "2025-12-20T17:10:55.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/c70120a6880579fb42b91567ad79feb4772f7be72e8d52fec403a3dde0c6/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c717490cec9e276afb0438dd165b7c3072d6c416709cc0f9f5a4c1070d23a44", size = 13084214, upload-time = "2025-12-20T17:10:57.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7df650e79031634ac90b11e64a9eedaf5a5e06fcd09bcd03a34be01745744466", size = 13561683, upload-time = "2025-12-20T17:10:59.49Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/48bdfd92794c5002d664e0910a349d0a1504671ef5ad358150f21643c79a/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cefd85033e66d4ea35b525bb0937d7f42d4cdcfed2d1888e1570d5ce450d3932", size = 14112147, upload-time = "2025-12-20T17:11:02.083Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b5/ac71694da92f5def5953ca99f18a10fe98eac2dd0a34079389b70b4d0394/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f5bf622d7c0435884e1e141ebbe4b2804e16b2dd23ae4c6183e2ea99233be70", size = 14661625, upload-time = "2025-12-20T17:11:04.528Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4d/a3cc1e96f080e253dad2251bfae7587cf2b7912bcd76fd43fd366ff35a87/scikit_image-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:abed017474593cd3056ae0fe948d07d0747b27a085e92df5474f4955dd65aec0", size = 11911059, upload-time = "2025-12-20T17:11:06.61Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/d1b8055f584acc937478abf4550d122936f420352422a1a625eef2c605d8/scikit_image-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:4d57e39ef67a95d26860c8caf9b14b8fb130f83b34c6656a77f191fa6d1d04d8", size = 11348740, upload-time = "2025-12-20T17:11:09.118Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/48/02357ffb2cca35640f33f2cfe054a4d6d5d7a229b88880a64f1e45c11f4e/scikit_image-0.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a2e852eccf41d2d322b8e60144e124802873a92b8d43a6f96331aa42888491c7", size = 12346329, upload-time = "2025-12-20T17:11:11.599Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b9/b792c577cea2c1e94cda83b135a656924fc57c428e8a6d302cd69aac1b60/scikit_image-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98329aab3bc87db352b9887f64ce8cdb8e75f7c2daa19927f2e121b797b678d5", size = 12031726, upload-time = "2025-12-20T17:11:13.871Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/9564250dfd65cb20404a611016db52afc6268b2b371cd19c7538ea47580f/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:915bb3ba66455cf8adac00dc8fdf18a4cd29656aec7ddd38cb4dda90289a6f21", size = 13094910, upload-time = "2025-12-20T17:11:16.2Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b8/0d8eeb5a9fd7d34ba84f8a55753a0a3e2b5b51b2a5a0ade648a8db4a62f7/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b36ab5e778bf50af5ff386c3ac508027dc3aaeccf2161bdf96bde6848f44d21b", size = 13660939, upload-time = "2025-12-20T17:11:18.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d6/91d8973584d4793d4c1a847d388e34ef1218d835eeddecfc9108d735b467/scikit_image-0.26.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:09bad6a5d5949c7896c8347424c4cca899f1d11668030e5548813ab9c2865dcb", size = 14138938, upload-time = "2025-12-20T17:11:20.919Z" },
+    { url = "https://files.pythonhosted.org/packages/39/9a/7e15d8dc10d6bbf212195fb39bdeb7f226c46dd53f9c63c312e111e2e175/scikit_image-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:aeb14db1ed09ad4bee4ceb9e635547a8d5f3549be67fc6c768c7f923e027e6cd", size = 14752243, upload-time = "2025-12-20T17:11:23.347Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/58/2b11b933097bc427e42b4a8b15f7de8f24f2bac1fd2779d2aea1431b2c31/scikit_image-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac529eb9dbd5954f9aaa2e3fe9a3fd9661bfe24e134c688587d811a0233127f1", size = 11906770, upload-time = "2025-12-20T17:11:25.297Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ec/96941474a18a04b69b6f6562a5bd79bd68049fa3728d3b350976eccb8b93/scikit_image-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:a2d211bc355f59725efdcae699b93b30348a19416cc9e017f7b2fb599faf7219", size = 11342506, upload-time = "2025-12-20T17:11:27.399Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e5/c1a9962b0cf1952f42d32b4a2e48eed520320dbc4d2ff0b981c6fa508b6b/scikit_image-0.26.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9eefb4adad066da408a7601c4c24b07af3b472d90e08c3e7483d4e9e829d8c49", size = 12663278, upload-time = "2025-12-20T17:11:29.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/97/c1a276a59ce8e4e24482d65c1a3940d69c6b3873279193b7ebd04e5ee56b/scikit_image-0.26.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6caec76e16c970c528d15d1c757363334d5cb3069f9cea93d2bead31820511f3", size = 12405142, upload-time = "2025-12-20T17:11:31.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4a/f1cbd1357caef6c7993f7efd514d6e53d8fd6f7fe01c4714d51614c53289/scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a07200fe09b9d99fcdab959859fe0f7db8df6333d6204344425d476850ce3604", size = 12942086, upload-time = "2025-12-20T17:11:33.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/74d9fb87c5655bd64cf00b0c44dc3d6206d9002e5f6ba1c9aeb13236f6bf/scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92242351bccf391fc5df2d1529d15470019496d2498d615beb68da85fe7fdf37", size = 13265667, upload-time = "2025-12-20T17:11:36.11Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/73/faddc2413ae98d863f6fa2e3e14da4467dd38e788e1c23346cf1a2b06b97/scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:52c496f75a7e45844d951557f13c08c81487c6a1da2e3c9c8a39fcde958e02cc", size = 14001966, upload-time = "2025-12-20T17:11:38.55Z" },
+    { url = "https://files.pythonhosted.org/packages/02/94/9f46966fa042b5d57c8cd641045372b4e0df0047dd400e77ea9952674110/scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:20ef4a155e2e78b8ab973998e04d8a361d49d719e65412405f4dadd9155a61d9", size = 14359526, upload-time = "2025-12-20T17:11:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b4/2840fe38f10057f40b1c9f8fb98a187a370936bf144a4ac23452c5ef1baf/scikit_image-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c9087cf7d0e7f33ab5c46d2068d86d785e70b05400a891f73a13400f1e1faf6a", size = 12287629, upload-time = "2025-12-20T17:11:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ba/73b6ca70796e71f83ab222690e35a79612f0117e5aaf167151b7d46f5f2c/scikit_image-0.26.0-cp313-cp313t-win_arm64.whl", hash = "sha256:27d58bc8b2acd351f972c6508c1b557cfed80299826080a4d803dd29c51b707e", size = 11647755, upload-time = "2025-12-20T17:11:45.279Z" },
+    { url = "https://files.pythonhosted.org/packages/51/44/6b744f92b37ae2833fd423cce8f806d2368859ec325a699dc30389e090b9/scikit_image-0.26.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:63af3d3a26125f796f01052052f86806da5b5e54c6abef152edb752683075a9c", size = 12365810, upload-time = "2025-12-20T17:11:47.357Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f5/83590d9355191f86ac663420fec741b82cc547a4afe7c4c1d986bf46e4db/scikit_image-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ce00600cd70d4562ed59f80523e18cdcc1fae0e10676498a01f73c255774aefd", size = 12075717, upload-time = "2025-12-20T17:11:49.483Z" },
+    { url = "https://files.pythonhosted.org/packages/72/48/253e7cf5aee6190459fe136c614e2cbccc562deceb4af96e0863f1b8ee29/scikit_image-0.26.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6381edf972b32e4f54085449afde64365a57316637496c1325a736987083e2ab", size = 13161520, upload-time = "2025-12-20T17:11:51.58Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c3/cec6a3cbaadfdcc02bd6ff02f3abfe09eaa7f4d4e0a525a1e3a3f4bce49c/scikit_image-0.26.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6624a76c6085218248154cc7e1500e6b488edcd9499004dd0d35040607d7505", size = 13684340, upload-time = "2025-12-20T17:11:53.708Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0d/39a776f675d24164b3a267aa0db9f677a4cb20127660d8bf4fd7fef66817/scikit_image-0.26.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f775f0e420faac9c2aa6757135f4eb468fb7b70e0b67fa77a5e79be3c30ee331", size = 14203839, upload-time = "2025-12-20T17:11:55.89Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/25/2514df226bbcedfe9b2caafa1ba7bc87231a0c339066981b182b08340e06/scikit_image-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede4d6d255cc5da9faeb2f9ba7fedbc990abbc652db429f40a16b22e770bb578", size = 14770021, upload-time = "2025-12-20T17:11:58.014Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/5b/0671dc91c0c79340c3fe202f0549c7d3681eb7640fe34ab68a5f090a7c7f/scikit_image-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:0660b83968c15293fd9135e8d860053ee19500d52bf55ca4fb09de595a1af650", size = 12023490, upload-time = "2025-12-20T17:12:00.013Z" },
+    { url = "https://files.pythonhosted.org/packages/65/08/7c4cb59f91721f3de07719085212a0b3962e3e3f2d1818cbac4eeb1ea53e/scikit_image-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:b8d14d3181c21c11170477a42542c1addc7072a90b986675a71266ad17abc37f", size = 11473782, upload-time = "2025-12-20T17:12:01.983Z" },
+    { url = "https://files.pythonhosted.org/packages/49/41/65c4258137acef3d73cb561ac55512eacd7b30bb4f4a11474cad526bc5db/scikit_image-0.26.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:cde0bbd57e6795eba83cb10f71a677f7239271121dc950bc060482834a668ad1", size = 12686060, upload-time = "2025-12-20T17:12:03.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/32/76971f8727b87f1420a962406388a50e26667c31756126444baf6668f559/scikit_image-0.26.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:163e9afb5b879562b9aeda0dd45208a35316f26cc7a3aed54fd601604e5cf46f", size = 12422628, upload-time = "2025-12-20T17:12:05.921Z" },
+    { url = "https://files.pythonhosted.org/packages/37/0d/996febd39f757c40ee7b01cdb861867327e5c8e5f595a634e8201462d958/scikit_image-0.26.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724f79fd9b6cb6f4a37864fe09f81f9f5d5b9646b6868109e1b100d1a7019e59", size = 12962369, upload-time = "2025-12-20T17:12:07.912Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b4/612d354f946c9600e7dea012723c11d47e8d455384e530f6daaaeb9bf62c/scikit_image-0.26.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3268f13310e6857508bd87202620df996199a016a1d281b309441d227c822394", size = 13272431, upload-time = "2025-12-20T17:12:10.255Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6e/26c00b466e06055a086de2c6e2145fe189ccdc9a1d11ccc7de020f2591ad/scikit_image-0.26.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fac96a1f9b06cd771cbbb3cd96c5332f36d4efd839b1d8b053f79e5887acde62", size = 14016362, upload-time = "2025-12-20T17:12:12.793Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/00a90402e1775634043c2a0af8a3c76ad450866d9fa444efcc43b553ba2d/scikit_image-0.26.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c1e7bd342f43e7a97e571b3f03ba4c1293ea1a35c3f13f41efdc8a81c1dc8f2", size = 14364151, upload-time = "2025-12-20T17:12:14.909Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ca/918d8d306bd43beacff3b835c6d96fac0ae64c0857092f068b88db531a7c/scikit_image-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b702c3bb115e1dcf4abf5297429b5c90f2189655888cbed14921f3d26f81d3a4", size = 12413484, upload-time = "2025-12-20T17:12:17.046Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cd/4da01329b5a8d47ff7ec3c99a2b02465a8017b186027590dc7425cee0b56/scikit_image-0.26.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0608aa4a9ec39e0843de10d60edb2785a30c1c47819b67866dd223ebd149acaf", size = 11769501, upload-time = "2025-12-20T17:12:19.339Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1883,6 +2094,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2026.3.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/e4/e804505f87627cd8cdae9c010c47c4485fd8c1ce31a7dd0ab7fcc4707377/tifffile-2026.3.3-py3-none-any.whl", hash = "sha256:e8be15c94273113d31ecb7aa3a39822189dd11c4967e3cc88c178f1ad2fd1170", size = 243960, upload-time = "2026-03-03T19:14:35.808Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2026.7.14"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/2f/e5fe51c8f782241d86fdf7251594b195f0d6c2fcf9d389079de212599246/tifffile-2026.7.14.tar.gz", hash = "sha256:ce2703e5ef22c868f1528d5f5b4ef75eefb019cf628a1c9ec0d17e0afeca8ef5", size = 437660, upload-time = "2026-07-14T23:41:31.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/e8/d381de4a3cc4e3682cba0338f43250893508aad0b310af1d0635f7b04413/tifffile-2026.7.14-py3-none-any.whl", hash = "sha256:4eb20372e76edf2c9fed922b1e3a0a0567be3560bd2008336115763bb1f3c034", size = 270614, upload-time = "2026-07-14T23:41:30.078Z" },
 ]
 
 [[package]]

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -576,7 +576,7 @@ wheels = [
 
 [[package]]
 name = "inline-core"
-version = "1.2.52"
+version = "1.2.53"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },

--- a/core/webui.bat
+++ b/core/webui.bat
@@ -90,7 +90,9 @@ rem slower with no error. When an NVIDIA GPU is present, resolve torch from the 
 set "TORCH_ARGS="
 where nvidia-smi >nul 2>nul || goto install_cpu
 nvidia-smi -L >nul 2>nul || goto install_cpu
-set "TORCH_ARGS=--extra-index-url https://download.pytorch.org/whl/cu124"
+rem unsafe-best-match: torchao is on the CUDA index too but only up to 0.9.0; without this uv's
+rem first-index rule stops there and fails our torchao>=0.14 pin instead of finding it on PyPI.
+set "TORCH_ARGS=--extra-index-url https://download.pytorch.org/whl/cu124 --index-strategy unsafe-best-match"
 echo NVIDIA GPU detected - installing the CUDA build of PyTorch.
 goto install_pkgs
 :install_cpu

--- a/core/webui.sh
+++ b/core/webui.sh
@@ -123,7 +123,10 @@ if [[ "$RUN_INSTALL" -eq 1 ]]; then
   # slower, with no error. When an NVIDIA GPU is present, resolve torch from the CUDA index.
   TORCH_INDEX=()
   if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
-    TORCH_INDEX=(--extra-index-url https://download.pytorch.org/whl/cu124)
+    # unsafe-best-match: torchao is on the CUDA index too but only up to 0.9.0; without this uv's
+    # first-index rule stops there and fails our torchao>=0.14 pin instead of finding it on PyPI.
+    TORCH_INDEX=(--extra-index-url https://download.pytorch.org/whl/cu124 \
+      --index-strategy unsafe-best-match)
     echo "NVIDIA GPU detected - installing the CUDA build of PyTorch."
   else
     echo "No NVIDIA GPU detected - installing the default (CPU) build of PyTorch."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inline-studio",
-  "version": "1.2.52",
+  "version": "1.2.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inline-studio",
-      "version": "1.2.52",
+      "version": "1.2.53",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@react-three/drei": "^10.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,36 +7,22 @@
     "": {
       "name": "inline-studio",
       "version": "1.2.52",
-      "hasInstallScript": true,
-      "license": "MIT",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.104.2",
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.6.1",
         "@xyflow/react": "^12.11.0",
-        "archiver": "^7.0.1",
-        "better-sqlite3": "^11.8.1",
-        "electron-updater": "^6.8.9",
-        "extract-zip": "^2.0.1",
-        "ffmpeg-static": "^5.2.0",
-        "ffprobe-static": "^3.1.0",
-        "fluent-ffmpeg": "^2.1.3",
         "react-resizable-panels": "^2.1.9",
-        "ws": "^8.18.0"
+        "three": "^0.171.0"
       },
       "devDependencies": {
-        "@electron/rebuild": "^3.7.1",
         "@eslint/js": "^9.18.0",
-        "@types/archiver": "^6.0.4",
-        "@types/better-sqlite3": "^7.6.12",
-        "@types/fluent-ffmpeg": "^2.1.27",
         "@types/node": "^22.10.5",
         "@types/react": "^19.0.4",
         "@types/react-dom": "^19.0.2",
-        "@types/ws": "^8.5.13",
+        "@types/three": "^0.171.0",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
-        "electron": "^33.3.1",
-        "electron-builder": "^25.1.8",
-        "electron-vite": "^2.3.0",
         "eslint": "^9.18.0",
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.16",
@@ -54,6 +40,10 @@
         "vite": "^5.4.11",
         "vitest": "^2.1.8",
         "zustand": "^5.0.3"
+      },
+      "engines": {
+        "node": ">=20.19.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -67,27 +57,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.104.2",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.2.tgz",
-      "integrity": "sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -312,22 +281,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
-      "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
@@ -415,364 +368,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@derhuerst/http-basic": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
-      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
-      "license": "MIT",
-      "dependencies": {
-        "caseless": "^0.12.0",
-        "concat-stream": "^2.0.0",
-        "http-response-object": "^3.0.1",
-        "parse-cache-control": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@develar/schema-utils": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
-      "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.0",
-        "ajv-keywords": "^3.4.1"
-      },
-      "engines": {
-        "node": ">= 8.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/@electron/asar": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
-      "integrity": "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^5.0.0",
-        "glob": "^7.1.6",
-        "minimatch": "^3.0.4"
-      },
-      "bin": {
-        "asar": "bin/asar.js"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
-    "node_modules/@electron/asar/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@electron/asar/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@electron/asar/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
-        "progress": "^2.0.3",
-        "semver": "^6.2.0",
-        "sumchecker": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "global-agent": "^3.0.0"
-      }
-    },
-    "node_modules/@electron/get/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@electron/get/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/get/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@electron/get/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/@electron/node-gyp": {
-      "version": "10.2.0-electron.1",
-      "resolved": "git+ssh://git@github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
-      "integrity": "sha512-CrYo6TntjpoMO1SHjl5Pa/JoUsECNqNdB7Kx49WLQpWzPw53eEITJ2Hs9fh/ryUYDn4pxZz11StaBYBrLFJdqg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "exponential-backoff": "^3.1.1",
-        "glob": "^8.1.0",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^10.2.1",
-        "nopt": "^6.0.0",
-        "proc-log": "^2.0.1",
-        "semver": "^7.3.5",
-        "tar": "^6.2.1",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@electron/notarize": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
-      "integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "fs-extra": "^9.0.1",
-        "promise-retry": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@electron/notarize/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@electron/osx-sign": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.1.tgz",
-      "integrity": "sha512-BAfviURMHpmb1Yb50YbCxnOY0wfwaLXH5KJ4+80zS0gUkzDX3ec23naTlEqKsN+PwYn+a1cCzM7BJ4Wcd3sGzw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "compare-version": "^0.1.2",
-        "debug": "^4.3.4",
-        "fs-extra": "^10.0.0",
-        "isbinaryfile": "^4.0.8",
-        "minimist": "^1.2.6",
-        "plist": "^3.0.5"
-      },
-      "bin": {
-        "electron-osx-flat": "bin/electron-osx-flat.js",
-        "electron-osx-sign": "bin/electron-osx-sign.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
-      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/gjtorikian/"
-      }
-    },
-    "node_modules/@electron/rebuild": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.7.2.tgz",
-      "integrity": "sha512-19/KbIR/DAxbsCkiaGMXIdPnMCJLkcf8AvGnduJtWBs/CBwiAjY1apCqOLVxrXg+rtXFCngbXhBanWjxLUt1Mg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@electron/node-gyp": "git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
-        "@malept/cross-spawn-promise": "^2.0.0",
-        "chalk": "^4.0.0",
-        "debug": "^4.1.1",
-        "detect-libc": "^2.0.1",
-        "fs-extra": "^10.0.0",
-        "got": "^11.7.0",
-        "node-abi": "^3.45.0",
-        "node-api-version": "^0.2.0",
-        "ora": "^5.1.0",
-        "read-binary-file-arch": "^1.0.6",
-        "semver": "^7.3.5",
-        "tar": "^6.0.5",
-        "yargs": "^17.0.1"
-      },
-      "bin": {
-        "electron-rebuild": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@electron/universal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.1.tgz",
-      "integrity": "sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@electron/asar": "^3.2.7",
-        "@malept/cross-spawn-promise": "^2.0.0",
-        "debug": "^4.3.1",
-        "dir-compare": "^4.2.0",
-        "fs-extra": "^11.1.1",
-        "minimatch": "^9.0.3",
-        "plist": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=16.4"
-      }
-    },
-    "node_modules/@electron/universal/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@electron/universal/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/universal/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1372,13 +967,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@gar/promisify": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
-      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1445,75 +1033,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1564,59 +1083,22 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@malept/cross-spawn-promise": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
-      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
-        }
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      }
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
     },
-    "node_modules/@malept/flatpak-bundler": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
-      "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
-      "dev": true,
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.1.1",
-        "fs-extra": "^9.0.0",
-        "lodash": "^4.17.15",
-        "tmp-promise": "^3.0.2"
+        "promise-worker-transferable": "^1.0.4"
       },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+      "peerDependencies": {
+        "three": ">= 0.159.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1657,43 +1139,116 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@npmcli/fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
-      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promisify": "^1.1.3",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@npmcli/move-file": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
-      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
-      "deprecated": "This functionality has been moved to @npmcli/fs",
-      "dev": true,
+    "node_modules/@react-three/drei": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
+      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
       "license": "MIT",
       "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
       },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+    "node_modules/@react-three/fiber": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
+      "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
       "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2053,57 +1608,11 @@
         "win32"
       ]
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
       "license": "MIT"
-    },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defer-to-connect": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
-      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@types/archiver": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.4.tgz",
-      "integrity": "sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/readdir-glob": "*"
-      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2148,29 +1657,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
-      }
-    },
-    "node_modules/@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cacheable-request": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "^3.1.4",
-        "@types/node": "*",
-        "@types/responselike": "^1.0.0"
       }
     },
     "node_modules/@types/d3-color": {
@@ -2222,47 +1708,16 @@
         "@types/d3-selection": "*"
       }
     },
-    "node_modules/@types/debug": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
-      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/ms": "*"
-      }
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/fluent-ffmpeg": {
-      "version": "2.1.28",
-      "resolved": "https://registry.npmjs.org/@types/fluent-ffmpeg/-/fluent-ffmpeg-2.1.28.tgz",
-      "integrity": "sha512-5ovxsDwBcPfJ+eYs1I/ZpcYCnkce7pvH9AHSvrZllAp1ZPpTRDZAFjF3TRFbukxSgIYTTNYePbS0rKUmaxVbXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/fs-extra": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
-      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -2273,50 +1728,26 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/keyv": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "22.19.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
       "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/plist": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
-      "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*",
-        "xmlbuilder": ">=11.0.1"
-      }
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2342,53 +1773,31 @@
         "@types/react": "*"
       }
     },
-    "node_modules/@types/readdir-glob": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
-      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
-      "dev": true,
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.171.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.171.0.tgz",
+      "integrity": "sha512-oLuT1SAsT+CUg/wxUTFHo0K3NtJLnx9sJhZWQJp/0uXqFpzSk1hRHmvWvpaAWSfvx2db0lVKZ5/wV0I0isD2mQ==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "*"
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
       }
     },
-    "node_modules/@types/responselike": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/verror": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
-      "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.61.0",
@@ -2633,6 +2042,24 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -2767,15 +2194,11 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.6"
-      }
+    "node_modules/@webgpu/types": {
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
+      "integrity": "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xyflow/react": {
       "version": "12.11.0",
@@ -2847,32 +2270,6 @@
         "d3-zoom": "^3.0.0"
       }
     },
-    "node_modules/7zip-bin": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
-      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2896,43 +2293,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -2948,16 +2308,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
       }
     },
     "node_modules/ansi-escapes": {
@@ -2980,6 +2330,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2992,6 +2343,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3024,397 +2376,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/app-builder-bin": {
-      "version": "5.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.10.tgz",
-      "integrity": "sha512-Ev4jj3D7Bo+O0GPD2NMvJl+PGiBAfS7pUGawntBNpCbxtpncfUixqFj9z9Jme7V7s3LBGqsWZZP54fxBX3JKJw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/app-builder-lib": {
-      "version": "25.1.8",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-25.1.8.tgz",
-      "integrity": "sha512-pCqe7dfsQFBABC1jeKZXQWhGcCPF3rPCXDdfqVKjIeWBcXzyC1iOWZdfFhGl+S9MyE/k//DFmC6FzuGAUudNDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@develar/schema-utils": "~2.6.5",
-        "@electron/notarize": "2.5.0",
-        "@electron/osx-sign": "1.3.1",
-        "@electron/rebuild": "3.6.1",
-        "@electron/universal": "2.0.1",
-        "@malept/flatpak-bundler": "^0.4.0",
-        "@types/fs-extra": "9.0.13",
-        "async-exit-hook": "^2.0.1",
-        "bluebird-lst": "^1.0.9",
-        "builder-util": "25.1.7",
-        "builder-util-runtime": "9.2.10",
-        "chromium-pickle-js": "^0.2.0",
-        "config-file-ts": "0.2.8-rc1",
-        "debug": "^4.3.4",
-        "dotenv": "^16.4.5",
-        "dotenv-expand": "^11.0.6",
-        "ejs": "^3.1.8",
-        "electron-publish": "25.1.7",
-        "form-data": "^4.0.0",
-        "fs-extra": "^10.1.0",
-        "hosted-git-info": "^4.1.0",
-        "is-ci": "^3.0.0",
-        "isbinaryfile": "^5.0.0",
-        "js-yaml": "^4.1.0",
-        "json5": "^2.2.3",
-        "lazy-val": "^1.0.5",
-        "minimatch": "^10.0.0",
-        "resedit": "^1.7.0",
-        "sanitize-filename": "^1.6.3",
-        "semver": "^7.3.8",
-        "tar": "^6.1.12",
-        "temp-file": "^3.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "dmg-builder": "25.1.8",
-        "electron-builder-squirrel-windows": "25.1.8"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/@electron/rebuild": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.6.1.tgz",
-      "integrity": "sha512-f6596ZHpEq/YskUd8emYvOUne89ij8mQgjYFA5ru25QwbrRO+t1SImofdDv7kKOuWCmVOuU5tvfkbgGxIl3E/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@malept/cross-spawn-promise": "^2.0.0",
-        "chalk": "^4.0.0",
-        "debug": "^4.1.1",
-        "detect-libc": "^2.0.1",
-        "fs-extra": "^10.0.0",
-        "got": "^11.7.0",
-        "node-abi": "^3.45.0",
-        "node-api-version": "^0.2.0",
-        "node-gyp": "^9.0.0",
-        "ora": "^5.1.0",
-        "read-binary-file-arch": "^1.0.6",
-        "semver": "^7.3.5",
-        "tar": "^6.0.5",
-        "yargs": "^17.0.1"
-      },
-      "bin": {
-        "electron-rebuild": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/aproba": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/archiver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^5.0.2",
-        "async": "^3.2.4",
-        "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/archiver-utils/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/archiver/node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
-        "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/archiver/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/archiver/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/archiver/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/archiver/node_modules/buffer-crc32": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/archiver/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/archiver/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/archiver/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/archiver/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/archiver/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/archiver/node_modules/tar-stream": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
-      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -3426,18 +2387,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.8"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -3447,50 +2398,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT"
-    },
-    "node_modules/async-exit-hook": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
-      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/autoprefixer": {
@@ -3530,20 +2437,6 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/b4a": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3552,98 +2445,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/bare-events": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
-      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-fs": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
-      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
-      },
-      "engines": {
-        "bare": ">=1.16.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-os": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
-    "node_modules/bare-path": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
-      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
-    },
-    "node_modules/bare-stream": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
-      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.8.1",
-        "streamx": "^2.25.0",
-        "teex": "^1.0.1"
-      },
-      "peerDependencies": {
-        "bare-abort-controller": "*",
-        "bare-buffer": "*",
-        "bare-events": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        },
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-events": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
-      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-path": "^3.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -3679,15 +2480,13 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
-      "hasInstallScript": true,
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "license": "MIT",
       "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -3702,52 +2501,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/bluebird-lst": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
-      "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bluebird": "^3.5.5"
-      }
-    },
-    "node_modules/boolean": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
@@ -3809,84 +2562,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
-    },
-    "node_modules/builder-util": {
-      "version": "25.1.7",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-25.1.7.tgz",
-      "integrity": "sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/debug": "^4.1.6",
-        "7zip-bin": "~5.2.0",
-        "app-builder-bin": "5.0.0-alpha.10",
-        "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "9.2.10",
-        "chalk": "^4.1.2",
-        "cross-spawn": "^7.0.3",
-        "debug": "^4.3.4",
-        "fs-extra": "^10.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.0",
-        "is-ci": "^3.0.0",
-        "js-yaml": "^4.1.0",
-        "source-map-support": "^0.5.19",
-        "stat-mode": "^1.0.0",
-        "temp-file": "^3.4.0"
-      }
-    },
-    "node_modules/builder-util-runtime": {
-      "version": "9.2.10",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz",
-      "integrity": "sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -3895,89 +2570,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cacache": {
-      "version": "16.1.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
-      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/move-file": "^2.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.6.0"
-      }
-    },
-    "node_modules/cacheable-request": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^6.0.1",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -4000,6 +2592,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/camera-controls": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
+      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001797",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
@@ -4020,12 +2625,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -4109,54 +2708,11 @@
         "node": ">= 6"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/chromium-pickle-js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
-      "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/classcat": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "license": "MIT"
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -4174,120 +2730,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/clone-response": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4300,17 +2747,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
+      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -4319,211 +2757,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/compare-version": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
-      "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/compress-commons/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/compress-commons/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/compress-commons/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/concat-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-      "engines": [
-        "node >= 6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/config-file-ts": {
-      "version": "0.2.8-rc1",
-      "resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.8-rc1.tgz",
-      "integrity": "sha512-GtNECbVI82bT4RiDIzBSVuTKoSHufnU7Ce7/42bkWZJZFLjmDF2WBpVsvRkhKCfKBnTBb3qZrBwPpFBU/Myvhg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.3.12",
-        "typescript": "^5.4.3"
-      }
-    },
-    "node_modules/config-file-ts/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/config-file-ts/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/config-file-ts/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/config-file-ts/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/config-file-ts/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -4532,86 +2771,22 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "license": "MIT"
-    },
-    "node_modules/crc": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
-      "dev": true,
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "buffer": "^5.1.0"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "license": "Apache-2.0",
+        "cross-spawn": "^7.0.1"
+      },
       "bin": {
-        "crc32": "bin/crc32.njs"
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
       },
       "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/crc32-stream/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/crc32-stream/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -4645,7 +2820,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {
@@ -4757,6 +2931,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4770,33 +2945,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-response/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -4807,15 +2955,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4823,100 +2962,14 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dev": true,
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
       "license": "MIT",
       "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "webgl-constants": "^1.1.1"
       }
-    },
-    "node_modules/defer-to-connect": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -4925,48 +2978,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/dir-compare": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
-      "integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "^3.0.5",
-        "p-limit": "^3.1.0 "
-      }
-    },
-    "node_modules/dir-compare/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/dir-compare/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -4974,339 +2985,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dmg-builder": {
-      "version": "25.1.8",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-25.1.8.tgz",
-      "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "app-builder-lib": "25.1.8",
-        "builder-util": "25.1.7",
-        "builder-util-runtime": "9.2.10",
-        "fs-extra": "^10.1.0",
-        "iconv-lite": "^0.6.2",
-        "js-yaml": "^4.1.0"
-      },
-      "optionalDependencies": {
-        "dmg-license": "^1.0.11"
-      }
-    },
-    "node_modules/dmg-license": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
-      "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "@types/plist": "^3.0.1",
-        "@types/verror": "^1.10.3",
-        "ajv": "^6.10.0",
-        "crc": "^3.8.0",
-        "iconv-corefoundation": "^1.1.7",
-        "plist": "^3.0.4",
-        "smart-buffer": "^4.0.2",
-        "verror": "^1.10.0"
-      },
-      "bin": {
-        "dmg-license": "bin/dmg-license.js"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/dotenv-expand": {
-      "version": "11.0.7",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
-      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dotenv": "^16.4.5"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "license": "MIT"
-    },
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/electron": {
-      "version": "33.4.11",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-33.4.11.tgz",
-      "integrity": "sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^20.9.0",
-        "extract-zip": "^2.0.1"
-      },
-      "bin": {
-        "electron": "cli.js"
-      },
-      "engines": {
-        "node": ">= 12.20.55"
-      }
-    },
-    "node_modules/electron-builder": {
-      "version": "25.1.8",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-25.1.8.tgz",
-      "integrity": "sha512-poRgAtUHHOnlzZnc9PK4nzG53xh74wj2Jy7jkTrqZ0MWPoHGh1M2+C//hGeYdA+4K8w4yiVCNYoLXF7ySj2Wig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "app-builder-lib": "25.1.8",
-        "builder-util": "25.1.7",
-        "builder-util-runtime": "9.2.10",
-        "chalk": "^4.1.2",
-        "dmg-builder": "25.1.8",
-        "fs-extra": "^10.1.0",
-        "is-ci": "^3.0.0",
-        "lazy-val": "^1.0.5",
-        "simple-update-notifier": "2.0.0",
-        "yargs": "^17.6.2"
-      },
-      "bin": {
-        "electron-builder": "cli.js",
-        "install-app-deps": "install-app-deps.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows": {
-      "version": "25.1.8",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-25.1.8.tgz",
-      "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "app-builder-lib": "25.1.8",
-        "archiver": "^5.3.1",
-        "builder-util": "25.1.7",
-        "fs-extra": "^10.1.0"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows/node_modules/archiver": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
-      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "archiver-utils": "^2.1.0",
-        "async": "^3.2.4",
-        "buffer-crc32": "^0.2.1",
-        "readable-stream": "^3.6.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^2.2.0",
-        "zip-stream": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/electron-builder-squirrel-windows/node_modules/compress-commons": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
-      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.2",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows/node_modules/crc32-stream": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
-      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows/node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows/node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows/node_modules/zip-stream": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
-      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "archiver-utils": "^3.0.4",
-        "compress-commons": "^4.1.2",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows/node_modules/zip-stream/node_modules/archiver-utils": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
-      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.2.3",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/electron-publish": {
-      "version": "25.1.7",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-25.1.7.tgz",
-      "integrity": "sha512-+jbTkR9m39eDBMP4gfbqglDd6UvBC7RLh5Y0MhFSsc6UkGHj9Vj9TWobxevHYMMqmoujL11ZLjfPpMX+Pt6YEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/fs-extra": "^9.0.11",
-        "builder-util": "25.1.7",
-        "builder-util-runtime": "9.2.10",
-        "chalk": "^4.1.2",
-        "fs-extra": "^10.1.0",
-        "lazy-val": "^1.0.5",
-        "mime": "^2.5.2"
-      }
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.371",
@@ -5314,122 +2997,6 @@
       "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/electron-updater": {
-      "version": "6.8.9",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
-      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
-      "license": "MIT",
-      "dependencies": {
-        "builder-util-runtime": "9.7.0",
-        "fs-extra": "^10.1.0",
-        "js-yaml": "^4.1.0",
-        "lazy-val": "^1.0.5",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.isequal": "^4.5.0",
-        "semver": "~7.7.3",
-        "tiny-typed-emitter": "^2.1.0"
-      }
-    },
-    "node_modules/electron-updater/node_modules/builder-util-runtime": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
-      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/electron-updater/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/electron-vite": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/electron-vite/-/electron-vite-2.3.0.tgz",
-      "integrity": "sha512-lsN2FymgJlp4k6MrcsphGqZQ9fKRdJKasoaiwIrAewN1tapYI/KINLdfEL7n10LuF0pPSNf/IqjzZbB5VINctg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.24.7",
-        "@babel/plugin-transform-arrow-functions": "^7.24.7",
-        "cac": "^6.7.14",
-        "esbuild": "^0.21.5",
-        "magic-string": "^0.30.10",
-        "picocolors": "^1.0.1"
-      },
-      "bin": {
-        "electron-vite": "bin/electron-vite.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "peerDependencies": {
-        "@swc/core": "^1.0.0",
-        "vite": "^4.0.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/electron/node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -5442,23 +3009,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/es-errors": {
@@ -5477,43 +3027,6 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -5795,39 +3308,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/events-universal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.7.0"
-      }
     },
     "node_modules/execa": {
       "version": "8.0.1",
@@ -5866,15 +3352,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5885,55 +3362,11 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/exponential-backoff": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
-      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extsprintf": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
-      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5980,12 +3413,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
-    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5996,60 +3423,10 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
-    "node_modules/ffmpeg-static": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
-      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
-      "hasInstallScript": true,
-      "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "@derhuerst/http-basic": "^8.2.0",
-        "env-paths": "^2.2.0",
-        "https-proxy-agent": "^5.0.0",
-        "progress": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/ffmpeg-static/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/ffmpeg-static/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/ffprobe-static": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ffprobe-static/-/ffprobe-static-3.1.0.tgz",
-      "integrity": "sha512-Dvpa9uhVMOYivhHKWLGDoa512J751qN1WZAIO+Xw4L/mrUSPxS4DApzSUDbCFE/LUq2+xYnznEahTd63AqBSpA==",
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -6063,52 +3440,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
-    "node_modules/filelist": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
-      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -6162,70 +3493,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/fluent-ffmpeg": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.3.tgz",
-      "integrity": "sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "dependencies": {
-        "async": "^0.2.9",
-        "which": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fluent-ffmpeg/node_modules/async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
-    },
-    "node_modules/fluent-ffmpeg/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -6239,46 +3506,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
-    },
-    "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -6305,57 +3532,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gauge": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/gauge/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gauge/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/gauge/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -6364,16 +3540,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -6389,87 +3555,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
-    },
-    "node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -6481,55 +3566,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/global-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "es6-error": "^4.1.1",
-        "matcher": "^3.0.0",
-        "roarr": "^2.15.3",
-        "semver": "^7.3.2",
-        "serialize-error": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=10.0"
       }
     },
     "node_modules/globals": {
@@ -6545,68 +3581,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globalthis": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "define-properties": "^1.2.1",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/got": {
-      "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
-        "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -6617,56 +3596,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/hasown": {
       "version": "2.0.4",
@@ -6681,102 +3610,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/hosted-git-info/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/hosted-git-info/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/http-response-object": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
-      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^10.0.3"
-      }
-    },
-    "node_modules/http-response-object/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "license": "MIT"
-    },
-    "node_modules/http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
     },
     "node_modules/human-signals": {
       "version": "5.0.0",
@@ -6786,16 +3624,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/husky": {
@@ -6812,37 +3640,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
-      }
-    },
-    "node_modules/iconv-corefoundation": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
-      "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "cli-truncate": "^2.1.0",
-        "node-addon-api": "^1.6.3"
-      },
-      "engines": {
-        "node": "^8.11.2 || >=10"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -6875,6 +3672,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6902,57 +3705,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/infer-owner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
-    },
-    "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -6964,19 +3716,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-ci": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^3.2.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
       }
     },
     "node_modules/is-core-module": {
@@ -7005,15 +3744,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -7027,23 +3757,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-interactive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-lambda": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7053,6 +3766,12 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "3.0.0",
@@ -7067,38 +3786,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/isbinaryfile": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
-      "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/gjtorikian/"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -7109,7 +3796,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
       "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/react-reconciler": "^0.28.9"
@@ -7122,43 +3808,9 @@
       "version": "0.28.9",
       "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
       "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/jake": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
-      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.6",
-        "filelist": "^1.0.4",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/jiti": {
@@ -7182,6 +3834,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
       "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7220,19 +3873,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -7247,14 +3887,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -7266,18 +3898,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/keyv": {
@@ -7311,54 +3931,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/lazy-val": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
-      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "license": "MIT"
-    },
-    "node_modules/lazystream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
-      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.6.3"
-      }
-    },
-    "node_modules/lazystream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/lazystream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/lazystream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -7371,6 +3943,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -7563,88 +4144,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/lodash.escaperegexp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lodash.union": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -7719,16 +4224,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -7739,6 +4234,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7747,110 +4252,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/make-fetch-happen": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
-      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "agentkeepalive": "^4.2.1",
-        "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^2.0.3",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^7.0.0",
-        "ssri": "^9.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/matcher": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/merge-stream": {
@@ -7870,6 +4271,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "license": "MIT"
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -7882,42 +4298,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -7946,16 +4326,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -7972,149 +4342,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
-      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.1.6",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
-      }
-    },
-    "node_modules/minipass-flush": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
-      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -8148,137 +4380,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/negotiator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
-      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/node-api-version": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
-      "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      }
-    },
-    "node_modules/node-gyp": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
-      "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "exponential-backoff": "^3.1.1",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^10.0.3",
-        "nopt": "^6.0.0",
-        "npmlog": "^6.0.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": "^12.13 || ^14.13 || >=16"
-      }
-    },
-    "node_modules/node-gyp/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/node-gyp/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/node-gyp/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/node-gyp/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/node-releases": {
       "version": "2.0.47",
@@ -8290,42 +4397,14 @@
         "node": ">=18"
       }
     },
-    "node_modules/nopt": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
-      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "^1.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -8357,23 +4436,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/npmlog": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^3.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.3",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8392,26 +4454,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -8448,123 +4490,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/ora": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ora/node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ora/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ora/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ora/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/ora/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8597,28 +4522,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8632,11 +4535,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-cache-control": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8645,16 +4543,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -8673,37 +4561,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
-    "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -8720,27 +4577,6 @@
       "engines": {
         "node": ">= 14.16"
       }
-    },
-    "node_modules/pe-library": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
-      "integrity": "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/jet2jet"
-      }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8793,21 +4629,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/plist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
-      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.9.10",
-        "base64-js": "^1.5.1",
-        "xmlbuilder": "^15.1.1"
-      },
-      "engines": {
-        "node": ">=10.4.0"
       }
     },
     "node_modules/postcss": {
@@ -8973,32 +4794,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -9026,69 +4826,14 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/proc-log": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
-      "integrity": "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "dev": true,
-      "license": "MIT",
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/punycode": {
@@ -9121,43 +4866,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/react": {
       "version": "19.2.7",
@@ -9248,17 +4956,19 @@
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
-    "node_modules/read-binary-file-arch": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
-      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
-      "dev": true,
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
       "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
       },
-      "bin": {
-        "read-binary-file-arch": "cli.js"
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -9269,56 +4979,6 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -9334,32 +4994,13 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resedit": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
-      "integrity": "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pe-library": "^0.4.1"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/jet2jet"
       }
     },
     "node_modules/resolve": {
@@ -9384,13 +5025,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/resolve-alpn": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -9399,19 +5033,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/responselike": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lowercase-keys": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -9447,16 +5068,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -9474,95 +5085,6 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/roarr": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "detect-node": "^2.0.4",
-        "globalthis": "^1.0.1",
-        "json-stringify-safe": "^5.0.1",
-        "semver-compare": "^1.0.0",
-        "sprintf-js": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
     },
     "node_modules/rollup": {
       "version": "4.61.1",
@@ -9633,52 +5155,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/sanitize-filename": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
-      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
-      "dev": true,
-      "license": "WTFPL OR ISC",
-      "dependencies": {
-        "truncate-utf8-bytes": "^1.0.0"
-      }
-    },
-    "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=11.0.0"
-      }
-    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -9689,6 +5165,7 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
       "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9696,38 +5173,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/serialize-error": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "type-fest": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -9761,150 +5206,13 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/simple-update-notifier": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
-      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/slice-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.1.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
-      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/socks-proxy-agent/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -9917,38 +5225,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/ssri": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
-      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -9956,25 +5232,31 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
       "license": "MIT",
       "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
       }
     },
-    "node_modules/stat-mode": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
-      "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -9982,26 +5264,6 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/streamx": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
-      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
-      "license": "MIT",
-      "dependencies": {
-        "events-universal": "^1.0.0",
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -10013,81 +5275,11 @@
         "node": ">=0.6.19"
       }
     },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -10097,28 +5289,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/strip-final-newline": {
@@ -10180,19 +5350,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/sumchecker": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
-      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 8.0"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10217,6 +5374,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
       }
     },
     "node_modules/tailwindcss": {
@@ -10257,105 +5423,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-fs/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/teex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "license": "MIT",
-      "dependencies": {
-        "streamx": "^2.12.5"
-      }
-    },
-    "node_modules/temp-file": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
-      "integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-exit-hook": "^2.0.1",
-        "fs-extra": "^10.0.0"
-      }
-    },
-    "node_modules/text-decoder": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
-      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
-      }
-    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -10379,10 +5446,42 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/tiny-typed-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
-      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+    "node_modules/three": {
+      "version": "0.171.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.171.0.tgz",
+      "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.11.tgz",
+      "integrity": "sha512-3JyEFWGjFn7zHmoa9+zG1BmW7X2okcmAB+0Cnu9UFbVs/jCBnl2A8o065ZlXiw145K3eBM3uLuzrYXC0RK7eDg==",
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -10477,26 +5576,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tmp": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
-      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/tmp-promise": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
-      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tmp": "^0.2.0"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -10510,20 +5589,34 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/truncate-utf8-bytes": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
-      "dev": true,
-      "license": "WTFPL",
+    "node_modules/troika-three-text": {
+      "version": "0.52.5",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.5.tgz",
+      "integrity": "sha512-Ry3jRhic9pzcY4JduSvRRyDmVOSqEW19gT4vtK+aCiPNVcDlmkxvGG0YbFd36RTDq1wExOupXnvNF/j1oiHHDA==",
+      "license": "MIT",
       "dependencies": {
-        "utf8-byte-length": "^1.0.1"
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.5",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
       }
     },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+    "node_modules/troika-three-utils": {
+      "version": "0.52.5",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.5.tgz",
+      "integrity": "sha512-WsePbcX8RtfidRfsxK1eCZCjF81ZDzAKHH/evLs0hdV2wpoCb0vArGZHdzdOJrSS3k4zfdtbKDaBh8+phkrYnw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
@@ -10546,16 +5639,41 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
       "dependencies": {
-        "safe-buffer": "^5.0.1"
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
       },
       "engines": {
-        "node": "*"
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/type-check": {
@@ -10570,26 +5688,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -10633,43 +5731,8 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/unique-filename": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
-      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/unique-slug": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
-      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -10721,33 +5784,20 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/utf8-byte-length": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
-      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
-      "dev": true,
-      "license": "(WTFPL OR MIT)"
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
-    "node_modules/verror": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
-      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
-      "dev": true,
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
       "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">= 4"
       }
     },
     "node_modules/vite": {
@@ -10899,15 +5949,16 @@
         }
       }
     },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -10941,16 +5992,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -10977,45 +6018,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
@@ -11056,53 +6058,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
-      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -11126,45 +6081,6 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -11178,155 +6094,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/zip-stream/node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
-        "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/zip-stream/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/zip-stream/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/zip-stream/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/zip-stream/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/zip-stream/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zip-stream/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/zip-stream/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/zip-stream/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/zustand": {
       "version": "5.0.14",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
       "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inline-studio",
-  "version": "1.2.52",
+  "version": "1.2.53",
   "description": "An experimentation layer for visual artists: a node canvas for building generative pipelines, served by the Inline Core engine.",
   "author": "Inline Studio",
   "license": "GPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -21,14 +21,18 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
     "@xyflow/react": "^12.11.0",
-    "react-resizable-panels": "^2.1.9"
+    "react-resizable-panels": "^2.1.9",
+    "three": "^0.171.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
     "@types/node": "^22.10.5",
     "@types/react": "^19.0.4",
     "@types/react-dom": "^19.0.2",
+    "@types/three": "^0.171.0",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.18.0",

--- a/packages/frontend/pyproject.toml
+++ b/packages/frontend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inline-studio-frontend"
-version = "1.2.52"
+version = "1.2.53"
 description = "Prebuilt Inline Studio web UI (SPA), served by Inline Core. Mirrors comfyui-frontend-package."
 requires-python = ">=3.9"
 readme = "README.md"

--- a/src/renderer/lib/dnd.ts
+++ b/src/renderer/lib/dnd.ts
@@ -44,20 +44,34 @@ export function getFrameDragId(dt: DataTransfer): string | null {
  */
 export const OUTPUT_DND_TYPE = 'application/x-inlinestudio-output'
 
-export function setOutputDragPayload(dt: DataTransfer, frameId: string, takeId?: string): void {
-  dt.setData(OUTPUT_DND_TYPE, JSON.stringify({ frameId, takeId: takeId ?? null }))
+export function setOutputDragPayload(
+  dt: DataTransfer,
+  frameId: string,
+  takeId?: string,
+  filePath?: string,
+): void {
+  dt.setData(
+    OUTPUT_DND_TYPE,
+    JSON.stringify({ frameId, takeId: takeId ?? null, filePath: filePath ?? null }),
+  )
 }
 
-function parseOutputPayload(dt: DataTransfer): { frameId: string; takeId: string | null } | null {
+function parseOutputPayload(
+  dt: DataTransfer,
+): { frameId: string; takeId: string | null; filePath: string | null } | null {
   const raw = dt.getData(OUTPUT_DND_TYPE)
   if (!raw) return null
   try {
-    const p = JSON.parse(raw) as { frameId?: unknown; takeId?: unknown }
+    const p = JSON.parse(raw) as { frameId?: unknown; takeId?: unknown; filePath?: unknown }
     if (typeof p.frameId !== 'string') return null
-    return { frameId: p.frameId, takeId: typeof p.takeId === 'string' ? p.takeId : null }
+    return {
+      frameId: p.frameId,
+      takeId: typeof p.takeId === 'string' ? p.takeId : null,
+      filePath: typeof p.filePath === 'string' ? p.filePath : null,
+    }
   } catch {
     // Legacy payload: a bare frame id string.
-    return { frameId: raw, takeId: null }
+    return { frameId: raw, takeId: null, filePath: null }
   }
 }
 
@@ -69,6 +83,10 @@ export function getOutputDragId(dt: DataTransfer): string | null {
 /** Decode a dragged output's specific take id, or null (unknown / not an output drag). */
 export function getOutputTakeId(dt: DataTransfer): string | null {
   return parseOutputPayload(dt)?.takeId ?? null
+}
+
+export function getOutputFilePath(dt: DataTransfer): string | null {
+  return parseOutputPayload(dt)?.filePath ?? null
 }
 
 /**

--- a/src/renderer/lib/matchControlAspect.ts
+++ b/src/renderer/lib/matchControlAspect.ts
@@ -1,0 +1,66 @@
+/**
+ * Snap a generation node's Width/Height to the aspect of the control map wired into its Control
+ * input, so the pose/depth map isn't stretched or cropped at generation time. Resolves the wired
+ * source's image, reads its real pixel size, and writes a gen-friendly (multiple-of-64) size back.
+ */
+import { resolveMedia } from '@/lib/media'
+import { useAssetStore } from '../store/assetStore'
+import { useMoodboardStore } from '../store/moodboardStore'
+
+const targetHandleOf = (data: Record<string, unknown>): string | undefined =>
+  (data as { targetHandle?: string }).targetHandle
+
+/** The project-relative image path feeding a node's Control input, or null. */
+function controlSourcePath(nodeId: string): string | null {
+  const { items, connectors } = useMoodboardStore.getState()
+  const conn = connectors.find(
+    (c) => c.toItemId === nodeId && targetHandleOf(c.data) === 'control_image',
+  )
+  const src = conn ? items.find((i) => i.id === conn.fromItemId) : undefined
+  if (!src) return null
+  const assets = useAssetStore.getState().assets
+  const byId = (id?: string | null): string | undefined =>
+    id ? assets.find((a) => a.id === id)?.filePath : undefined
+
+  if (src.type === 'controlSpace') return byId(src.data.controlAssetId) ?? null
+  if (src.type === 'core') return src.data.core?.output?.filePath ?? null
+  if (src.type === 'loader') return byId((src.data.assetIds ?? [])[0]) ?? null
+  if (src.type === 'asset') return byId(src.assetId) ?? null
+  return null
+}
+
+function imageSize(url: string): Promise<{ w: number; h: number } | null> {
+  return new Promise((resolve) => {
+    const img = new Image()
+    img.onload = () => resolve({ w: img.naturalWidth, h: img.naturalHeight })
+    img.onerror = () => resolve(null)
+    img.src = url
+  })
+}
+
+/** A gen-friendly size at the source aspect: long edge ~1216, both edges a multiple of 64, clamped. */
+function fitGenSize(w: number, h: number): { width: number; height: number } {
+  const scale = 1216 / Math.max(w, h)
+  const snap = (n: number): number =>
+    Math.max(256, Math.min(2048, Math.round((n * scale) / 64) * 64))
+  return { width: snap(w), height: snap(h) }
+}
+
+/** Returns the new size on success (also written to the node), or null if nothing is wired/loadable. */
+export async function matchControlAspect(
+  nodeId: string,
+): Promise<{ width: number; height: number } | null> {
+  const path = controlSourcePath(nodeId)
+  if (!path) return null
+  const dims = await imageSize(resolveMedia(path))
+  if (!dims) return null
+  const size = fitGenSize(dims.w, dims.h)
+
+  const node = useMoodboardStore.getState().items.find((i) => i.id === nodeId)
+  const core = node?.data.core
+  if (!core) return null
+  await useMoodboardStore.getState().updateItem(nodeId, {
+    data: { ...node.data, core: { ...core, params: { ...core.params, ...size } } },
+  })
+  return size
+}

--- a/src/renderer/lib/pngRecipe.test.ts
+++ b/src/renderer/lib/pngRecipe.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { parseRecipeBytes, type Recipe } from './pngRecipe'
+
+const PNG_SIG = [137, 80, 78, 71, 13, 10, 26, 10]
+
+/** Build a minimal PNG: signature + one tEXt chunk (keyword\0text) + IEND. Enough to exercise the
+ * parser (CRC is not validated by the reader). */
+function pngWithText(keyword: string, text: string): Uint8Array {
+  const enc = (s: string): number[] => Array.from(s, (c) => c.charCodeAt(0))
+  const chunk = (type: string, data: number[]): number[] => {
+    const len = data.length
+    return [
+      (len >>> 24) & 255,
+      (len >>> 16) & 255,
+      (len >>> 8) & 255,
+      len & 255,
+      ...enc(type),
+      ...data,
+      0,
+      0,
+      0,
+      0, // zeroed CRC
+    ]
+  }
+  const textData = [...enc(keyword), 0, ...enc(text)]
+  return new Uint8Array([...PNG_SIG, ...chunk('tEXt', textData), ...chunk('IEND', [])])
+}
+
+describe('parseRecipeBytes', () => {
+  const recipe: Recipe = {
+    version: 1,
+    app: 'inline-studio',
+    target: 'z1',
+    prompt: 'a fox',
+    graph: { items: [{ id: 'z1', type: 'core', data: {}, x: 0, y: 0 }], connectors: [] },
+  }
+
+  it('extracts and parses the inline-studio recipe from a tEXt chunk', () => {
+    const png = pngWithText('inline-studio', JSON.stringify(recipe))
+    expect(parseRecipeBytes(png)).toEqual(recipe)
+  })
+
+  it('returns null for a PNG with no recipe chunk', () => {
+    expect(parseRecipeBytes(pngWithText('Comment', 'made elsewhere'))).toBeNull()
+  })
+
+  it('returns null when the chunk is not our app (foreign JSON)', () => {
+    const png = pngWithText('inline-studio', JSON.stringify({ app: 'other', prompt: 'x' }))
+    expect(parseRecipeBytes(png)).toBeNull()
+  })
+
+  it('returns null for non-PNG bytes and malformed JSON', () => {
+    expect(parseRecipeBytes(new Uint8Array([1, 2, 3]))).toBeNull()
+    expect(parseRecipeBytes(pngWithText('inline-studio', '{not json'))).toBeNull()
+  })
+})

--- a/src/renderer/lib/pngRecipe.ts
+++ b/src/renderer/lib/pngRecipe.ts
@@ -1,0 +1,104 @@
+/**
+ * Read the Inline recipe embedded in a PNG (a tEXt/iTXt chunk keyed `inline-studio`, written by Core
+ * at generation time). Lets a generated image - dropped from the Outputs tab or shared and imported
+ * from disk - rebuild the graph that made it. Pure byte parsing, no dependencies.
+ */
+
+/** One canvas node in a recipe (trimmed by Core to the rebuild-relevant fields). */
+export interface RecipeItem {
+  id: string
+  type: string
+  data: Record<string, unknown>
+  x: number
+  y: number
+  width?: number
+  height?: number
+  assetId?: string | null
+  frameId?: string | null
+}
+
+export interface RecipeConnector {
+  fromItemId: string
+  toItemId: string
+  data: Record<string, unknown>
+}
+
+export interface Recipe {
+  version?: number
+  app?: string
+  target?: string
+  coreType?: string
+  params?: Record<string, unknown>
+  prompt?: string
+  graph?: { items: RecipeItem[]; connectors: RecipeConnector[] }
+}
+
+const PNG_SIG = [137, 80, 78, 71, 13, 10, 26, 10]
+const KEYWORD = 'inline-studio'
+
+const latin1 = (b: Uint8Array, from: number, to: number): string => {
+  let s = ''
+  for (let i = from; i < to; i++) s += String.fromCharCode(b[i])
+  return s
+}
+
+/** The text of the `inline-studio` chunk, or null. Handles tEXt and uncompressed iTXt (Core writes
+ * ASCII-escaped JSON, so it lands as tEXt; iTXt is handled for robustness). */
+function extractRecipeText(buf: Uint8Array): string | null {
+  if (buf.length < 8 || PNG_SIG.some((b, i) => buf[i] !== b)) return null
+  const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
+  let off = 8
+  while (off + 8 <= buf.length) {
+    const len = dv.getUint32(off)
+    const type = latin1(buf, off + 4, off + 8)
+    const start = off + 8
+    const end = start + len
+    if (end > buf.length) break
+    if (type === 'tEXt') {
+      let z = start
+      while (z < end && buf[z] !== 0) z++
+      if (latin1(buf, start, z) === KEYWORD) return latin1(buf, z + 1, end)
+    } else if (type === 'iTXt') {
+      let z = start
+      while (z < end && buf[z] !== 0) z++
+      const key = latin1(buf, start, z)
+      z++ // keyword null
+      const compressed = buf[z] !== 0
+      z += 2 // compression flag + method
+      while (z < end && buf[z] !== 0) z++ // language tag
+      z++
+      while (z < end && buf[z] !== 0) z++ // translated keyword
+      z++
+      if (key === KEYWORD && !compressed) {
+        return new TextDecoder().decode(buf.subarray(z, end))
+      }
+    }
+    if (type === 'IEND') break
+    off = end + 4 // skip data + CRC
+  }
+  return null
+}
+
+/** Parse a recipe from raw PNG bytes, or null if none/invalid. */
+export function parseRecipeBytes(bytes: Uint8Array): Recipe | null {
+  const text = extractRecipeText(bytes)
+  if (!text) return null
+  try {
+    const parsed: unknown = JSON.parse(text)
+    if (parsed && typeof parsed === 'object' && (parsed as Recipe).app === 'inline-studio') {
+      return parsed as Recipe
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+/** Read a recipe from an image Blob/File (fetched output or a dropped PNG). */
+export async function readRecipeFromBlob(blob: Blob): Promise<Recipe | null> {
+  try {
+    return parseRecipeBytes(new Uint8Array(await blob.arrayBuffer()))
+  } catch {
+    return null
+  }
+}

--- a/src/renderer/lib/recipeGraph.ts
+++ b/src/renderer/lib/recipeGraph.ts
@@ -9,6 +9,7 @@
  */
 import type { MoodboardItem } from '@shared/types'
 import { useMoodboardStore } from '../store/moodboardStore'
+import { useGenerationStore } from '../store/generationStore'
 import type { Recipe } from './pngRecipe'
 
 interface Point {
@@ -64,8 +65,17 @@ export async function buildGraphFromRecipe(recipe: Recipe, drop: Point): Promise
       if (created && assetIds.length) {
         await store.updateItem(created.id, { data: { ...created.data, assetIds } }, false)
       }
+    } else if (it.type === 'frame') {
+      // A fal gen node (Core authored it with the model + params); rendered-frame image sources
+      // have no `fal` block and are skipped (their media doesn't transfer across a rebuild).
+      const fal = data.fal as { modelId?: string; params?: Record<string, unknown> } | undefined
+      if (!fal?.modelId) continue
+      created = await store.addGenNode(fal.modelId, x, y)
+      if (created?.frameId && fal.params) {
+        await useGenerationStore.getState().setParams(created.frameId, fal.params)
+      }
     } else {
-      continue // asset/frame/text/etc. need existing project media - skipped in v1
+      continue // asset/text/etc. need existing project media - skipped in v1
     }
 
     if (created) idMap.set(it.id, created.id)

--- a/src/renderer/lib/recipeGraph.ts
+++ b/src/renderer/lib/recipeGraph.ts
@@ -1,0 +1,83 @@
+/**
+ * Rebuild a canvas subgraph from a recipe (embedded in a generated image). Recreates the recipe's
+ * nodes with fresh ids, offset so the producing node lands at the drop point, then re-wires the
+ * links. Used by "Load graph" when an output image is dropped or a shared image is imported.
+ *
+ * v1 rebuilds Core-generation graphs (core / prompt / control-space / loader nodes). Media-bearing
+ * nodes (asset/frame) and cross-project media refs are skipped or left dangling - the structure,
+ * prompt and settings transfer; the actual input images don't (a follow-up embeds those bytes).
+ */
+import type { MoodboardItem } from '@shared/types'
+import { useMoodboardStore } from '../store/moodboardStore'
+import type { Recipe } from './pngRecipe'
+
+interface Point {
+  x: number
+  y: number
+}
+
+/** Rebuild the recipe onto the board near `drop`. Returns the number of nodes created. */
+export async function buildGraphFromRecipe(recipe: Recipe, drop: Point): Promise<number> {
+  const graph = recipe.graph
+  if (!graph?.items?.length) return 0
+  const store = useMoodboardStore.getState()
+
+  const target = graph.items.find((i) => i.id === recipe.target) ?? graph.items[0]
+  const offX = drop.x - target.x
+  const offY = drop.y - target.y
+  const idMap = new Map<string, string>()
+
+  for (const it of graph.items) {
+    const x = it.x + offX
+    const y = it.y + offY
+    const data = it.data ?? {}
+    let created: MoodboardItem | null = null
+
+    if (it.type === 'core') {
+      const core = data.core as { type?: string; params?: Record<string, unknown> } | undefined
+      if (!core?.type) continue
+      created = await store.addCoreNode(core.type, x, y)
+      if (created) {
+        await store.updateItem(
+          created.id,
+          { data: { ...created.data, core: { type: core.type, params: core.params ?? {} } } },
+          false,
+        )
+      }
+    } else if (it.type === 'prompt') {
+      created = await store.addPrompt(x, y)
+      if (created) {
+        await store.updateItem(
+          created.id,
+          { data: { ...created.data, promptText: String(data.promptText ?? '') } },
+          false,
+        )
+      }
+    } else if (it.type === 'controlSpace') {
+      created = await store.addControlSpace(x, y)
+      if (created && (data.controlAssetId || data.controlScene)) {
+        await store.updateItem(created.id, { data: { ...created.data, ...data } }, false)
+      }
+    } else if (it.type === 'loader') {
+      created = await store.addLoader(x, y)
+      const assetIds = (data.assetIds as string[] | undefined) ?? []
+      if (created && assetIds.length) {
+        await store.updateItem(created.id, { data: { ...created.data, assetIds } }, false)
+      }
+    } else {
+      continue // asset/frame/text/etc. need existing project media - skipped in v1
+    }
+
+    if (created) idMap.set(it.id, created.id)
+  }
+
+  for (const c of graph.connectors ?? []) {
+    const from = idMap.get(c.fromItemId)
+    const to = idMap.get(c.toItemId)
+    if (!from || !to) continue
+    const cd = c.data as { sourceHandle?: string; targetHandle?: string }
+    await store.connect(from, to, cd.sourceHandle ?? null, cd.targetHandle ?? null)
+  }
+
+  return idMap.size
+}

--- a/src/renderer/store/controlSpaceStore.ts
+++ b/src/renderer/store/controlSpaceStore.ts
@@ -1,0 +1,18 @@
+/**
+ * Which Control Space node's full-screen 3D editor is open. Mirrors `lightboxStore` (a tiny toggle
+ * store), so the editor is mounted once at app root and any Control Space node can open it by id.
+ */
+import { create } from 'zustand'
+
+interface ControlSpaceState {
+  /** The moodboard item id whose editor is open, or null when closed. */
+  editingItemId: string | null
+  open: (itemId: string) => void
+  close: () => void
+}
+
+export const useControlSpaceStore = create<ControlSpaceState>((set) => ({
+  editingItemId: null,
+  open: (itemId) => set({ editingItemId: itemId }),
+  close: () => set({ editingItemId: null }),
+}))

--- a/src/renderer/store/moodboardStore.ts
+++ b/src/renderer/store/moodboardStore.ts
@@ -46,6 +46,8 @@ interface MoodboardState {
   addEmptyFrame: (x: number, y: number) => Promise<MoodboardItem | null>
   /** Create a standalone "Load Assets" loader (a `type:'loader'` item holding asset refs). */
   addLoader: (x: number, y: number) => Promise<MoodboardItem | null>
+  /** Create a "Control Space" 3D pose-editor node (renders an OpenPose control map). */
+  addControlSpace: (x: number, y: number) => Promise<MoodboardItem | null>
   /** Append library assets to a loader's ordered asset list (deduped). */
   addLoaderAssets: (itemId: string, assetIds: string[]) => Promise<void>
   /** Remove one asset from a loader. */
@@ -83,6 +85,9 @@ interface MoodboardState {
   ) => Promise<MoodboardItem[]>
   /** `recordHistory: false` skips the undo snapshot - used by programmatic layout fits. */
   updateItem: (id: string, patch: MoodboardItemPatch, recordHistory?: boolean) => Promise<void>
+  /** Restore the text of the prompt node wired into `nodeId`'s `prompt` input (no-op if none). Used
+   * when switching a gen node's take history so the shown image's prompt is restored non-destructively. */
+  setConnectedPromptText: (nodeId: string, text: string) => Promise<void>
   deleteItem: (id: string) => Promise<void>
   /** Delete one render from a Core node's output history (and its file). */
   removeCoreOutput: (itemId: string, takeId: string) => Promise<void>
@@ -304,6 +309,22 @@ export const useMoodboardStore = create<MoodboardState>((set, get) => ({
     try {
       get().record()
       const res = await studio().moodboard.addLoader(x, y)
+      if (!res.ok) {
+        set({ error: res.error })
+        return null
+      }
+      set((s) => ({ items: [...s.items, res.value] }))
+      return res.value
+    } catch (e) {
+      set({ error: ipcErrorMessage(e) })
+      return null
+    }
+  },
+
+  addControlSpace: async (x, y) => {
+    try {
+      get().record()
+      const res = await studio().moodboard.addControlSpace(x, y)
       if (!res.ok) {
         set({ error: res.error })
         return null
@@ -635,6 +656,18 @@ export const useMoodboardStore = create<MoodboardState>((set, get) => ({
     } catch (e) {
       set({ error: ipcErrorMessage(e) })
     }
+  },
+
+  setConnectedPromptText: async (nodeId, text) => {
+    const { items, connectors } = get()
+    const conn = connectors.find(
+      (c) =>
+        c.toItemId === nodeId && (c.data as { targetHandle?: string }).targetHandle === 'prompt',
+    )
+    if (!conn) return
+    const promptNode = items.find((i) => i.id === conn.fromItemId && i.type === 'prompt')
+    if (!promptNode || promptNode.data.promptText === text) return
+    await get().updateItem(promptNode.id, { data: { ...promptNode.data, promptText: text } })
   },
 
   deleteItem: async (id) => {

--- a/src/renderer/views/ControlSpace/CharacterRig.tsx
+++ b/src/renderer/views/ControlSpace/CharacterRig.tsx
@@ -1,0 +1,96 @@
+/**
+ * One posable OpenPose character in the Control Space scene: joints as clickable spheres, bones as
+ * colored lines. When this character is active, its selected joint carries a TransformControls move
+ * gizmo; dragging it reports the new pose and pauses the orbit camera. Non-active characters render
+ * dimmed so the active one reads clearly.
+ */
+import { useEffect, useRef } from 'react'
+import { Line, TransformControls } from '@react-three/drei'
+import * as THREE from 'three'
+import { LIMBS, POSE_COLORS, type Vec3 } from './skeleton'
+
+export function CharacterRig({
+  joints,
+  gizmoJoint,
+  dim,
+  onPickJoint,
+  onMoveJoints,
+  setOrbit,
+}: {
+  joints: Vec3[]
+  /** Joint index to attach the move gizmo to, or null (only the active character passes a value). */
+  gizmoJoint: number | null
+  dim: boolean
+  onPickJoint: (j: number) => void
+  onMoveJoints: (joints: Vec3[]) => void
+  setOrbit: (on: boolean) => void
+}): React.JSX.Element {
+  const meshes = useRef<(THREE.Mesh | null)[]>([])
+  const transform = useRef<React.ComponentRef<typeof TransformControls>>(null)
+
+  useEffect(() => {
+    const controls = transform.current
+    if (!controls) return
+    const onDrag = (ev: { value: boolean }): void => setOrbit(!ev.value)
+    // three-stdlib's TransformControls fires 'dragging-changed', which isn't in Object3DEventMap.
+    const evt = controls as unknown as {
+      addEventListener(e: 'dragging-changed', cb: (ev: { value: boolean }) => void): void
+      removeEventListener(e: 'dragging-changed', cb: (ev: { value: boolean }) => void): void
+    }
+    evt.addEventListener('dragging-changed', onDrag)
+    return () => evt.removeEventListener('dragging-changed', onDrag)
+  }, [gizmoJoint, setOrbit])
+
+  const syncFromGizmo = (): void => {
+    if (gizmoJoint === null) return
+    const mesh = meshes.current[gizmoJoint]
+    if (!mesh) return
+    const next = joints.slice()
+    next[gizmoJoint] = [mesh.position.x, mesh.position.y, mesh.position.z]
+    onMoveJoints(next)
+  }
+
+  return (
+    <group>
+      {LIMBS.map(([a, b], i) => (
+        <Line
+          key={`limb-${i}`}
+          points={[joints[a], joints[b]] as [number, number, number][]}
+          color={POSE_COLORS[i % POSE_COLORS.length]}
+          lineWidth={dim ? 2 : 3}
+          transparent
+          opacity={dim ? 0.4 : 1}
+        />
+      ))}
+      {joints.map((j, i) => (
+        <mesh
+          key={`joint-${i}`}
+          ref={(m) => {
+            meshes.current[i] = m
+          }}
+          position={j as [number, number, number]}
+          onClick={(e) => {
+            e.stopPropagation()
+            onPickJoint(i)
+          }}
+        >
+          <sphereGeometry args={[0.03, 16, 16]} />
+          <meshBasicMaterial
+            color={gizmoJoint === i ? 'white' : POSE_COLORS[i % POSE_COLORS.length]}
+            transparent
+            opacity={dim ? 0.45 : 1}
+          />
+        </mesh>
+      ))}
+      {gizmoJoint !== null && meshes.current[gizmoJoint] && (
+        <TransformControls
+          ref={transform}
+          object={meshes.current[gizmoJoint] ?? undefined}
+          mode="translate"
+          size={0.6}
+          onObjectChange={syncFromGizmo}
+        />
+      )}
+    </group>
+  )
+}

--- a/src/renderer/views/ControlSpace/ControlSpaceEditor.tsx
+++ b/src/renderer/views/ControlSpace/ControlSpaceEditor.tsx
@@ -60,33 +60,50 @@ function CameraRig({ fov }: { fov: number }): null {
 
 /** Project every character's 3D joints with the live camera and draw them onto one OpenPose control
  * image (a black canvas), then hand back a PNG blob. Fires when `nonce` changes. */
+/** Output size for a control map at aspect (w/h), long edge 768. */
+function outputSize(aspect: number): { w: number; h: number } {
+  return aspect >= 1
+    ? { w: 768, h: Math.max(1, Math.round(768 / aspect)) }
+    : { w: Math.max(1, Math.round(768 * aspect)), h: 768 }
+}
+
+/** A copy of the live camera reprojected at the OUTPUT aspect, so the control map isn't stretched
+ * when the generator resizes it to its own (e.g. square) resolution - the pose-distortion fix. */
+function outputCamera(camera: THREE.Camera, aspect: number): THREE.PerspectiveCamera {
+  const cam = (camera as THREE.PerspectiveCamera).clone()
+  cam.aspect = aspect
+  cam.updateProjectionMatrix()
+  return cam
+}
+
 function PoseRenderer({
   characters,
   nonce,
   enabled,
+  aspect,
   onRendered,
 }: {
   characters: Vec3[][]
   nonce: number
   enabled: boolean
+  aspect: number
   onRendered: (blob: Blob) => void
 }): null {
   const camera = useThree((s) => s.camera)
-  const size = useThree((s) => s.size)
 
   useEffect(() => {
     if (nonce === 0 || !enabled) return
-    const w = 768
-    const h = Math.max(1, Math.round((768 * size.height) / size.width))
+    const { w, h } = outputSize(aspect)
     const canvas = document.createElement('canvas')
     canvas.width = w
     canvas.height = h
     const ctx = canvas.getContext('2d')
     if (!ctx) return
+    const cam = outputCamera(camera, aspect)
     const v = new THREE.Vector3()
     const project = (joints: Vec3[]): Point2D[] =>
       joints.map(([x, y, z]) => {
-        v.set(x, y, z).project(camera)
+        v.set(x, y, z).project(cam)
         return { x: (v.x * 0.5 + 0.5) * w, y: (1 - (v.y * 0.5 + 0.5)) * h, visible: v.z < 1 }
       })
     // First character clears to black; the rest overlay onto the same map.
@@ -101,6 +118,14 @@ function PoseRenderer({
 
 const btn =
   'rounded-md border border-border px-2 py-1 text-xs text-zinc-200 hover:bg-panel disabled:opacity-50'
+
+// Output aspect presets (w/h). Match the pick to the gen node's width/height.
+const ASPECTS: { label: string; value: number }[] = [
+  { label: '1:1', value: 1 },
+  { label: '3:4', value: 3 / 4 },
+  { label: '4:3', value: 4 / 3 },
+  { label: '16:9', value: 16 / 9 },
+]
 
 function RotateIcon({ cw = false }: { cw?: boolean }): React.JSX.Element {
   return (
@@ -129,6 +154,9 @@ export default function ControlSpaceEditor(): React.JSX.Element | null {
   const [selJoint, setSelJoint] = useState<number | null>(null)
   const [fov, setFov] = useState(45)
   const [mapKind, setMapKind] = useState<'pose' | 'depth'>('pose')
+  // Output aspect (w/h) of the control map. It must match the gen node's resolution or the generator
+  // stretches the map and the pose comes out distorted; default square = Z-Image's 1024x1024 default.
+  const [aspect, setAspect] = useState(1)
   const [orbit, setOrbit] = useState(true)
   const [nonce, setNonce] = useState(0)
   const [preview, setPreview] = useState<string | null>(null)
@@ -161,6 +189,7 @@ export default function ControlSpaceEditor(): React.JSX.Element | null {
     )
     setFov(scene?.fov ?? 45)
     setMapKind(scene?.output ?? 'pose')
+    setAspect(scene?.aspect ?? 1)
     setActive(0)
     setSelJoint(null)
     setPreview((prev) => {
@@ -274,6 +303,7 @@ export default function ControlSpaceEditor(): React.JSX.Element | null {
         fov,
         camera: cameraPose.current,
         output: mapKind,
+        aspect,
       }
       await useMoodboardStore.getState().updateItem(editingItemId, {
         data: { ...(item?.data ?? {}), controlAssetId: asset.id, controlScene: scene },
@@ -380,6 +410,26 @@ export default function ControlSpaceEditor(): React.JSX.Element | null {
             ))}
           </div>
 
+          <div
+            className="flex items-center overflow-hidden rounded-md border border-border"
+            title="Output aspect - match it to the gen node's width/height so the pose isn't stretched"
+          >
+            {ASPECTS.map((a) => (
+              <button
+                key={a.label}
+                onClick={() => setAspect(a.value)}
+                disabled={busy}
+                className={`px-2 py-1 text-xs disabled:opacity-50 ${
+                  Math.abs(aspect - a.value) < 0.001
+                    ? 'bg-panel text-white'
+                    : 'text-zinc-300 hover:bg-panel/60'
+                }`}
+              >
+                {a.label}
+              </button>
+            ))}
+          </div>
+
           <label className="flex items-center gap-1.5 text-xs text-zinc-400">
             FOV
             <input
@@ -443,15 +493,26 @@ export default function ControlSpaceEditor(): React.JSX.Element | null {
               characters={characters.map((c) => c.joints)}
               nonce={nonce}
               enabled={mapKind === 'pose'}
+              aspect={aspect}
               onRendered={handleRendered}
             />
             <DepthRenderer
               characters={characters.map((c) => c.joints)}
               nonce={nonce}
               enabled={mapKind === 'depth'}
+              aspect={aspect}
               onRendered={handleRendered}
             />
           </Canvas>
+
+          {/* Safe-frame guide: the region captured at the chosen output aspect (shares the camera's
+              vertical view). Pose only what's inside it. */}
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div
+              className="h-full border border-dashed border-white/25 shadow-[0_0_0_9999px_rgba(0,0,0,0.35)]"
+              style={{ aspectRatio: String(aspect) }}
+            />
+          </div>
 
           {preview && (
             <div className="absolute bottom-3 right-3 w-40 overflow-hidden rounded-md border border-border bg-black shadow-lg">

--- a/src/renderer/views/ControlSpace/ControlSpaceEditor.tsx
+++ b/src/renderer/views/ControlSpace/ControlSpaceEditor.tsx
@@ -1,0 +1,474 @@
+/**
+ * Control Space: a 3D pose editor in a modal dialog. Pose one or more OpenPose characters, orbit and
+ * frame the camera, then render the scene to an OpenPose control image that drives a ControlNet
+ * generation. Mounted once at app root (like MediaLightbox); opened per node via `controlSpaceStore`.
+ *
+ * Depth output and free-fly camera modes build on this same scene (see docs/controlnet-control-space).
+ */
+import { createPortal } from 'react-dom'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Canvas, useThree } from '@react-three/fiber'
+import { Grid, OrbitControls } from '@react-three/drei'
+import * as THREE from 'three'
+import { useControlSpaceStore } from '../../store/controlSpaceStore'
+import { useMoodboardStore } from '../../store/moodboardStore'
+import { useAssetStore } from '../../store/assetStore'
+import { importFilesToLibrary } from '../../lib/importFiles'
+import { CharacterRig } from './CharacterRig'
+import { DepthRenderer } from './DepthRenderer'
+import {
+  centroid,
+  drawOpenPose,
+  PRESETS,
+  rotatePoseY,
+  STANDING,
+  translatePose,
+  type Point2D,
+  type Vec3,
+} from './skeleton'
+
+interface Character {
+  id: string
+  joints: Vec3[]
+}
+
+const rest = (): Vec3[] => STANDING.map((v) => [...v] as Vec3)
+
+/** Read the persisted scene back into characters, tolerating the legacy single-`joints` shape. */
+function loadCharacters(scene: {
+  joints?: [number, number, number][]
+  characters?: { joints: [number, number, number][] }[]
+}): Vec3[][] {
+  if (scene.characters?.length)
+    return scene.characters.map((c) => c.joints.map((v) => [...v] as Vec3))
+  if (scene.joints?.length) return [scene.joints.map((v) => [...v] as Vec3)]
+  return [rest()]
+}
+
+/** Keep the perspective camera's FOV in sync with the slider. */
+function CameraRig({ fov }: { fov: number }): null {
+  const camera = useThree((s) => s.camera)
+  useEffect(() => {
+    const cam = camera as THREE.PerspectiveCamera
+    if (cam.isPerspectiveCamera) {
+      cam.fov = fov
+      cam.updateProjectionMatrix()
+    }
+  }, [camera, fov])
+  return null
+}
+
+/** Project every character's 3D joints with the live camera and draw them onto one OpenPose control
+ * image (a black canvas), then hand back a PNG blob. Fires when `nonce` changes. */
+function PoseRenderer({
+  characters,
+  nonce,
+  enabled,
+  onRendered,
+}: {
+  characters: Vec3[][]
+  nonce: number
+  enabled: boolean
+  onRendered: (blob: Blob) => void
+}): null {
+  const camera = useThree((s) => s.camera)
+  const size = useThree((s) => s.size)
+
+  useEffect(() => {
+    if (nonce === 0 || !enabled) return
+    const w = 768
+    const h = Math.max(1, Math.round((768 * size.height) / size.width))
+    const canvas = document.createElement('canvas')
+    canvas.width = w
+    canvas.height = h
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    const v = new THREE.Vector3()
+    const project = (joints: Vec3[]): Point2D[] =>
+      joints.map(([x, y, z]) => {
+        v.set(x, y, z).project(camera)
+        return { x: (v.x * 0.5 + 0.5) * w, y: (1 - (v.y * 0.5 + 0.5)) * h, visible: v.z < 1 }
+      })
+    // First character clears to black; the rest overlay onto the same map.
+    characters.forEach((joints, i) => drawOpenPose(ctx, project(joints), w, h, i === 0))
+    canvas.toBlob((blob) => {
+      if (blob) onRendered(blob)
+    }, 'image/png')
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nonce])
+  return null
+}
+
+const btn =
+  'rounded-md border border-border px-2 py-1 text-xs text-zinc-200 hover:bg-panel disabled:opacity-50'
+
+function RotateIcon({ cw = false }: { cw?: boolean }): React.JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-3.5 w-3.5"
+      style={cw ? { transform: 'scaleX(-1)' } : undefined}
+    >
+      <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+      <path d="M3 3v5h5" />
+    </svg>
+  )
+}
+
+// Default export so the mount can `React.lazy` this (three.js stays out of the initial bundle).
+export default function ControlSpaceEditor(): React.JSX.Element | null {
+  const editingItemId = useControlSpaceStore((s) => s.editingItemId)
+  const close = useControlSpaceStore((s) => s.close)
+  const [characters, setCharacters] = useState<Character[]>(() => [{ id: 'c0', joints: rest() }])
+  const [active, setActive] = useState(0)
+  const [selJoint, setSelJoint] = useState<number | null>(null)
+  const [fov, setFov] = useState(45)
+  const [mapKind, setMapKind] = useState<'pose' | 'depth'>('pose')
+  const [orbit, setOrbit] = useState(true)
+  const [nonce, setNonce] = useState(0)
+  const [preview, setPreview] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const idSeq = useRef(1)
+  // 'save' renders then persists the map to the node; 'preview' only refreshes the corner thumbnail.
+  const renderMode = useRef<'preview' | 'save'>('preview')
+
+  // The editor remounts each open (the mount gate unmounts it on close), so the saved scene read here
+  // seeds the initial camera; live changes are captured back into cameraPose on every orbit change.
+  const savedScene = useMemo(
+    () => useMoodboardStore.getState().items.find((i) => i.id === editingItemId)?.data.controlScene,
+    [editingItemId],
+  )
+  const initialCamPos = (savedScene?.camera?.position ?? [0, 1.2, 3.2]) as [number, number, number]
+  const initialTarget = (savedScene?.camera?.target ?? [0, 0.9, 0]) as [number, number, number]
+  const orbitRef = useRef<React.ComponentRef<typeof OrbitControls>>(null)
+  const cameraPose = useRef({ position: initialCamPos, target: initialTarget })
+
+  const open = editingItemId !== null
+  useEffect(() => {
+    if (!open) return
+    const scene = savedScene
+    idSeq.current = 1
+    setCharacters(
+      (scene ? loadCharacters(scene) : [rest()]).map((joints) => ({
+        id: `c${idSeq.current++}`,
+        joints,
+      })),
+    )
+    setFov(scene?.fov ?? 45)
+    setMapKind(scene?.output ?? 'pose')
+    setActive(0)
+    setSelJoint(null)
+    setPreview((prev) => {
+      if (prev) URL.revokeObjectURL(prev)
+      return null
+    })
+  }, [open, editingItemId, savedScene])
+
+  // Arrow keys nudge the selected joint: Left/Right = X, Up/Down = Y, Shift+Up/Down = Z (depth).
+  useEffect(() => {
+    if (!open) return
+    const step = 0.02
+    const onKey = (e: KeyboardEvent): void => {
+      if (selJoint === null || e.target instanceof HTMLInputElement) return
+      let dx = 0
+      let dy = 0
+      let dz = 0
+      if (e.key === 'ArrowLeft') dx = -step
+      else if (e.key === 'ArrowRight') dx = step
+      else if (e.key === 'ArrowUp') {
+        if (e.shiftKey) dz = -step
+        else dy = step
+      } else if (e.key === 'ArrowDown') {
+        if (e.shiftKey) dz = step
+        else dy = -step
+      } else return
+      e.preventDefault()
+      setCharacters((cs) =>
+        cs.map((c, i) => {
+          if (i !== active) return c
+          const joints = c.joints.slice()
+          const [x, y, z] = joints[selJoint]
+          joints[selJoint] = [x + dx, y + dy, z + dz]
+          return { ...c, joints }
+        }),
+      )
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, active, selJoint])
+
+  const captureCam = (): void => {
+    const c = orbitRef.current
+    if (!c) return
+    const cam = c.object
+    cameraPose.current = {
+      position: [cam.position.x, cam.position.y, cam.position.z],
+      target: [c.target.x, c.target.y, c.target.z],
+    }
+  }
+  const resetView = (): void => {
+    const c = orbitRef.current
+    if (!c) return
+    c.object.position.set(0, 1.2, 3.2)
+    c.target.set(0, 0.9, 0)
+    c.update()
+  }
+  const frameActive = (): void => {
+    const c = orbitRef.current
+    const char = characters[active] ?? characters[0]
+    if (!c || !char) return
+    const [cx, cy, cz] = centroid(char.joints)
+    c.object.position.set(cx, cy, cz + 3)
+    c.target.set(cx, cy, cz)
+    c.update()
+  }
+
+  const activeChar = characters[active] ?? characters[0]
+  const setActiveJoints = (joints: Vec3[]): void =>
+    setCharacters((cs) => cs.map((c, i) => (i === active ? { ...c, joints } : c)))
+
+  const addCharacter = (): void => {
+    const placed = translatePose(rest(), characters.length * 0.8, 0, 0)
+    setCharacters((cs) => [...cs, { id: `c${idSeq.current++}`, joints: placed }])
+    setActive(characters.length)
+    setSelJoint(null)
+  }
+  const removeActive = (): void => {
+    if (characters.length <= 1) return
+    setCharacters((cs) => cs.filter((_, i) => i !== active))
+    setActive((a) => Math.max(0, a - 1))
+    setSelJoint(null)
+  }
+  const turn = (angle: number): void => setActiveJoints(rotatePoseY(activeChar.joints, angle))
+  const applyPreset = (name: string): void => {
+    // Keep the character where it stands: align the preset's centroid to the current one (x/z only).
+    const [cx, , cz] = centroid(activeChar.joints)
+    const [px, , pz] = centroid(PRESETS[name])
+    setActiveJoints(translatePose(PRESETS[name], cx - px, 0, cz - pz))
+  }
+
+  const handleRendered = async (blob: Blob): Promise<void> => {
+    const url = URL.createObjectURL(blob)
+    setPreview((prev) => {
+      if (prev) URL.revokeObjectURL(prev)
+      return url
+    })
+    if (renderMode.current !== 'save' || !editingItemId) return
+    renderMode.current = 'preview'
+    setBusy(true)
+    try {
+      const file = new File([blob], `control-space-${mapKind}.png`, { type: 'image/png' })
+      const [asset] = await importFilesToLibrary([file], null)
+      if (!asset) return
+      await useAssetStore.getState().load()
+      const item = useMoodboardStore.getState().items.find((i) => i.id === editingItemId)
+      const scene = {
+        characters: characters.map((c) => ({
+          joints: c.joints.map((v) => [v[0], v[1], v[2]] as [number, number, number]),
+        })),
+        fov,
+        camera: cameraPose.current,
+        output: mapKind,
+      }
+      await useMoodboardStore.getState().updateItem(editingItemId, {
+        data: { ...(item?.data ?? {}), controlAssetId: asset.id, controlScene: scene },
+      })
+      close()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const render = (mode: 'preview' | 'save'): void => {
+    renderMode.current = mode
+    setNonce((n) => n + 1)
+  }
+
+  const presetNames = useMemo(() => Object.keys(PRESETS), [])
+  if (!open) return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[150] flex items-center justify-center bg-black/70 p-6"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget && !busy) close()
+      }}
+    >
+      <div className="flex h-[min(760px,88vh)] w-[min(1100px,92vw)] flex-col overflow-hidden rounded-xl border border-border bg-surface shadow-2xl">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-border px-4 py-2">
+          <span className="text-sm font-medium text-zinc-200">Control Space</span>
+
+          <div className="flex items-center gap-1">
+            <button onClick={addCharacter} disabled={busy} className={btn}>
+              Add character
+            </button>
+            <span className="px-1 text-xs text-zinc-400">
+              {active + 1}/{characters.length}
+            </span>
+            <button onClick={() => turn(Math.PI)} disabled={busy} className={btn}>
+              Turn around
+            </button>
+            <button
+              onClick={() => turn(-Math.PI / 4)}
+              disabled={busy}
+              className={btn}
+              title="Rotate left"
+            >
+              <RotateIcon />
+            </button>
+            <button
+              onClick={() => turn(Math.PI / 4)}
+              disabled={busy}
+              className={btn}
+              title="Rotate right"
+            >
+              <RotateIcon cw />
+            </button>
+            <button
+              onClick={removeActive}
+              disabled={busy || characters.length <= 1}
+              className={btn}
+            >
+              Remove
+            </button>
+          </div>
+
+          <div className="flex items-center gap-1">
+            {presetNames.map((name) => (
+              <button
+                key={name}
+                onClick={() => applyPreset(name)}
+                disabled={busy}
+                className={`${btn} capitalize`}
+              >
+                {name}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-1">
+            <button
+              onClick={frameActive}
+              disabled={busy}
+              className={btn}
+              title="Frame the active character"
+            >
+              Frame
+            </button>
+            <button onClick={resetView} disabled={busy} className={btn} title="Reset the camera">
+              Reset view
+            </button>
+          </div>
+
+          <div className="flex items-center overflow-hidden rounded-md border border-border">
+            {(['pose', 'depth'] as const).map((k) => (
+              <button
+                key={k}
+                onClick={() => setMapKind(k)}
+                disabled={busy}
+                className={`px-2 py-1 text-xs capitalize disabled:opacity-50 ${
+                  mapKind === k ? 'bg-panel text-white' : 'text-zinc-300 hover:bg-panel/60'
+                }`}
+              >
+                {k}
+              </button>
+            ))}
+          </div>
+
+          <label className="flex items-center gap-1.5 text-xs text-zinc-400">
+            FOV
+            <input
+              type="range"
+              min={20}
+              max={90}
+              value={fov}
+              onChange={(e) => setFov(Number(e.target.value))}
+              className="h-1 w-24 accent-emerald-500"
+            />
+          </label>
+
+          <div className="ml-auto flex items-center gap-1">
+            <button onClick={() => render('preview')} disabled={busy} className={btn}>
+              Preview map
+            </button>
+            <button
+              onClick={() => render('save')}
+              disabled={busy}
+              className="rounded-md border border-emerald-700 bg-emerald-600/20 px-2.5 py-1 text-xs text-emerald-200 hover:bg-emerald-600/30 disabled:opacity-50"
+            >
+              {busy ? 'Saving…' : 'Save to node'}
+            </button>
+            <button onClick={close} disabled={busy} className={btn}>
+              Close
+            </button>
+          </div>
+        </div>
+
+        <div className="relative min-h-0 flex-1 bg-black">
+          <Canvas camera={{ position: initialCamPos, fov }} className="h-full w-full">
+            <color attach="background" args={['#0a0a0a']} />
+            <ambientLight intensity={0.8} />
+            <directionalLight position={[3, 5, 2]} intensity={0.6} />
+            <Grid args={[10, 10]} cellColor="#333" sectionColor="#444" infiniteGrid />
+            {characters.map((c, idx) => (
+              <CharacterRig
+                key={c.id}
+                joints={c.joints}
+                gizmoJoint={idx === active ? selJoint : null}
+                dim={idx !== active}
+                onPickJoint={(j) => {
+                  setActive(idx)
+                  setSelJoint(j)
+                }}
+                onMoveJoints={(joints) =>
+                  setCharacters((cs) => cs.map((cc, i) => (i === idx ? { ...cc, joints } : cc)))
+                }
+                setOrbit={setOrbit}
+              />
+            ))}
+            <OrbitControls
+              ref={orbitRef}
+              makeDefault
+              enabled={orbit}
+              target={initialTarget}
+              onChange={captureCam}
+            />
+            <CameraRig fov={fov} />
+            <PoseRenderer
+              characters={characters.map((c) => c.joints)}
+              nonce={nonce}
+              enabled={mapKind === 'pose'}
+              onRendered={handleRendered}
+            />
+            <DepthRenderer
+              characters={characters.map((c) => c.joints)}
+              nonce={nonce}
+              enabled={mapKind === 'depth'}
+              onRendered={handleRendered}
+            />
+          </Canvas>
+
+          {preview && (
+            <div className="absolute bottom-3 right-3 w-40 overflow-hidden rounded-md border border-border bg-black shadow-lg">
+              <div className="border-b border-border px-2 py-1 text-[10px] capitalize text-zinc-400">
+                {mapKind} control map
+              </div>
+              <img src={preview} alt={`${mapKind} control map`} className="block h-auto w-full" />
+            </div>
+          )}
+
+          <div className="pointer-events-none absolute left-3 top-3 rounded-md bg-black/60 px-2.5 py-1.5 text-[11px] text-zinc-300">
+            Click a joint to select, drag the gizmo or use arrow keys (Shift = depth) to pose.
+            Orbit/zoom with the mouse.
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/renderer/views/ControlSpace/ControlSpaceEditor.tsx
+++ b/src/renderer/views/ControlSpace/ControlSpaceEditor.tsx
@@ -6,7 +6,7 @@
  * Depth output and free-fly camera modes build on this same scene (see docs/controlnet-control-space).
  */
 import { createPortal } from 'react-dom'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Canvas, useThree } from '@react-three/fiber'
 import { Grid, OrbitControls } from '@react-three/drei'
 import * as THREE from 'three'
@@ -19,10 +19,14 @@ import { DepthRenderer } from './DepthRenderer'
 import {
   centroid,
   drawOpenPose,
+  faceOcclusion,
+  facingLabel,
+  facingPromptHint,
   PRESETS,
   rotatePoseY,
   STANDING,
   translatePose,
+  type Facing,
   type Point2D,
   type Vec3,
 } from './skeleton'
@@ -101,11 +105,20 @@ function PoseRenderer({
     if (!ctx) return
     const cam = outputCamera(camera, aspect)
     const v = new THREE.Vector3()
-    const project = (joints: Vec3[]): Point2D[] =>
-      joints.map(([x, y, z]) => {
+    const camPos: Vec3 = [cam.position.x, cam.position.y, cam.position.z]
+    const project = (joints: Vec3[]): Point2D[] => {
+      // Drop the face keypoints the head turns away from the camera, so a back-facing pose reads as
+      // back-facing to the ControlNet (not just a mirrored front).
+      const cull = faceOcclusion(joints, camPos)
+      return joints.map(([x, y, z], idx) => {
         v.set(x, y, z).project(cam)
-        return { x: (v.x * 0.5 + 0.5) * w, y: (1 - (v.y * 0.5 + 0.5)) * h, visible: v.z < 1 }
+        return {
+          x: (v.x * 0.5 + 0.5) * w,
+          y: (1 - (v.y * 0.5 + 0.5)) * h,
+          visible: v.z < 1 && !cull[idx],
+        }
       })
+    }
     // First character clears to black; the rest overlay onto the same map.
     characters.forEach((joints, i) => drawOpenPose(ctx, project(joints), w, h, i === 0))
     canvas.toBlob((blob) => {
@@ -118,6 +131,13 @@ function PoseRenderer({
 
 const btn =
   'rounded-md border border-border px-2 py-1 text-xs text-zinc-200 hover:bg-panel disabled:opacity-50'
+
+const FACING_TEXT: Record<Facing, string> = {
+  front: 'facing the camera',
+  'three-quarter': 'three-quarter view',
+  profile: 'side profile',
+  back: 'facing away (back view)',
+}
 
 // Output aspect presets (w/h). Match the pick to the gen node's width/height.
 const ASPECTS: { label: string; value: number }[] = [
@@ -161,6 +181,8 @@ export default function ControlSpaceEditor(): React.JSX.Element | null {
   const [nonce, setNonce] = useState(0)
   const [preview, setPreview] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
+  const [facings, setFacings] = useState<(Facing | null)[]>([])
+  const [applyHint, setApplyHint] = useState(true)
   const idSeq = useRef(1)
   // 'save' renders then persists the map to the node; 'preview' only refreshes the corner thumbnail.
   const renderMode = useRef<'preview' | 'save'>('preview')
@@ -190,6 +212,7 @@ export default function ControlSpaceEditor(): React.JSX.Element | null {
     setFov(scene?.fov ?? 45)
     setMapKind(scene?.output ?? 'pose')
     setAspect(scene?.aspect ?? 1)
+    setApplyHint(scene?.applyPromptHint ?? true)
     setActive(0)
     setSelJoint(null)
     setPreview((prev) => {
@@ -231,6 +254,18 @@ export default function ControlSpaceEditor(): React.JSX.Element | null {
     return () => window.removeEventListener('keydown', onKey)
   }, [open, active, selJoint])
 
+  // Facing depends on both the pose and the camera, so it is refreshed from each. State only changes
+  // when a label actually flips, so orbiting (which fires per frame) doesn't re-render the editor.
+  const refreshFacing = useCallback((chars: readonly Vec3[][]): void => {
+    const next = chars.map((joints) => facingLabel(joints, cameraPose.current.position))
+    setFacings((prev) =>
+      prev.length === next.length && prev.every((f, i) => f === next[i]) ? prev : next,
+    )
+  }, [])
+  useEffect(() => {
+    refreshFacing(characters.map((c) => c.joints))
+  }, [characters, refreshFacing])
+
   const captureCam = (): void => {
     const c = orbitRef.current
     if (!c) return
@@ -239,6 +274,7 @@ export default function ControlSpaceEditor(): React.JSX.Element | null {
       position: [cam.position.x, cam.position.y, cam.position.z],
       target: [c.target.x, c.target.y, c.target.z],
     }
+    refreshFacing(characters.map((c2) => c2.joints))
   }
   const resetView = (): void => {
     const c = orbitRef.current
@@ -304,6 +340,9 @@ export default function ControlSpaceEditor(): React.JSX.Element | null {
         camera: cameraPose.current,
         output: mapKind,
         aspect,
+        facing: facings,
+        promptHint: hint,
+        applyPromptHint: applyHint,
       }
       await useMoodboardStore.getState().updateItem(editingItemId, {
         data: { ...(item?.data ?? {}), controlAssetId: asset.id, controlScene: scene },
@@ -320,6 +359,8 @@ export default function ControlSpaceEditor(): React.JSX.Element | null {
   }
 
   const presetNames = useMemo(() => Object.keys(PRESETS), [])
+  const hint = applyHint ? facingPromptHint(facings) : null
+  const activeFacing = facings[active] ?? null
   if (!open) return null
 
   return createPortal(
@@ -526,6 +567,41 @@ export default function ControlSpaceEditor(): React.JSX.Element | null {
           <div className="pointer-events-none absolute left-3 top-3 rounded-md bg-black/60 px-2.5 py-1.5 text-[11px] text-zinc-300">
             Click a joint to select, drag the gizmo or use arrow keys (Shift = depth) to pose.
             Orbit/zoom with the mouse.
+          </div>
+
+          {/* Which way the camera sees the character, and the prompt text that facing adds. */}
+          <div className="absolute right-3 top-3 max-w-[15rem] rounded-md bg-black/60 px-2.5 py-1.5 text-[11px]">
+            <div className="flex items-center gap-1.5">
+              <span className="text-zinc-400">Character {active + 1}:</span>
+              <span
+                className={
+                  activeFacing === 'back'
+                    ? 'font-medium text-amber-300'
+                    : 'font-medium text-zinc-200'
+                }
+              >
+                {activeFacing ? FACING_TEXT[activeFacing] : 'unknown'}
+              </span>
+            </div>
+            <label className="mt-1 flex cursor-pointer items-start gap-1.5 text-zinc-400">
+              <input
+                type="checkbox"
+                checked={applyHint}
+                onChange={(e) => setApplyHint(e.target.checked)}
+                className="mt-0.5 accent-emerald-500"
+              />
+              <span>
+                Add facing to prompt
+                {hint && <span className="block text-zinc-500">“{hint.positive}”</span>}
+                {applyHint && !hint && (
+                  <span className="block text-zinc-500">
+                    {facings.length > 1 && new Set(facings).size > 1
+                      ? 'mixed facings - nothing added'
+                      : 'nothing needed for this facing'}
+                  </span>
+                )}
+              </span>
+            </label>
           </div>
         </div>
       </div>

--- a/src/renderer/views/ControlSpace/ControlSpaceEditorMount.tsx
+++ b/src/renderer/views/ControlSpace/ControlSpaceEditorMount.tsx
@@ -1,0 +1,18 @@
+/**
+ * Mounts the Control Space 3D editor only while it is open, so its three.js/react-three-fiber bundle
+ * is fetched on demand (the first time a user opens Control Space) rather than in the initial SPA load.
+ */
+import { Suspense, lazy } from 'react'
+import { useControlSpaceStore } from '../../store/controlSpaceStore'
+
+const ControlSpaceEditor = lazy(() => import('./ControlSpaceEditor'))
+
+export function ControlSpaceEditorMount(): React.JSX.Element | null {
+  const open = useControlSpaceStore((s) => s.editingItemId !== null)
+  if (!open) return null
+  return (
+    <Suspense fallback={null}>
+      <ControlSpaceEditor />
+    </Suspense>
+  )
+}

--- a/src/renderer/views/ControlSpace/DepthRenderer.tsx
+++ b/src/renderer/views/ControlSpace/DepthRenderer.tsx
@@ -38,21 +38,26 @@ export function DepthRenderer({
   characters,
   nonce,
   enabled,
+  aspect,
   onRendered,
 }: {
   characters: Vec3[][]
   nonce: number
   enabled: boolean
+  aspect: number
   onRendered: (blob: Blob) => void
 }): null {
   const gl = useThree((s) => s.gl)
   const camera = useThree((s) => s.camera)
-  const size = useThree((s) => s.size)
 
   useEffect(() => {
     if (nonce === 0 || !enabled) return
-    const w = 768
-    const h = Math.max(1, Math.round((768 * size.height) / size.width))
+    // Render at the OUTPUT aspect (not the wide viewport) so depth isn't stretched at gen time.
+    const w = aspect >= 1 ? 768 : Math.max(1, Math.round(768 * aspect))
+    const h = aspect >= 1 ? Math.max(1, Math.round(768 / aspect)) : 768
+    const renderCam = (camera as THREE.PerspectiveCamera).clone()
+    renderCam.aspect = aspect
+    renderCam.updateProjectionMatrix()
 
     // Distance range from the camera to every joint -> adaptive near/far for contrast.
     let dmin = Infinity
@@ -101,7 +106,7 @@ export function DepthRenderer({
     gl.setRenderTarget(target)
     gl.setClearColor(0x000000, 1) // background = far = black
     gl.clear()
-    gl.render(scene, camera)
+    gl.render(scene, renderCam)
     const buf = new Uint8Array(w * h * 4)
     gl.readRenderTargetPixels(target, 0, 0, w, h, buf)
     gl.setRenderTarget(prevTarget)

--- a/src/renderer/views/ControlSpace/DepthRenderer.tsx
+++ b/src/renderer/views/ControlSpace/DepthRenderer.tsx
@@ -1,0 +1,141 @@
+/**
+ * Renders the characters as a grayscale depth map (near = bright), the control image a depth
+ * ControlNet expects. The skeleton is thin, so we build a volumetric body offscreen at capture time
+ * (a capsule per limb) and render it with a small shader that outputs linear camera-distance,
+ * normalized to the scene's own near/far range for good contrast. Fires when `nonce` changes and
+ * `enabled` (the output kind is "depth").
+ *
+ * The depth convention is owned here (not three's MeshDepthMaterial packing), so it is unambiguous;
+ * only whether it renders at all is browser-gated, like the rest of the R3F editor.
+ */
+import { useEffect } from 'react'
+import { useThree } from '@react-three/fiber'
+import * as THREE from 'three'
+import { LIMBS, type Vec3 } from './skeleton'
+
+const DEPTH_SHADER = {
+  vertex: `
+    varying float vDist;
+    void main() {
+      vec4 mv = modelViewMatrix * vec4(position, 1.0);
+      vDist = -mv.z; // positive distance in front of the camera
+      gl_Position = projectionMatrix * mv;
+    }
+  `,
+  fragment: `
+    uniform float uNear;
+    uniform float uFar;
+    varying float vDist;
+    void main() {
+      float t = clamp((vDist - uNear) / max(uFar - uNear, 0.0001), 0.0, 1.0);
+      float g = 1.0 - t; // near = bright
+      gl_FragColor = vec4(vec3(g), 1.0);
+    }
+  `,
+}
+
+export function DepthRenderer({
+  characters,
+  nonce,
+  enabled,
+  onRendered,
+}: {
+  characters: Vec3[][]
+  nonce: number
+  enabled: boolean
+  onRendered: (blob: Blob) => void
+}): null {
+  const gl = useThree((s) => s.gl)
+  const camera = useThree((s) => s.camera)
+  const size = useThree((s) => s.size)
+
+  useEffect(() => {
+    if (nonce === 0 || !enabled) return
+    const w = 768
+    const h = Math.max(1, Math.round((768 * size.height) / size.width))
+
+    // Distance range from the camera to every joint -> adaptive near/far for contrast.
+    let dmin = Infinity
+    let dmax = -Infinity
+    const cam = camera.position
+    for (const joints of characters) {
+      for (const [x, y, z] of joints) {
+        const d = Math.hypot(x - cam.x, y - cam.y, z - cam.z)
+        if (d < dmin) dmin = d
+        if (d > dmax) dmax = d
+      }
+    }
+    if (!isFinite(dmin)) return
+    const mat = new THREE.ShaderMaterial({
+      vertexShader: DEPTH_SHADER.vertex,
+      fragmentShader: DEPTH_SHADER.fragment,
+      uniforms: { uNear: { value: Math.max(0.05, dmin - 0.3) }, uFar: { value: dmax + 0.3 } },
+    })
+
+    const scene = new THREE.Scene()
+    const up = new THREE.Vector3(0, 1, 0)
+    const a = new THREE.Vector3()
+    const b = new THREE.Vector3()
+    const dir = new THREE.Vector3()
+    const geometries: THREE.BufferGeometry[] = []
+    for (const joints of characters) {
+      for (const [i, j] of LIMBS) {
+        a.set(...joints[i])
+        b.set(...joints[j])
+        dir.subVectors(b, a)
+        const len = dir.length()
+        if (len < 1e-4) continue
+        const geo = new THREE.CapsuleGeometry(0.06, len, 4, 8)
+        geometries.push(geo)
+        const mesh = new THREE.Mesh(geo, mat)
+        mesh.position.copy(a).add(b).multiplyScalar(0.5)
+        mesh.quaternion.setFromUnitVectors(up, dir.clone().normalize())
+        scene.add(mesh)
+      }
+    }
+
+    const target = new THREE.WebGLRenderTarget(w, h)
+    const prevTarget = gl.getRenderTarget()
+    const prevClear = gl.getClearColor(new THREE.Color()).clone()
+    const prevAlpha = gl.getClearAlpha()
+    gl.setRenderTarget(target)
+    gl.setClearColor(0x000000, 1) // background = far = black
+    gl.clear()
+    gl.render(scene, camera)
+    const buf = new Uint8Array(w * h * 4)
+    gl.readRenderTargetPixels(target, 0, 0, w, h, buf)
+    gl.setRenderTarget(prevTarget)
+    gl.setClearColor(prevClear, prevAlpha)
+
+    const canvas = document.createElement('canvas')
+    canvas.width = w
+    canvas.height = h
+    const ctx = canvas.getContext('2d')
+    if (ctx) {
+      const img = ctx.createImageData(w, h)
+      // readRenderTargetPixels is bottom-up; flip vertically into the 2D canvas.
+      for (let y = 0; y < h; y++) {
+        const srcRow = (h - 1 - y) * w * 4
+        const dstRow = y * w * 4
+        for (let x = 0; x < w; x++) {
+          const s = srcRow + x * 4
+          const d = dstRow + x * 4
+          img.data[d] = buf[s]
+          img.data[d + 1] = buf[s + 1]
+          img.data[d + 2] = buf[s + 2]
+          img.data[d + 3] = 255
+        }
+      }
+      ctx.putImageData(img, 0, 0)
+      canvas.toBlob((blob) => {
+        if (blob) onRendered(blob)
+      }, 'image/png')
+    }
+
+    target.dispose()
+    mat.dispose()
+    geometries.forEach((g) => g.dispose())
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nonce])
+  return null
+}

--- a/src/renderer/views/ControlSpace/DepthRenderer.tsx
+++ b/src/renderer/views/ControlSpace/DepthRenderer.tsx
@@ -1,38 +1,14 @@
 /**
- * Renders the characters as a grayscale depth map (near = bright), the control image a depth
- * ControlNet expects. The skeleton is thin, so we build a volumetric body offscreen at capture time
- * (a capsule per limb) and render it with a small shader that outputs linear camera-distance,
- * normalized to the scene's own near/far range for good contrast. Fires when `nonce` changes and
- * `enabled` (the output kind is "depth").
- *
- * The depth convention is owned here (not three's MeshDepthMaterial packing), so it is unambiguous;
- * only whether it renders at all is browser-gated, like the rest of the R3F editor.
+ * Renders the Control Space characters to a grayscale depth map (near = bright), the control image a
+ * depth ControlNet expects, and hands back a PNG blob. Fires when `nonce` changes and `enabled` (the
+ * output kind is "depth"). The scene itself is built by `depthScene.ts`; this owns only the
+ * render-target round trip, which is why it is the browser-gated half.
  */
 import { useEffect } from 'react'
 import { useThree } from '@react-three/fiber'
 import * as THREE from 'three'
-import { LIMBS, type Vec3 } from './skeleton'
-
-const DEPTH_SHADER = {
-  vertex: `
-    varying float vDist;
-    void main() {
-      vec4 mv = modelViewMatrix * vec4(position, 1.0);
-      vDist = -mv.z; // positive distance in front of the camera
-      gl_Position = projectionMatrix * mv;
-    }
-  `,
-  fragment: `
-    uniform float uNear;
-    uniform float uFar;
-    varying float vDist;
-    void main() {
-      float t = clamp((vDist - uNear) / max(uFar - uNear, 0.0001), 0.0, 1.0);
-      float g = 1.0 - t; // near = bright
-      gl_FragColor = vec4(vec3(g), 1.0);
-    }
-  `,
-}
+import { buildDepthScene } from './depthScene'
+import { type Vec3 } from './skeleton'
 
 export function DepthRenderer({
   characters,
@@ -59,45 +35,8 @@ export function DepthRenderer({
     renderCam.aspect = aspect
     renderCam.updateProjectionMatrix()
 
-    // Distance range from the camera to every joint -> adaptive near/far for contrast.
-    let dmin = Infinity
-    let dmax = -Infinity
-    const cam = camera.position
-    for (const joints of characters) {
-      for (const [x, y, z] of joints) {
-        const d = Math.hypot(x - cam.x, y - cam.y, z - cam.z)
-        if (d < dmin) dmin = d
-        if (d > dmax) dmax = d
-      }
-    }
-    if (!isFinite(dmin)) return
-    const mat = new THREE.ShaderMaterial({
-      vertexShader: DEPTH_SHADER.vertex,
-      fragmentShader: DEPTH_SHADER.fragment,
-      uniforms: { uNear: { value: Math.max(0.05, dmin - 0.3) }, uFar: { value: dmax + 0.3 } },
-    })
-
-    const scene = new THREE.Scene()
-    const up = new THREE.Vector3(0, 1, 0)
-    const a = new THREE.Vector3()
-    const b = new THREE.Vector3()
-    const dir = new THREE.Vector3()
-    const geometries: THREE.BufferGeometry[] = []
-    for (const joints of characters) {
-      for (const [i, j] of LIMBS) {
-        a.set(...joints[i])
-        b.set(...joints[j])
-        dir.subVectors(b, a)
-        const len = dir.length()
-        if (len < 1e-4) continue
-        const geo = new THREE.CapsuleGeometry(0.06, len, 4, 8)
-        geometries.push(geo)
-        const mesh = new THREE.Mesh(geo, mat)
-        mesh.position.copy(a).add(b).multiplyScalar(0.5)
-        mesh.quaternion.setFromUnitVectors(up, dir.clone().normalize())
-        scene.add(mesh)
-      }
-    }
+    if (!characters.length) return
+    const { scene, dispose } = buildDepthScene(characters, renderCam)
 
     const target = new THREE.WebGLRenderTarget(w, h)
     const prevTarget = gl.getRenderTarget()
@@ -138,8 +77,7 @@ export function DepthRenderer({
     }
 
     target.dispose()
-    mat.dispose()
-    geometries.forEach((g) => g.dispose())
+    dispose()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [nonce])
   return null

--- a/src/renderer/views/ControlSpace/depthScene.ts
+++ b/src/renderer/views/ControlSpace/depthScene.ts
@@ -1,0 +1,218 @@
+/**
+ * The depth body proxy: the three.js scene a Control Space depth map is rendered from. React-free so
+ * it can be rendered and measured outside the app.
+ *
+ * Two things make this map usable as a ControlNet input. The bodies have real volume - limb capsules
+ * with anatomical thickness, a skull, and a face that protrudes along the head's forward axis, so
+ * facing is legible in the pixels (the face self-occludes when the character turns away). And the
+ * frame is dense: a ground plane and backdrop mean every pixel carries a depth value, because these
+ * models are trained on monocular depth estimates of real photos, never on a silhouette in a void.
+ *
+ * The depth convention is owned here (not three's MeshDepthMaterial packing), so it is unambiguous.
+ */
+import * as THREE from 'three'
+import { depthRange, headFrame, HEAD_POINTS, LIMBS, nearestGroundHit, type Vec3 } from './skeleton'
+
+const DEPTH_SHADER = {
+  vertex: `
+    varying float vDist;
+    void main() {
+      vec4 mv = modelViewMatrix * vec4(position, 1.0);
+      vDist = -mv.z; // positive distance in front of the camera
+      gl_Position = projectionMatrix * mv;
+    }
+  `,
+  fragment: `
+    uniform float uNear;
+    uniform float uFar;
+    varying float vDist;
+    void main() {
+      float t = clamp((vDist - uNear) / max(uFar - uNear, 0.0001), 0.0, 1.0);
+      float g = 1.0 - t; // near = bright
+      gl_FragColor = vec4(vec3(g), 1.0);
+    }
+  `,
+}
+
+/** Limbs that make up the body; head keypoints are replaced by the skull + face volume below. */
+const BODY_LIMBS = LIMBS.filter(([a, b]) => !HEAD_POINTS.includes(a) && !HEAD_POINTS.includes(b))
+
+/** OpenPose has no shoulder-shoulder or hip-hip bone, but a torso is a box, not a V. */
+const TORSO_FILL: readonly [number, number][] = [
+  [2, 5],
+  [8, 11],
+]
+
+/** Capsule radius per bone, keyed `a-b` - a torso is not as thin as a forearm. */
+const LIMB_RADIUS: Record<string, number> = {
+  '1-2': 0.09,
+  '1-5': 0.09,
+  '2-3': 0.055,
+  '3-4': 0.045,
+  '5-6': 0.055,
+  '6-7': 0.045,
+  '1-8': 0.13,
+  '1-11': 0.13,
+  '8-9': 0.085,
+  '9-10': 0.06,
+  '11-12': 0.085,
+  '12-13': 0.06,
+  '2-5': 0.1,
+  '8-11': 0.11,
+}
+
+/** Sphere radius per joint, so bones meet in a rounded mass instead of a visible seam. */
+const JOINT_RADIUS: Record<number, number> = {
+  1: 0.085,
+  2: 0.085,
+  5: 0.085,
+  3: 0.05,
+  6: 0.05,
+  4: 0.04,
+  7: 0.04,
+  8: 0.095,
+  11: 0.095,
+  9: 0.06,
+  12: 0.06,
+  10: 0.045,
+  13: 0.045,
+}
+
+const SKULL_RADIUS = 0.1
+
+/**
+ * Build one character's depth proxy into `scene`. Geometries are collected so the caller can dispose
+ * them after the readback.
+ */
+function buildBody(
+  joints: Vec3[],
+  mat: THREE.Material,
+  scene: THREE.Scene,
+  geometries: THREE.BufferGeometry[],
+): void {
+  const up = new THREE.Vector3(0, 1, 0)
+  const a = new THREE.Vector3()
+  const b = new THREE.Vector3()
+  const dir = new THREE.Vector3()
+
+  const add = (geo: THREE.BufferGeometry): THREE.Mesh => {
+    geometries.push(geo)
+    const mesh = new THREE.Mesh(geo, mat)
+    scene.add(mesh)
+    return mesh
+  }
+  const capsule = (from: THREE.Vector3, to: THREE.Vector3, radius: number): void => {
+    dir.subVectors(to, from)
+    const len = dir.length()
+    if (len < 1e-4) return
+    const mesh = add(new THREE.CapsuleGeometry(radius, len, 4, 10))
+    mesh.position.copy(from).add(to).multiplyScalar(0.5)
+    mesh.quaternion.setFromUnitVectors(up, dir.clone().normalize())
+  }
+
+  for (const [i, j] of [...BODY_LIMBS, ...TORSO_FILL]) {
+    a.set(...joints[i])
+    b.set(...joints[j])
+    capsule(a, b, LIMB_RADIUS[`${i}-${j}`] ?? 0.05)
+  }
+  for (const [index, radius] of Object.entries(JOINT_RADIUS)) {
+    add(new THREE.SphereGeometry(radius, 12, 10)).position.set(...joints[Number(index)])
+  }
+
+  const head = headFrame(joints)
+  if (!head) return
+  const center = new THREE.Vector3(...head.center)
+  const forward = new THREE.Vector3(...head.forward)
+
+  const neck = new THREE.Vector3(...joints[1])
+  capsule(neck, center, 0.05)
+  // The head's own up (neck -> skull), so a lying or tilted character's skull is still egg-shaped
+  // along the head axis rather than along world Y.
+  const headUp = center.clone().sub(neck)
+  if (headUp.lengthSq() < 1e-8) headUp.copy(up)
+  headUp.normalize()
+
+  const skull = add(new THREE.SphereGeometry(SKULL_RADIUS, 16, 14))
+  skull.position.copy(center)
+  skull.scale.set(1, 1.15, 1.08)
+  skull.quaternion.setFromUnitVectors(up, headUp)
+
+  // The face: a mass that breaks the skull's silhouette forward, plus a nose ridge. Both vanish
+  // behind the skull when the head turns away - the whole point of rendering depth from 3D.
+  add(new THREE.SphereGeometry(0.055, 12, 10))
+    .position.copy(center)
+    .addScaledVector(forward, SKULL_RADIUS * 0.85)
+    .addScaledVector(headUp, -0.015)
+  const nose = add(new THREE.ConeGeometry(0.03, 0.07, 10))
+  nose.position.copy(center).addScaledVector(forward, SKULL_RADIUS * 1.2)
+  nose.quaternion.setFromUnitVectors(up, forward)
+
+  for (const ear of [16, 17]) {
+    if (joints[ear]) add(new THREE.SphereGeometry(0.032, 10, 8)).position.set(...joints[ear])
+  }
+}
+
+/**
+ * A ground plane and a backdrop, so every pixel of the map carries a depth value. Without them the
+ * figure floats in a void that is ~78% pure black, which reads as "infinitely far" everywhere and
+ * the ControlNet ignores it - monocular depth estimates, what these models are trained on, are dense.
+ * The backdrop is billboarded to the render camera so it always covers the frame.
+ */
+function buildStage(
+  scene: THREE.Scene,
+  geometries: THREE.BufferGeometry[],
+  mat: THREE.Material,
+  camera: THREE.PerspectiveCamera,
+  backdrop: number,
+): void {
+  const ground = new THREE.PlaneGeometry(80, 80)
+  geometries.push(ground)
+  const floor = new THREE.Mesh(ground, mat)
+  floor.rotation.x = -Math.PI / 2
+  scene.add(floor)
+
+  camera.updateMatrixWorld()
+  const wall = new THREE.PlaneGeometry(80, 80)
+  geometries.push(wall)
+  const back = new THREE.Mesh(wall, mat)
+  const forward = camera.getWorldDirection(new THREE.Vector3())
+  back.position
+    .copy(camera.getWorldPosition(new THREE.Vector3()))
+    .addScaledVector(forward, backdrop)
+  back.quaternion.copy(camera.getWorldQuaternion(new THREE.Quaternion()))
+  scene.add(back)
+}
+
+/** The scene a depth map is rendered from: volumetric bodies on a ground plane against a backdrop. */
+export function buildDepthScene(
+  characters: readonly Vec3[][],
+  camera: THREE.PerspectiveCamera,
+): { scene: THREE.Scene; dispose: () => void } {
+  camera.updateMatrixWorld()
+  const cam = camera.getWorldPosition(new THREE.Vector3())
+  const fwd = camera.getWorldDirection(new THREE.Vector3())
+  const up = camera.up.clone().applyQuaternion(camera.getWorldQuaternion(new THREE.Quaternion()))
+  const ground = nearestGroundHit(
+    [cam.x, cam.y, cam.z],
+    [fwd.x, fwd.y, fwd.z],
+    [up.x, up.y, up.z],
+    camera.fov,
+  )
+  const { near, far, backdrop } = depthRange(characters, [cam.x, cam.y, cam.z], ground)
+  const mat = new THREE.ShaderMaterial({
+    vertexShader: DEPTH_SHADER.vertex,
+    fragmentShader: DEPTH_SHADER.fragment,
+    uniforms: { uNear: { value: near }, uFar: { value: far } },
+  })
+  const scene = new THREE.Scene()
+  const geometries: THREE.BufferGeometry[] = []
+  for (const joints of characters) buildBody(joints, mat, scene, geometries)
+  buildStage(scene, geometries, mat, camera, backdrop)
+  return {
+    scene,
+    dispose: () => {
+      mat.dispose()
+      geometries.forEach((g) => g.dispose())
+    },
+  }
+}

--- a/src/renderer/views/ControlSpace/projection.diag.test.ts
+++ b/src/renderer/views/ControlSpace/projection.diag.test.ts
@@ -114,3 +114,23 @@ describe('Control Space projection diagnostics', () => {
     expect(true).toBe(true)
   })
 })
+
+describe('full-body framing at portrait aspect (832x1216)', () => {
+  it('reports where head and feet land in the map', () => {
+    const aspect = 832 / 1216 // ~0.684 - the user's gen size
+    const cam = makeCamera(aspect)
+    const { w, h } = outputSize(aspect)
+    const p = project(STANDING, cam, w, h)
+    const head = p[0] // nose
+    const feet = [p[10], p[13]] // ankles
+    const inFrame = p.filter((q) => q.inFrame).length
+    console.log(`\naspect ${aspect.toFixed(3)} map ${w}x${h}:`)
+    console.log(`  head y = ${head.y.toFixed(0)} (top margin ${((head.y / h) * 100).toFixed(0)}%)`)
+    console.log(`  feet y = ${Math.max(feet[0].y, feet[1].y).toFixed(0)} (bottom edge at ${h})`)
+    console.log(
+      `  figure spans ${(((Math.max(feet[0].y, feet[1].y) - head.y) / h) * 100).toFixed(0)}% of the map height`,
+    )
+    console.log(`  ${inFrame}/18 joints in-frame`)
+    expect(inFrame).toBe(18)
+  })
+})

--- a/src/renderer/views/ControlSpace/projection.diag.test.ts
+++ b/src/renderer/views/ControlSpace/projection.diag.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Diagnostic: reproduce exactly how the editor projects 3D joints to the 2D OpenPose control map,
+ * so we can see (headlessly, no GPU) whether "Turn around" changes the map and whether characters
+ * land inside the rendered frame (an off-frame pose -> near-black map -> random generation).
+ */
+import { describe, expect, it } from 'vitest'
+import * as THREE from 'three'
+import { KEYPOINTS, STANDING, rotatePoseY, translatePose, type Vec3 } from './skeleton'
+
+/** The editor's default view: camera at (0,1.2,3.2), fov 45, looking at (0,0.9,0). */
+function makeCamera(aspect: number): THREE.PerspectiveCamera {
+  const cam = new THREE.PerspectiveCamera(45, aspect, 0.1, 1000)
+  cam.position.set(0, 1.2, 3.2)
+  cam.lookAt(0, 0.9, 0)
+  cam.updateMatrixWorld(true)
+  cam.updateProjectionMatrix()
+  return cam
+}
+
+function outputSize(aspect: number): { w: number; h: number } {
+  return aspect >= 1
+    ? { w: 768, h: Math.round(768 / aspect) }
+    : { w: Math.round(768 * aspect), h: 768 }
+}
+
+interface P2 {
+  x: number
+  y: number
+  inFrame: boolean
+}
+
+function project(
+  joints: readonly Vec3[],
+  cam: THREE.PerspectiveCamera,
+  w: number,
+  h: number,
+): P2[] {
+  const v = new THREE.Vector3()
+  return joints.map(([x, y, z]) => {
+    v.set(x, y, z).project(cam)
+    const px = (v.x * 0.5 + 0.5) * w
+    const py = (1 - (v.y * 0.5 + 0.5)) * h
+    return { x: px, y: py, inFrame: v.z < 1 && px >= 0 && px <= w && py >= 0 && py <= h }
+  })
+}
+
+function meanShift(a: P2[], b: P2[]): number {
+  let s = 0
+  for (let i = 0; i < a.length; i++) s += Math.hypot(a[i].x - b[i].x, a[i].y - b[i].y)
+  return s / a.length
+}
+
+const framed = (p: P2[]): string => `${p.filter((q) => q.inFrame).length}/${p.length} in-frame`
+
+describe('Control Space projection diagnostics', () => {
+  it('reports whether Turn around changes the projected map (symmetric vs asymmetric)', () => {
+    const aspect = 1
+    const cam = makeCamera(aspect)
+    const { w, h } = outputSize(aspect)
+
+    const standing = project(STANDING, cam, w, h)
+    const standingTurned = project(rotatePoseY(STANDING, Math.PI), cam, w, h)
+
+    // An asymmetric pose: raise the left wrist/elbow out to the side.
+    const armOut = STANDING.map((v) => [...v] as Vec3)
+    armOut[6] = [0.5, 1.45, 0] // l-elbow out
+    armOut[7] = [0.75, 1.45, 0] // l-wrist out
+    const armOutP = project(armOut, cam, w, h)
+    const armOutTurned = project(rotatePoseY(armOut, Math.PI), cam, w, h)
+
+    console.log('\n=== TURN AROUND (front camera, 768x768) ===')
+    console.log(`standing:            ${framed(standing)}`)
+    console.log(
+      `standing turned:     mean joint shift = ${meanShift(standing, standingTurned).toFixed(1)} px  (symmetric pose -> ~mirror, small)`,
+    )
+    console.log(
+      `arm-out l-wrist px:  ${armOutP[7].x.toFixed(0)}  -> turned: ${armOutTurned[7].x.toFixed(0)}  (should cross the body)`,
+    )
+    console.log(
+      `arm-out turned:      mean joint shift = ${meanShift(armOutP, armOutTurned).toFixed(1)} px`,
+    )
+
+    // Turn around DOES change the map (mirror + limb-color swap = a back-view OpenPose), even for a
+    // symmetric pose; an asymmetric pose flips its arms across the body. So "turn around not working"
+    // is the model not following front/back from OpenPose - not a geometry/save bug.
+    expect(meanShift(standing, standingTurned)).toBeGreaterThan(30)
+    expect(meanShift(armOutP, armOutTurned)).toBeGreaterThan(80)
+  })
+
+  it('reports whether 1 and 2 characters stay inside the frame at each aspect', () => {
+    for (const aspect of [1, 3 / 4, 16 / 9]) {
+      const cam = makeCamera(aspect)
+      const { w, h } = outputSize(aspect)
+      const one = project(STANDING, cam, w, h)
+      // The editor auto-spaces a 2nd character at +0.8 in x.
+      const twoA = project(STANDING, cam, w, h)
+      const twoB = project(translatePose(STANDING, 0.8, 0, 0), cam, w, h)
+      const label = aspect === 1 ? '1:1' : aspect < 1 ? '3:4' : '16:9'
+      console.log(
+        `\naspect ${label} (${w}x${h}): 1 char ${framed(one)} | 2 chars A ${framed(twoA)} B ${framed(twoB)}`,
+      )
+    }
+    expect(KEYPOINTS.length).toBe(18)
+  })
+
+  it('shows where the 2nd character lands vs the frame edge (x in pixels)', () => {
+    const cam = makeCamera(1)
+    const { w } = outputSize(1)
+    const secondChar = project(translatePose(STANDING, 0.8, 0, 0), cam, w, w)
+    const xs = secondChar.map((p) => p.x)
+    console.log(
+      `\n2nd char x-range at 1:1 768-wide: [${Math.min(...xs).toFixed(0)}, ${Math.max(...xs).toFixed(0)}]  (frame is 0..768)`,
+    )
+    expect(true).toBe(true)
+  })
+})

--- a/src/renderer/views/ControlSpace/skeleton.test.ts
+++ b/src/renderer/views/ControlSpace/skeleton.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   centroid,
+  depthRange,
   drawOpenPose,
+  faceOcclusion,
+  facingLabel,
+  facingPromptHint,
+  headFrame,
   KEYPOINT_COUNT,
   KEYPOINTS,
   LIMBS,
+  nearestGroundHit,
   POSE_COLORS,
   PRESETS,
   rotatePoseY,
@@ -71,6 +77,124 @@ describe('pose transforms', () => {
       expect(y).toBeCloseTo(STANDING[i][1] - 2, 6)
       expect(z).toBeCloseTo(STANDING[i][2] + 3, 6)
     })
+  })
+})
+
+describe('faceOcclusion (front/back facing)', () => {
+  // STANDING faces +Z (nose is forward of the neck/ears in +Z).
+  const NOSE = 0
+  const R_EYE = 14
+  const L_EYE = 15
+  const R_EAR = 16
+  const L_EAR = 17
+
+  it('keeps the face when the camera is in front of it', () => {
+    const cull = faceOcclusion(STANDING, [0, 1.5, 5]) // camera at +Z, facing the character's front
+    expect(cull[NOSE]).toBe(false)
+    expect(cull[R_EYE]).toBe(false)
+    expect(cull[L_EYE]).toBe(false)
+  })
+
+  it('culls the nose and eyes but keeps the ears when the head faces away', () => {
+    const cull = faceOcclusion(STANDING, [0, 1.5, -5]) // camera behind the character
+    expect(cull[NOSE]).toBe(true)
+    expect(cull[R_EYE]).toBe(true)
+    expect(cull[L_EYE]).toBe(true)
+    expect(cull[R_EAR]).toBe(false) // ears stay - what OpenPose sees from behind
+    expect(cull[L_EAR]).toBe(false)
+  })
+
+  it('turning the character around flips which side the camera sees as the face', () => {
+    const turned = rotatePoseY(STANDING, Math.PI) // now faces -Z
+    const front = faceOcclusion(turned, [0, 1.5, 5]) // camera at +Z now sees the back of the head
+    expect(front[NOSE]).toBe(true)
+    const behind = faceOcclusion(turned, [0, 1.5, -5]) // camera at -Z now sees the face
+    expect(behind[NOSE]).toBe(false)
+  })
+})
+
+describe('facing', () => {
+  const FRONT: Vec3 = [0, 1.5, 5]
+  const BEHIND: Vec3 = [0, 1.5, -5]
+  const SIDE: Vec3 = [5, 1.5, 0.12] // level with the nose, so the camera is exactly side-on
+
+  it('the head frame points from the skull center toward the nose', () => {
+    const head = headFrame(STANDING)
+    expect(head).not.toBeNull()
+    expect(head!.forward[2]).toBeGreaterThan(0.8) // STANDING faces +Z
+    expect(Math.hypot(...head!.forward)).toBeCloseTo(1, 6)
+  })
+
+  it('labels front, back and profile from the camera position', () => {
+    expect(facingLabel(STANDING, FRONT)).toBe('front')
+    expect(facingLabel(STANDING, BEHIND)).toBe('back')
+    expect(facingLabel(STANDING, SIDE)).toBe('profile')
+  })
+
+  it('follows the character when it turns around', () => {
+    const turned = rotatePoseY(STANDING, Math.PI)
+    expect(facingLabel(turned, FRONT)).toBe('back')
+    expect(facingLabel(turned, BEHIND)).toBe('front')
+  })
+
+  it('a back-facing scene gets a prompt hint; a front-facing one needs none', () => {
+    expect(facingPromptHint(['front'])).toBeNull()
+    expect(facingPromptHint(['three-quarter'])).toBeNull()
+    const hint = facingPromptHint(['back', 'back'])
+    expect(hint?.positive).toContain('from behind')
+    expect(hint?.negative).toContain('looking at the camera')
+  })
+
+  it('says nothing when characters face different ways or the head is degenerate', () => {
+    expect(facingPromptHint(['back', 'front'])).toBeNull()
+    expect(facingPromptHint([])).toBeNull()
+    expect(facingPromptHint([null])).toBeNull()
+  })
+
+  it('agrees with faceOcclusion: a back label means the face keypoints are culled', () => {
+    expect(facingLabel(STANDING, BEHIND)).toBe('back')
+    expect(faceOcclusion(STANDING, BEHIND)[0]).toBe(true)
+    expect(faceOcclusion(STANDING, FRONT)[0]).toBe(false)
+  })
+})
+
+describe('depth map range', () => {
+  const CAM: Vec3 = [0, 1.2, 3.2]
+  const FWD: Vec3 = [0, -0.09, -0.99] // the editor's default framing, looking slightly down
+  const UP: Vec3 = [0, 1, 0]
+
+  it('finds the ground at the bottom of the frame, and reports none when looking up', () => {
+    const hit = nearestGroundHit(CAM, FWD, UP, 45)
+    expect(hit).not.toBeNull()
+    expect(hit!).toBeGreaterThan(0)
+    expect(hit!).toBeLessThan(3.2) // nearer than the character, so it owns the near plane
+    expect(nearestGroundHit(CAM, [0, 0.5, -0.87], UP, 45)).toBeNull()
+  })
+
+  it('spans nearest visible surface to backdrop, and never lets the backdrop hit pure black', () => {
+    const ground = nearestGroundHit(CAM, FWD, UP, 45)
+    const { near, far, backdrop } = depthRange([STANDING], CAM, ground)
+    expect(near).toBeCloseTo(ground!, 6) // the floor is nearer than the body
+    expect(backdrop).toBeGreaterThan(near)
+    expect(far).toBeGreaterThan(backdrop) // headroom, so the background is dark grey not 0
+    // The shader maps distance -> 1-t; the backdrop must land clear of black.
+    const backdropGrey = 1 - (backdrop - near) / (far - near)
+    expect(backdropGrey).toBeGreaterThan(0.05)
+  })
+
+  it('falls back to the body when there is no ground in frame', () => {
+    const { near } = depthRange([STANDING], CAM, null)
+    const nearest = Math.min(
+      ...STANDING.map(([x, y, z]) => Math.hypot(x - CAM[0], y - CAM[1], z - CAM[2])),
+    )
+    expect(near).toBeLessThan(nearest) // padded by a body radius so the surface isn't clipped
+    expect(near).toBeGreaterThan(nearest - 0.3)
+  })
+
+  it('degenerate input does not produce a NaN range', () => {
+    const { near, far } = depthRange([], CAM)
+    expect(Number.isFinite(near)).toBe(true)
+    expect(far).toBeGreaterThan(near)
   })
 })
 

--- a/src/renderer/views/ControlSpace/skeleton.test.ts
+++ b/src/renderer/views/ControlSpace/skeleton.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  centroid,
+  drawOpenPose,
+  KEYPOINT_COUNT,
+  KEYPOINTS,
+  LIMBS,
+  POSE_COLORS,
+  PRESETS,
+  rotatePoseY,
+  STANDING,
+  translatePose,
+  type Point2D,
+  type Vec3,
+} from './skeleton'
+
+describe('OpenPose skeleton model', () => {
+  it('has 18 keypoints and one color per keypoint', () => {
+    expect(KEYPOINT_COUNT).toBe(18)
+    expect(KEYPOINTS).toHaveLength(18)
+    expect(POSE_COLORS).toHaveLength(18)
+  })
+
+  it('every limb connects valid keypoint indices', () => {
+    for (const [a, b] of LIMBS) {
+      expect(a).toBeGreaterThanOrEqual(0)
+      expect(b).toBeGreaterThanOrEqual(0)
+      expect(a).toBeLessThan(KEYPOINT_COUNT)
+      expect(b).toBeLessThan(KEYPOINT_COUNT)
+    }
+  })
+
+  it('every preset defines all 18 joints', () => {
+    for (const pose of Object.values(PRESETS)) expect(pose).toHaveLength(18)
+  })
+})
+
+describe('pose transforms', () => {
+  const approx = (a: readonly Vec3[], b: readonly Vec3[]): void => {
+    a.forEach(([x, y, z], i) => {
+      expect(x).toBeCloseTo(b[i][0], 6)
+      expect(y).toBeCloseTo(b[i][1], 6)
+      expect(z).toBeCloseTo(b[i][2], 6)
+    })
+  }
+
+  it('centroid averages the joints', () => {
+    const [cx, cy, cz] = centroid([
+      [0, 0, 0],
+      [2, 4, 6],
+    ])
+    expect([cx, cy, cz]).toEqual([1, 2, 3])
+  })
+
+  it('a full turn (2pi) is a no-op and never changes Y', () => {
+    approx(rotatePoseY(STANDING, Math.PI * 2), STANDING)
+    rotatePoseY(STANDING, 1.234).forEach(([, y], i) => expect(y).toBeCloseTo(STANDING[i][1], 6))
+  })
+
+  it('a half turn mirrors x and z about the centroid (front/back)', () => {
+    const [cx, , cz] = centroid(STANDING)
+    rotatePoseY(STANDING, Math.PI).forEach(([x, , z], i) => {
+      expect(x).toBeCloseTo(2 * cx - STANDING[i][0], 6)
+      expect(z).toBeCloseTo(2 * cz - STANDING[i][2], 6)
+    })
+  })
+
+  it('translatePose shifts every joint by the offset', () => {
+    translatePose(STANDING, 1, -2, 3).forEach(([x, y, z], i) => {
+      expect(x).toBeCloseTo(STANDING[i][0] + 1, 6)
+      expect(y).toBeCloseTo(STANDING[i][1] - 2, 6)
+      expect(z).toBeCloseTo(STANDING[i][2] + 3, 6)
+    })
+  })
+})
+
+describe('drawOpenPose', () => {
+  const fakeCtx = () =>
+    ({
+      fillRect: vi.fn(),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      stroke: vi.fn(),
+      arc: vi.fn(),
+      fill: vi.fn(),
+      fillStyle: '',
+      strokeStyle: '',
+      lineWidth: 0,
+      lineCap: '',
+    }) as unknown as CanvasRenderingContext2D
+
+  const allVisible = (): Point2D[] =>
+    Array.from({ length: 18 }, (_, i) => ({ x: i * 10, y: i * 5, visible: true }))
+
+  it('clears the background and draws a dot per visible joint and a stroke per drawable limb', () => {
+    const ctx = fakeCtx()
+    drawOpenPose(ctx, allVisible(), 512, 512)
+    expect(ctx.fillRect).toHaveBeenCalledTimes(1) // black background
+    expect((ctx.arc as ReturnType<typeof vi.fn>).mock.calls.length).toBe(18) // one dot per joint
+    expect((ctx.stroke as ReturnType<typeof vi.fn>).mock.calls.length).toBe(LIMBS.length)
+  })
+
+  it('skips limbs and dots for hidden joints', () => {
+    const ctx = fakeCtx()
+    const pts = allVisible()
+    pts[4].visible = false // r-wrist hidden -> its dot and the elbow-wrist limb are skipped
+    drawOpenPose(ctx, pts, 512, 512)
+    expect((ctx.arc as ReturnType<typeof vi.fn>).mock.calls.length).toBe(17)
+    const wristLimbs = LIMBS.filter(([a, b]) => a === 4 || b === 4).length
+    expect((ctx.stroke as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+      LIMBS.length - wristLimbs,
+    )
+  })
+
+  it('can skip the clear to overlay multiple characters', () => {
+    const ctx = fakeCtx()
+    drawOpenPose(ctx, allVisible(), 512, 512, false)
+    expect(ctx.fillRect).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/views/ControlSpace/skeleton.ts
+++ b/src/renderer/views/ControlSpace/skeleton.ts
@@ -74,9 +74,11 @@ export const POSE_COLORS: readonly string[] = [
 
 export type Vec3 = readonly [number, number, number]
 
-/** A rest pose: standing, facing +Z, Y up, roughly 1.7 units tall. Indexed by KEYPOINTS order. */
+/** A rest pose: standing, facing +Z, Y up, roughly 1.7 units tall. Indexed by KEYPOINTS order.
+ * The face keypoints sit a real head-radius in front of the ears (not a few cm), so the head's
+ * forward vector - which drives both facing detection and the depth proxy's nose - is unambiguous. */
 export const STANDING: readonly Vec3[] = [
-  [0, 1.62, 0.05],
+  [0, 1.62, 0.12],
   [0, 1.45, 0],
   [-0.18, 1.45, 0],
   [-0.2, 1.15, 0],
@@ -90,15 +92,15 @@ export const STANDING: readonly Vec3[] = [
   [0.1, 1.0, 0],
   [0.11, 0.55, 0],
   [0.11, 0.08, 0],
-  [-0.03, 1.66, 0.07],
-  [0.03, 1.66, 0.07],
+  [-0.03, 1.66, 0.1],
+  [0.03, 1.66, 0.1],
   [-0.07, 1.64, 0.02],
   [0.07, 1.64, 0.02],
 ]
 
 /** Sitting: hips + knees bent forward, feet under the knees. */
 export const SITTING: readonly Vec3[] = [
-  [0, 1.12, 0.05],
+  [0, 1.12, 0.12],
   [0, 0.95, 0],
   [-0.18, 0.95, 0],
   [-0.2, 0.68, 0.05],
@@ -112,8 +114,8 @@ export const SITTING: readonly Vec3[] = [
   [0.1, 0.5, 0],
   [0.12, 0.45, 0.35],
   [0.12, 0.08, 0.35],
-  [-0.03, 1.16, 0.07],
-  [0.03, 1.16, 0.07],
+  [-0.03, 1.16, 0.1],
+  [0.03, 1.16, 0.1],
   [-0.07, 1.14, 0.02],
   [0.07, 1.14, 0.02],
 ]
@@ -157,6 +159,157 @@ export function rotatePoseY(joints: readonly Vec3[], angle: number): Vec3[] {
 /** Shift every joint of a pose by a fixed offset (used to space multiple characters apart). */
 export function translatePose(joints: readonly Vec3[], dx: number, dy: number, dz: number): Vec3[] {
   return joints.map(([x, y, z]) => [x + dx, y + dy, z + dz] as Vec3)
+}
+
+/** The front-of-face keypoints (nose, right eye, left eye). An OpenPose ControlNet reads front vs
+ * back almost entirely from whether these are present, so they must be culled when the head faces
+ * away - otherwise a turned-around character still renders looking at the camera. */
+const FACE_FRONT: readonly number[] = [0, 14, 15]
+
+/** Every keypoint that belongs to the head, not the body. */
+export const HEAD_POINTS: readonly number[] = [0, 14, 15, 16, 17]
+
+function norm([x, y, z]: Vec3): Vec3 {
+  const len = Math.hypot(x, y, z) || 1
+  return [x / len, y / len, z / len]
+}
+
+/**
+ * The head's center and unit forward (gaze) direction: the ear midpoint is the skull center and
+ * ear-midpoint -> nose is forward, falling back to the neck when the ears are degenerate. Shared by
+ * the facing math and the depth body proxy, which both need to know where the face points.
+ */
+export function headFrame(joints: readonly Vec3[]): { center: Vec3; forward: Vec3 } | null {
+  const nose = joints[0]
+  const neck = joints[1]
+  const rEar = joints[16]
+  const lEar = joints[17]
+  if (!nose || !neck) return null
+  const center: Vec3 =
+    rEar && lEar
+      ? [(rEar[0] + lEar[0]) / 2, (rEar[1] + lEar[1]) / 2, (rEar[2] + lEar[2]) / 2]
+      : neck
+  const fwd: Vec3 = [nose[0] - center[0], nose[1] - center[1], nose[2] - center[2]]
+  if (Math.hypot(...fwd) < 1e-6) return null
+  return { center, forward: norm(fwd) }
+}
+
+/** cos of the angle between the head's forward direction and the direction to the camera: 1 = looking
+ * straight at it, 0 = side-on profile, -1 = looking directly away. */
+export function facingCos(joints: readonly Vec3[], camPos: Vec3): number | null {
+  const head = headFrame(joints)
+  const nose = joints[0]
+  if (!head || !nose) return null
+  const [tx, ty, tz] = norm([camPos[0] - nose[0], camPos[1] - nose[1], camPos[2] - nose[2]])
+  return head.forward[0] * tx + head.forward[1] * ty + head.forward[2] * tz
+}
+
+/**
+ * Which keypoints the head occludes by facing away from the camera - a boolean per KEYPOINTS index
+ * (true = drop it). When the face points away from the camera those keypoints are on the hidden
+ * side, so we drop the nose + eyes and keep the ears, which is what OpenPose sees from behind.
+ * Purely geometric, so it holds for any character orientation or camera angle.
+ */
+export function faceOcclusion(joints: readonly Vec3[], camPos: Vec3): boolean[] {
+  const cull = new Array(KEYPOINT_COUNT).fill(false) as boolean[]
+  const cos = facingCos(joints, camPos)
+  if (cos !== null && cos < 0) for (const i of FACE_FRONT) cull[i] = true
+  return cull
+}
+
+export type Facing = 'front' | 'three-quarter' | 'profile' | 'back'
+
+/** How the character is turned relative to the camera. `null` when the head is degenerate. */
+export function facingLabel(joints: readonly Vec3[], camPos: Vec3): Facing | null {
+  const cos = facingCos(joints, camPos)
+  if (cos === null) return null
+  if (cos > 0.5) return 'front'
+  if (cos > 0.15) return 'three-quarter'
+  if (cos > -0.15) return 'profile'
+  return 'back'
+}
+
+/**
+ * The prompt text a facing needs, per character. A face-less OpenPose skeleton is *ambiguous*, not
+ * back-facing - real detections lose the face to blur and distance too - so the model falls back on
+ * its prior (a visible face) and renders the head turned back over the shoulder. The control image
+ * has no channel that can say "away"; the text encoder does, so the facing is stated there.
+ * Front/three-quarter need nothing: they are what the prior already assumes.
+ */
+const FACING_PROMPT: Record<Facing, { positive: string; negative: string }> = {
+  front: { positive: '', negative: '' },
+  'three-quarter': { positive: '', negative: '' },
+  profile: {
+    positive: 'seen in profile, side view, head facing sideways',
+    negative: 'facing the camera, front view',
+  },
+  back: {
+    positive: 'seen from behind, back view, back of the head, facing away from the camera',
+    negative: 'face visible, looking at the camera, head turned back over the shoulder, front view',
+  },
+}
+
+/**
+ * The prompt hint for a whole scene, or null when there is nothing to say. Only emitted when every
+ * character shares a facing - a mixed scene has no single true statement, and a wrong global hint is
+ * worse than none.
+ */
+export function facingPromptHint(
+  labels: readonly (Facing | null)[],
+): { positive: string; negative: string } | null {
+  const known = labels.filter((l): l is Facing => l !== null)
+  if (!known.length || known.some((l) => l !== known[0])) return null
+  const hint = FACING_PROMPT[known[0]]
+  return hint.positive ? hint : null
+}
+
+/**
+ * Distance to the nearest ground-plane point the camera can see - the bottom edge of the frame,
+ * which is the closest surface in the map once a floor is rendered. Null when the camera looks at or
+ * above the horizon and never sees the ground. The bottom-centre ray is the nearest hit: a corner
+ * ray points less steeply downward once normalized, so it lands farther away.
+ */
+export function nearestGroundHit(
+  camPos: Vec3,
+  forward: Vec3,
+  up: Vec3,
+  fovDeg: number,
+  groundY = 0,
+): number | null {
+  const t = Math.tan((fovDeg * Math.PI) / 360)
+  const dir = norm([forward[0] - up[0] * t, forward[1] - up[1] * t, forward[2] - up[2] * t])
+  if (dir[1] >= -1e-6) return null
+  const distance = (groundY - camPos[1]) / dir[1]
+  return distance > 0 ? distance : null
+}
+
+/**
+ * The camera-distance range a depth map should span, plus where to put the backdrop.
+ *
+ * A depth ControlNet is trained on monocular depth estimates of real photos: dense, full-frame, and
+ * using the whole 0-255 range. So `near` is the nearest surface actually in frame (the floor at the
+ * bottom edge, else the closest body), and `far` sits a little past the backdrop so the background
+ * lands on a dark grey rather than the pure black that reads as "no depth here".
+ */
+export function depthRange(
+  characters: readonly (readonly Vec3[])[],
+  camPos: Vec3,
+  groundNear: number | null = null,
+): { near: number; far: number; backdrop: number } {
+  let dmin = Infinity
+  let dmax = -Infinity
+  for (const joints of characters) {
+    for (const [x, y, z] of joints) {
+      const d = Math.hypot(x - camPos[0], y - camPos[1], z - camPos[2])
+      if (d < dmin) dmin = d
+      if (d > dmax) dmax = d
+    }
+  }
+  if (!isFinite(dmin)) return { near: 0.05, far: 1, backdrop: 0.8 }
+  const skin = 0.15 // a torso capsule radius: the body surface sits this far in front of its joints
+  const backdrop = dmax + skin + 1.2
+  const near = Math.max(0.05, Math.min(dmin - skin, groundNear ?? Infinity))
+  return { near, far: backdrop + 0.15 * (backdrop - near), backdrop }
 }
 
 export interface Point2D {

--- a/src/renderer/views/ControlSpace/skeleton.ts
+++ b/src/renderer/views/ControlSpace/skeleton.ts
@@ -1,0 +1,209 @@
+/**
+ * The OpenPose BODY-18 (COCO) skeleton: keypoint order, limb connections, the canonical color
+ * palette, a few default 3D poses, and a 2D renderer that draws the skeleton as the control image a
+ * pose ControlNet expects. Pure and framework-free so it can be unit tested; the 3D editor projects
+ * its rig joints to 2D screen coordinates and hands them to `drawOpenPose`.
+ */
+
+/** COCO / OpenPose BODY-18 keypoint order (index === position in every array below). */
+export const KEYPOINTS = [
+  'nose',
+  'neck',
+  'r-shoulder',
+  'r-elbow',
+  'r-wrist',
+  'l-shoulder',
+  'l-elbow',
+  'l-wrist',
+  'r-hip',
+  'r-knee',
+  'r-ankle',
+  'l-hip',
+  'l-knee',
+  'l-ankle',
+  'r-eye',
+  'l-eye',
+  'r-ear',
+  'l-ear',
+] as const
+
+export const KEYPOINT_COUNT = KEYPOINTS.length
+
+/** The limb connections OpenPose draws, in the canonical order the color palette is keyed to. */
+export const LIMBS: readonly [number, number][] = [
+  [1, 2],
+  [1, 5],
+  [2, 3],
+  [3, 4],
+  [5, 6],
+  [6, 7],
+  [1, 8],
+  [8, 9],
+  [9, 10],
+  [1, 11],
+  [11, 12],
+  [12, 13],
+  [1, 0],
+  [0, 14],
+  [14, 16],
+  [0, 15],
+  [15, 17],
+]
+
+/** The canonical OpenPose limb/keypoint color palette (18 hues around the wheel). */
+export const POSE_COLORS: readonly string[] = [
+  'rgb(255,0,0)',
+  'rgb(255,85,0)',
+  'rgb(255,170,0)',
+  'rgb(255,255,0)',
+  'rgb(170,255,0)',
+  'rgb(85,255,0)',
+  'rgb(0,255,0)',
+  'rgb(0,255,85)',
+  'rgb(0,255,170)',
+  'rgb(0,255,255)',
+  'rgb(0,170,255)',
+  'rgb(0,85,255)',
+  'rgb(0,0,255)',
+  'rgb(85,0,255)',
+  'rgb(170,0,255)',
+  'rgb(255,0,255)',
+  'rgb(255,0,170)',
+  'rgb(255,0,85)',
+]
+
+export type Vec3 = readonly [number, number, number]
+
+/** A rest pose: standing, facing +Z, Y up, roughly 1.7 units tall. Indexed by KEYPOINTS order. */
+export const STANDING: readonly Vec3[] = [
+  [0, 1.62, 0.05],
+  [0, 1.45, 0],
+  [-0.18, 1.45, 0],
+  [-0.2, 1.15, 0],
+  [-0.22, 0.9, 0],
+  [0.18, 1.45, 0],
+  [0.2, 1.15, 0],
+  [0.22, 0.9, 0],
+  [-0.1, 1.0, 0],
+  [-0.11, 0.55, 0],
+  [-0.11, 0.08, 0],
+  [0.1, 1.0, 0],
+  [0.11, 0.55, 0],
+  [0.11, 0.08, 0],
+  [-0.03, 1.66, 0.07],
+  [0.03, 1.66, 0.07],
+  [-0.07, 1.64, 0.02],
+  [0.07, 1.64, 0.02],
+]
+
+/** Sitting: hips + knees bent forward, feet under the knees. */
+export const SITTING: readonly Vec3[] = [
+  [0, 1.12, 0.05],
+  [0, 0.95, 0],
+  [-0.18, 0.95, 0],
+  [-0.2, 0.68, 0.05],
+  [-0.22, 0.5, 0.2],
+  [0.18, 0.95, 0],
+  [0.2, 0.68, 0.05],
+  [0.22, 0.5, 0.2],
+  [-0.1, 0.5, 0],
+  [-0.12, 0.45, 0.35],
+  [-0.12, 0.08, 0.35],
+  [0.1, 0.5, 0],
+  [0.12, 0.45, 0.35],
+  [0.12, 0.08, 0.35],
+  [-0.03, 1.16, 0.07],
+  [0.03, 1.16, 0.07],
+  [-0.07, 1.14, 0.02],
+  [0.07, 1.14, 0.02],
+]
+
+/** Lying: the standing pose laid along +X (a 90 degree tilt), head to the right. */
+export const LYING: readonly Vec3[] = STANDING.map(([x, y, z]) => [y - 0.85, -x + 0.9, z]) as Vec3[]
+
+export const PRESETS: Record<string, readonly Vec3[]> = {
+  standing: STANDING,
+  sitting: SITTING,
+  lying: LYING,
+}
+
+/** Mean position of a pose's joints (its rough center of mass). */
+export function centroid(joints: readonly Vec3[]): Vec3 {
+  const n = joints.length || 1
+  let sx = 0
+  let sy = 0
+  let sz = 0
+  for (const [x, y, z] of joints) {
+    sx += x
+    sy += y
+    sz += z
+  }
+  return [sx / n, sy / n, sz / n]
+}
+
+/** Rotate a pose about its centroid on the vertical (Y) axis. A half turn (Math.PI) faces the
+ * character the other way, which is how front/back is posed for the control map. */
+export function rotatePoseY(joints: readonly Vec3[], angle: number): Vec3[] {
+  const [cx, , cz] = centroid(joints)
+  const cos = Math.cos(angle)
+  const sin = Math.sin(angle)
+  return joints.map(([x, y, z]) => {
+    const dx = x - cx
+    const dz = z - cz
+    return [cx + dx * cos + dz * sin, y, cz - dx * sin + dz * cos] as Vec3
+  })
+}
+
+/** Shift every joint of a pose by a fixed offset (used to space multiple characters apart). */
+export function translatePose(joints: readonly Vec3[], dx: number, dy: number, dz: number): Vec3[] {
+  return joints.map(([x, y, z]) => [x + dx, y + dy, z + dz] as Vec3)
+}
+
+export interface Point2D {
+  /** Pixel coordinates in the control image. */
+  x: number
+  y: number
+  /** False when the joint is behind the camera / culled; its limbs/dot are skipped. */
+  visible: boolean
+}
+
+/**
+ * Draw the skeleton onto a 2D context as an OpenPose control map: black background, colored limb
+ * bones, colored keypoint dots. `points` are pixel coordinates (already projected from 3D), one per
+ * KEYPOINTS index. Multiple characters are drawn by calling this once per character onto the same
+ * context (pass `clear: false` after the first).
+ */
+export function drawOpenPose(
+  ctx: CanvasRenderingContext2D,
+  points: Point2D[],
+  width: number,
+  height: number,
+  clear = true,
+): void {
+  if (clear) {
+    ctx.fillStyle = 'black'
+    ctx.fillRect(0, 0, width, height)
+  }
+  const dot = Math.max(3, Math.round(width / 220))
+  const bone = Math.max(2, Math.round(width / 260))
+
+  ctx.lineCap = 'round'
+  LIMBS.forEach(([a, b], i) => {
+    const p = points[a]
+    const q = points[b]
+    if (!p?.visible || !q?.visible) return
+    ctx.strokeStyle = POSE_COLORS[i % POSE_COLORS.length]
+    ctx.lineWidth = bone
+    ctx.beginPath()
+    ctx.moveTo(p.x, p.y)
+    ctx.lineTo(q.x, q.y)
+    ctx.stroke()
+  })
+  points.forEach((p, i) => {
+    if (!p?.visible) return
+    ctx.fillStyle = POSE_COLORS[i % POSE_COLORS.length]
+    ctx.beginPath()
+    ctx.arc(p.x, p.y, dot, 0, Math.PI * 2)
+    ctx.fill()
+  })
+}

--- a/src/renderer/views/Library/OutputThumb.tsx
+++ b/src/renderer/views/Library/OutputThumb.tsx
@@ -44,7 +44,7 @@ export function OutputThumb({
       // Frame payload → drop on a node feeds it as input; output payload → drop on canvas creates a
       // new frame fed by this output. The take id pins the exact image dragged.
       setFrameDragPayload(e.dataTransfer, frameId)
-      setOutputDragPayload(e.dataTransfer, frameId, id)
+      setOutputDragPayload(e.dataTransfer, frameId, id, filePath)
     } else {
       // Core-node output: no frame, so carry the raw file for the drop target to import.
       setMediaFileDragPayload(e.dataTransfer, { filePath, kind, name: `${label}.${extFor(kind)}` })

--- a/src/renderer/views/Moodboard/AddNodeMenu.tsx
+++ b/src/renderer/views/Moodboard/AddNodeMenu.tsx
@@ -17,7 +17,14 @@ import { isExtensionNode, extensionOf } from '@shared/extensions'
 import { listNodeDefs, groupByOwner } from '@shared/nodes/registry'
 
 /** The node kinds the Add menu can create (Text has its own toolbar tool, so it's not here). */
-export type AddNodeKind = 'load' | 'layer' | 'preview' | 'director' | 'trim' | 'prompt'
+export type AddNodeKind =
+  | 'load'
+  | 'layer'
+  | 'preview'
+  | 'director'
+  | 'trim'
+  | 'prompt'
+  | 'controlSpace'
 
 type Tab = 'core' | 'api'
 
@@ -46,6 +53,7 @@ const ENTRIES: Entry[] = [
   { kind: 'director', label: 'Video Director', icon: <ClapperboardIcon />, category: CANVAS },
   { kind: 'trim', label: 'Edit Video/Audio', icon: <ScissorsIcon />, category: CANVAS },
   { kind: 'prompt', label: 'Prompt', icon: <PromptIcon />, category: CANVAS },
+  { kind: 'controlSpace', label: 'Control Space', icon: <PoseIcon />, category: CANVAS },
 ]
 
 export function AddNodeMenu({
@@ -325,6 +333,18 @@ function ImageIcon(): React.JSX.Element {
       <rect x="3" y="3" width="18" height="18" rx="2" />
       <circle cx="8.5" cy="8.5" r="1.5" />
       <path d="M21 15l-5-5L5 21" />
+    </Svg>
+  )
+}
+
+function PoseIcon(): React.JSX.Element {
+  return (
+    <Svg>
+      <circle cx="12" cy="5" r="2" />
+      <path d="M12 7v6" />
+      <path d="M8 9h8" />
+      <path d="m12 13-3 6" />
+      <path d="m12 13 3 6" />
     </Svg>
   )
 }

--- a/src/renderer/views/Moodboard/CoreParamWidget.tsx
+++ b/src/renderer/views/Moodboard/CoreParamWidget.tsx
@@ -118,6 +118,19 @@ function NumberField({
     }
   }, [external])
 
+  // Emit while typing so the value registers immediately (not only on blur). A finite entry commits
+  // live (unclamped, so mid-typing "5" toward "512" isn't yanked to the min); an empty/partial box is
+  // left alone until blur resolves it to the clamped value or the default.
+  const emit = (raw: string): void => {
+    setDraft(raw)
+    if (raw.trim() === '') return
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed)) {
+      lastExternal.current = parsed
+      onCommit(parsed)
+    }
+  }
+
   const commit = (): void => {
     const parsed = draft.trim() === '' ? Number(field.default) : Number(draft)
     const resolved = Number.isFinite(parsed)
@@ -137,7 +150,7 @@ function NumberField({
         min={field.min}
         max={field.max}
         step={field.step}
-        onChange={(e) => setDraft(e.target.value)}
+        onChange={(e) => emit(e.target.value)}
         onBlur={commit}
         className={inputCls}
       />

--- a/src/renderer/views/Moodboard/CoreParamWidget.tsx
+++ b/src/renderer/views/Moodboard/CoreParamWidget.tsx
@@ -37,6 +37,13 @@ export function CoreParamWidget({
     )
   }
   if (field.widget === 'select') {
+    const options = field.options ?? []
+    // A file-picker whose empty value means "none"/"auto" needs an explicit empty option, or the
+    // native select shows the FIRST file while the value is really "" - which reads as picked when
+    // it isn't (e.g. the ControlNet dropdown looked set but control was actually off).
+    const needsEmpty =
+      !options.some((o) => o.value === '') && (field.default === '' || field.optionsFrom != null)
+    const emptyLabel = field.optionsFrom === 'controlnet' ? 'None' : 'Auto'
     return (
       <label className="flex flex-col gap-1">
         <span className={labelCls}>{field.label}</span>
@@ -45,7 +52,8 @@ export function CoreParamWidget({
           onChange={(e) => onCommit(e.target.value)}
           className={inputCls}
         >
-          {(field.options ?? []).map((o) => (
+          {needsEmpty && <option value="">{emptyLabel}</option>}
+          {options.map((o) => (
             <option key={o.value} value={o.value}>
               {o.label}
             </option>

--- a/src/renderer/views/Moodboard/MoodboardPanel.tsx
+++ b/src/renderer/views/Moodboard/MoodboardPanel.tsx
@@ -42,6 +42,7 @@ import {
   getFrameDragId,
   getMediaFileDrag,
   getOutputDragId,
+  getOutputFilePath,
   getOutputTakeId,
 } from '../../lib/dnd'
 import { ImageNode } from './nodes/ImageNode'
@@ -808,25 +809,16 @@ function Board(): React.JSX.Element {
     // into the Library, then drop a Load Assets loader fed by it at the drop point.
     const media = getMediaFileDrag(e.dataTransfer)
     if (media) {
-      const loadAsAsset = async (): Promise<void> => {
-        const asset = await importMediaUrlToLibrary(resolveMedia(media.filePath), media.name)
-        if (!asset) return
-        // Surface the imported asset in the store, or the loader can't resolve its input thumb
-        // (resolveInputThumbs drops any input whose asset isn't loaded) and shows "no media".
-        await loadAssets()
-        const loader = await addLoader(drop.x, drop.y)
-        if (loader) await addLoaderAssets(loader.id, [asset.id])
-      }
       // A generated PNG carries the recipe that made it → offer to rebuild the graph instead.
       if (media.kind === 'image') {
         void (async () => {
           const blob = await fetch(resolveMedia(media.filePath))
             .then((r) => r.blob())
             .catch(() => null)
-          await offerRecipeOrRun(blob, drop, () => void loadAsAsset())
+          await offerRecipeOrRun(blob, drop, () => void loadImageAsAsset(media.filePath, drop))
         })()
       } else {
-        void loadAsAsset()
+        void loadImageAsAsset(media.filePath, drop)
       }
       return
     }
@@ -836,11 +828,28 @@ function Board(): React.JSX.Element {
     const outputFrameId = getOutputDragId(e.dataTransfer)
     if (outputFrameId) {
       const takeId = getOutputTakeId(e.dataTransfer)
-      void (async () => {
+      const outPath = getOutputFilePath(e.dataTransfer)
+      const newFrameFromOutput = async (): Promise<void> => {
         if (takeId) await setHero(outputFrameId, takeId)
         const item = await addEmptyFrame(drop.x, drop.y)
         if (item?.frameId) await addSourceInput(item.frameId, outputFrameId)
-      })()
+      }
+      // A fal PNG output carries its recipe → offer to rebuild the graph; else the default flow.
+      if (outPath && outPath.toLowerCase().endsWith('.png')) {
+        void (async () => {
+          const blob = await fetch(resolveMedia(outPath))
+            .then((r) => r.blob())
+            .catch(() => null)
+          const recipe = blob ? await readRecipeFromBlob(blob) : null
+          if (recipe?.graph?.items?.length) {
+            setRecipeChoice({ recipe, drop, onAsset: () => void loadImageAsAsset(outPath, drop) })
+          } else {
+            void newFrameFromOutput()
+          }
+        })()
+      } else {
+        void newFrameFromOutput()
+      }
       return
     }
 
@@ -871,6 +880,21 @@ function Board(): React.JSX.Element {
       return
     }
     placeAssetsAt(ids, drop)
+  }
+
+  /** Import an image at a project-relative path into the Library, then drop a Load Assets loader fed
+   * by it (the "Load as asset" action for a dropped generation). */
+  const loadImageAsAsset = async (
+    filePath: string,
+    drop: { x: number; y: number },
+  ): Promise<void> => {
+    const name = filePath.split('/').pop() || 'image.png'
+    const asset = await importMediaUrlToLibrary(resolveMedia(filePath), name)
+    if (!asset) return
+    // Surface the imported asset in the store, or the loader can't resolve its input thumb.
+    await loadAssets()
+    const loader = await addLoader(drop.x, drop.y)
+    if (loader) await addLoaderAssets(loader.id, [asset.id])
   }
 
   /** Read a recipe from the dropped image; if present, prompt Load-graph vs Load-as-asset, else run

--- a/src/renderer/views/Moodboard/MoodboardPanel.tsx
+++ b/src/renderer/views/Moodboard/MoodboardPanel.tsx
@@ -60,12 +60,16 @@ import { LayerNode } from './nodes/LayerNode'
 import { DirectorNode } from './nodes/DirectorNode'
 import { TrimNode } from './nodes/TrimNode'
 import { LoaderNode } from './nodes/LoaderNode'
+import { ControlSpaceNode } from './nodes/ControlSpaceNode'
 import { GraphNode } from './nodes/GraphNode'
 import { ResourceNode } from './nodes/ResourceNode'
 import { DeletableEdge } from './edges/DeletableEdge'
 import { SideMenu } from './SideMenu'
 import { CanvasToolbar } from './CanvasToolbar'
 import { AddNodeMenu, type AddNodeKind } from './AddNodeMenu'
+import { Modal } from '../../components/Modal'
+import { readRecipeFromBlob, type Recipe } from '../../lib/pngRecipe'
+import { buildGraphFromRecipe } from '../../lib/recipeGraph'
 import { FrameInspector } from './FrameInspector'
 import { CheckIcon, CloseIcon, CopyIcon } from '../../components/icons'
 
@@ -93,6 +97,7 @@ const nodeTypes: NodeTypes = {
   trim: TrimNode,
   prompt: PromptNode,
   loader: LoaderNode,
+  controlSpace: ControlSpaceNode,
   core: GraphNode,
   resource: ResourceNode,
 }
@@ -260,6 +265,7 @@ function Board(): React.JSX.Element {
   const addTrim = useMoodboardStore((s) => s.addTrim)
   const addEmptyFrame = useMoodboardStore((s) => s.addEmptyFrame)
   const addLoader = useMoodboardStore((s) => s.addLoader)
+  const addControlSpace = useMoodboardStore((s) => s.addControlSpace)
   const addLoaderAssets = useMoodboardStore((s) => s.addLoaderAssets)
   const addPrompt = useMoodboardStore((s) => s.addPrompt)
   const addCoreNode = useMoodboardStore((s) => s.addCoreNode)
@@ -300,6 +306,12 @@ function Board(): React.JSX.Element {
   } | null>(null)
   // Active canvas tool: Select (edit - marquee/move) vs Pan (view - drag pans, nodes locked).
   const [tool, setTool] = useState<'select' | 'pan'>('select')
+  // A dropped Inline image that carries a recipe: offer "Load graph" vs "Load as asset".
+  const [recipeChoice, setRecipeChoice] = useState<{
+    recipe: Recipe
+    drop: { x: number; y: number }
+    onAsset: () => void
+  } | null>(null)
   // "Add node" list (toolbar + button, or double-click empty canvas in Select mode).
   const [addMenu, setAddMenu] = useState<{
     x: number
@@ -716,6 +728,9 @@ function Board(): React.JSX.Element {
       case 'prompt':
         void addPrompt(m.flowX, m.flowY)
         break
+      case 'controlSpace':
+        void addControlSpace(m.flowX, m.flowY)
+        break
     }
   }
 
@@ -793,7 +808,7 @@ function Board(): React.JSX.Element {
     // into the Library, then drop a Load Assets loader fed by it at the drop point.
     const media = getMediaFileDrag(e.dataTransfer)
     if (media) {
-      void (async () => {
+      const loadAsAsset = async (): Promise<void> => {
         const asset = await importMediaUrlToLibrary(resolveMedia(media.filePath), media.name)
         if (!asset) return
         // Surface the imported asset in the store, or the loader can't resolve its input thumb
@@ -801,7 +816,18 @@ function Board(): React.JSX.Element {
         await loadAssets()
         const loader = await addLoader(drop.x, drop.y)
         if (loader) await addLoaderAssets(loader.id, [asset.id])
-      })()
+      }
+      // A generated PNG carries the recipe that made it → offer to rebuild the graph instead.
+      if (media.kind === 'image') {
+        void (async () => {
+          const blob = await fetch(resolveMedia(media.filePath))
+            .then((r) => r.blob())
+            .catch(() => null)
+          await offerRecipeOrRun(blob, drop, () => void loadAsAsset())
+        })()
+      } else {
+        void loadAsAsset()
+      }
       return
     }
 
@@ -832,12 +858,31 @@ function Board(): React.JSX.Element {
 
     const ids = getAssetDragIds(e.dataTransfer)
     if (ids.length === 0) {
-      // Files dropped from the OS → import into the library, then place as frames.
+      // Files dropped from the OS → import into the library, then place as frames. A shared Inline
+      // PNG carries its recipe, so offer to rebuild the graph instead of just importing it.
       const files = Array.from(e.dataTransfer.files ?? [])
-      if (files.length > 0) void placeDroppedFiles(files, drop)
+      if (files.length === 0) return
+      const png = files.find((f) => f.type === 'image/png')
+      if (png && files.length === 1) {
+        void offerRecipeOrRun(png, drop, () => void placeDroppedFiles(files, drop))
+      } else {
+        void placeDroppedFiles(files, drop)
+      }
       return
     }
     placeAssetsAt(ids, drop)
+  }
+
+  /** Read a recipe from the dropped image; if present, prompt Load-graph vs Load-as-asset, else run
+   * the asset fallback directly. */
+  const offerRecipeOrRun = async (
+    blob: Blob | null,
+    drop: { x: number; y: number },
+    onAsset: () => void,
+  ): Promise<void> => {
+    const recipe = blob ? await readRecipeFromBlob(blob) : null
+    if (recipe?.graph?.items?.length) setRecipeChoice({ recipe, drop, onAsset })
+    else onAsset()
   }
 
   /** Place existing library assets as frames at/near a drop point (cascaded). */
@@ -1038,6 +1083,49 @@ function Board(): React.JSX.Element {
         <CoreSettingsPanel />
         <ModelInfoPanel />
         <ModelRequirementsModal />
+
+        <Modal
+          open={recipeChoice !== null}
+          onClose={() => setRecipeChoice(null)}
+          title="This image carries its graph"
+        >
+          {recipeChoice && (
+            <div className="flex flex-col gap-4 p-5">
+              <p className="text-sm text-zinc-300">
+                This Inline image embeds the graph that generated it
+                {recipeChoice.recipe.prompt ? (
+                  <>
+                    {' '}
+                    (<span className="text-zinc-400">“{recipeChoice.recipe.prompt}”</span>)
+                  </>
+                ) : null}
+                . Rebuild that graph on the canvas, or just add the image as an asset?
+              </p>
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={() => {
+                    const c = recipeChoice
+                    setRecipeChoice(null)
+                    c.onAsset()
+                  }}
+                  className="rounded-md border border-border px-3 py-1.5 text-sm text-zinc-200 hover:bg-panel"
+                >
+                  Load as asset
+                </button>
+                <button
+                  onClick={() => {
+                    const c = recipeChoice
+                    setRecipeChoice(null)
+                    void buildGraphFromRecipe(c.recipe, c.drop)
+                  }}
+                  className="rounded-md border border-emerald-700 bg-emerald-600/20 px-3 py-1.5 text-sm text-emerald-200 hover:bg-emerald-600/30"
+                >
+                  Load graph
+                </button>
+              </div>
+            </div>
+          )}
+        </Modal>
       </div>
 
       <FrameInspector />
@@ -1188,6 +1276,9 @@ function itemToNode(
   }
   if (item.type === 'loader') {
     return { ...common, type: 'loader', data: { itemId: item.id } }
+  }
+  if (item.type === 'controlSpace') {
+    return { ...common, type: 'controlSpace', data: { itemId: item.id } }
   }
   if (item.type === 'core') {
     return { ...common, type: 'core', data: { itemId: item.id } }

--- a/src/renderer/views/Moodboard/MoodboardPanel.tsx
+++ b/src/renderer/views/Moodboard/MoodboardPanel.tsx
@@ -28,6 +28,7 @@ import { copyText } from '@/lib/clipboard'
 import type { MoodboardItem, MoodboardConnector, TextItemData, Frame, Asset } from '@shared/types'
 import { portKindColor, portsSatisfy, type NodeDescriptor, type PortKind } from '@shared/coreNodes'
 import { useMoodboardStore } from '../../store/moodboardStore'
+import { useProjectStore } from '../../store/projectStore'
 import { useCoreNodesStore } from '../../store/coreNodesStore'
 import { useGraphSelectionStore } from '../../store/graphSelectionStore'
 import { expandToGraphs, runTargets, toEdges } from './graphSelection'
@@ -84,6 +85,31 @@ function FrameNodeSwitch(props: NodeProps): React.JSX.Element {
   const provider = useFrameStore((s) => s.frames.find((f) => f.id === frameId)?.provider)
   if (!loader && provider === 'fal') return <GenNode {...props} />
   return <FrameNode {...props} />
+}
+
+/** Per-project canvas pan/zoom, so a project reopens where the user left it. Best-effort localStorage
+ * (per browser); a blocked/full store just falls back to fit-all. */
+const viewportKey = (id: string): string => `inline:viewport:${id}`
+
+function readViewport(id: string): { x: number; y: number; zoom: number } | null {
+  try {
+    const raw = localStorage.getItem(viewportKey(id))
+    const v = raw ? (JSON.parse(raw) as { x?: number; y?: number; zoom?: number }) : null
+    if (v && typeof v.x === 'number' && typeof v.y === 'number' && typeof v.zoom === 'number') {
+      return { x: v.x, y: v.y, zoom: v.zoom }
+    }
+  } catch {
+    /* corrupt or unavailable storage */
+  }
+  return null
+}
+
+function writeViewport(id: string, v: { x: number; y: number; zoom: number }): void {
+  try {
+    localStorage.setItem(viewportKey(id), JSON.stringify(v))
+  } catch {
+    /* storage full or blocked */
+  }
 }
 
 const nodeTypes: NodeTypes = {
@@ -290,7 +316,11 @@ function Board(): React.JSX.Element {
   const setCanvasSelection = useUiStore((s) => s.setCanvasSelection)
   const setCanvasCenter = useUiStore((s) => s.setCanvasCenter)
   const wrapperRef = useRef<HTMLDivElement>(null)
-  const { screenToFlowPosition, getNodes } = useReactFlow()
+  const { screenToFlowPosition, getNodes, getViewport, setViewport, fitView } = useReactFlow()
+  const projectId = useProjectStore((s) => s.current?.id ?? null)
+  // Restore the canvas pan/zoom where the user left it, once per project open (after its board
+  // loads); a project with no saved view falls back to fit-all.
+  const restoredFor = useRef<string | null>(null)
   const updateNodeInternals = useUpdateNodeInternals()
   const [nodes, setNodes] = useNodesState<Node>([])
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
@@ -328,6 +358,16 @@ function Board(): React.JSX.Element {
     void loadAssets()
     void loadFrames()
   }, [load, loadAssets, loadFrames])
+
+  // Once a project's board has loaded, restore the pan/zoom the user left it at (or fit-all if none).
+  // Guarded so it runs once per project open, after nodes exist (fitView needs them).
+  useEffect(() => {
+    if (!projectId || items.length === 0 || restoredFor.current === projectId) return
+    restoredFor.current = projectId
+    const saved = readViewport(projectId)
+    if (saved) void setViewport(saved)
+    else void fitView({ maxZoom: 1 })
+  }, [projectId, items.length, setViewport, fitView])
 
   const assetsById = useMemo(() => new Map(assets.map((a) => [a.id, a])), [assets])
 
@@ -580,6 +620,9 @@ function Board(): React.JSX.Element {
     side: 'input' | 'output',
   ): PortKind | null => {
     const item = items.find((it) => it.id === itemId)
+    // Control Space emits a control map, not a plain image: kind it 'control' so it can only feed a
+    // gen node's Control input, never the img2img Image input (which would ignore the pose).
+    if (item?.type === 'controlSpace' && side === 'output') return 'control'
     const core = item?.type === 'core' ? item.data.core : undefined
     if (!core) return null
     const descriptor = coreDescriptors.find((d) => d.type === core.type)
@@ -1021,6 +1064,10 @@ function Board(): React.JSX.Element {
           onEdgesDelete={(deleted) => deleted.forEach((e) => void disconnect(e.id))}
           // Mirror the viewport so the assistant can use it as a "place here" spot.
           onMove={() => setCanvasCenter(centre())}
+          // Persist pan/zoom per project so it reopens where the user left it (see the restore effect).
+          onMoveEnd={() => {
+            if (projectId) writeViewport(projectId, getViewport())
+          }}
           onInit={() => setCanvasCenter(centre())}
           proOptions={{ hideAttribution: true }}
           minZoom={0.1}
@@ -1029,10 +1076,6 @@ function Board(): React.JSX.Element {
           // compositing layer small - with nodes spread far apart, the full layer can
           // exceed the GPU's max texture size and render as grey/blank when scrolling.
           onlyRenderVisibleElements
-          fitView
-          // Cap the initial fit's zoom so a board with a single small node (e.g. a new project's
-          // chooser) lands at a normal 1:1 view instead of blowing up to fill the viewport.
-          fitViewOptions={{ maxZoom: 1 }}
         >
           <Background gap={22} size={2.5} color="#525a66" />
         </ReactFlow>

--- a/src/renderer/views/Moodboard/nodes/ControlSpaceNode.tsx
+++ b/src/renderer/views/Moodboard/nodes/ControlSpaceNode.tsx
@@ -34,6 +34,8 @@ export function ControlSpaceNode({ id, selected }: NodeProps): React.JSX.Element
   const assetId = item?.data.controlAssetId
   const asset = assetId ? assets.find((a) => a.id === assetId) : undefined
   const src = asset ? resolveMedia(asset.filePath) : null
+  const scene = item?.data.controlScene
+  const hint = (scene?.applyPromptHint ?? true) ? (scene?.promptHint ?? null) : null
   const suggested = reqs?.components.find((c) => c.optional && !c.present) ?? null
   const suggestedPct = suggestedDl ? Math.round(suggestedDl.fraction * 100) : null
 
@@ -76,7 +78,15 @@ export function ControlSpaceNode({ id, selected }: NodeProps): React.JSX.Element
             )}
           </div>
 
-          <div className="flex items-center justify-end border-t border-border bg-surface/90 px-2 py-1">
+          <div className="flex items-center justify-between gap-2 border-t border-border bg-surface/90 px-2 py-1">
+            {/* The facing text this node adds to a downstream prompt - the control map itself has no
+                way to say "facing away", so it is worth surfacing where the wiring is visible. */}
+            <span
+              className="truncate text-[10px] text-zinc-500"
+              title={hint ? `Adds to the prompt: “${hint.positive}”` : undefined}
+            >
+              {hint ? '+ facing in prompt' : ''}
+            </span>
             <button
               onClick={() => openEditor(id)}
               title="Open the 3D pose editor"

--- a/src/renderer/views/Moodboard/nodes/ControlSpaceNode.tsx
+++ b/src/renderer/views/Moodboard/nodes/ControlSpaceNode.tsx
@@ -1,0 +1,105 @@
+import { useEffect } from 'react'
+import { Handle, Position, type NodeProps } from '@xyflow/react'
+import { resolveMedia } from '@/lib/media'
+import { useAssetStore } from '../../../store/assetStore'
+import { useMoodboardStore } from '../../../store/moodboardStore'
+import { useControlSpaceStore } from '../../../store/controlSpaceStore'
+import { useModelRequirementsStore } from '../../../store/modelRequirementsStore'
+import { NodeFrame } from './NodeFrame'
+import { BoxIcon, DownloadIcon, NodeBadge, NodeBadgeRow } from './NodeBadge'
+
+// Reuse the shared requirements/download flow under this pseudo node type (a Core provider is
+// registered for it), so the global popup + progress events cover Control Space too.
+const REQ_TYPE = 'controlSpace'
+
+/**
+ * "Control Space": a source node whose face shows the last rendered OpenPose control map and opens
+ * the full-screen 3D pose editor. Its render (a library asset in `data.controlAssetId`) feeds a gen
+ * node's control input via the output handle. When no ControlNet model is on disk it offers a
+ * one-click download (the map needs a ControlNet downstream to actually steer generation).
+ */
+export function ControlSpaceNode({ id, selected }: NodeProps): React.JSX.Element {
+  const item = useMoodboardStore((s) => s.items.find((it) => it.id === id))
+  const assets = useAssetStore((s) => s.assets)
+  const openEditor = useControlSpaceStore((s) => s.open)
+  const loadReqs = useModelRequirementsStore((s) => s.load)
+  const openReqs = useModelRequirementsStore((s) => s.open)
+  const reqs = useModelRequirementsStore((s) => s.byType[REQ_TYPE])
+  const suggestedDl = useModelRequirementsStore((s) => s.downloads[REQ_TYPE]?.controlnet)
+
+  useEffect(() => {
+    void loadReqs(REQ_TYPE)
+  }, [loadReqs])
+
+  const assetId = item?.data.controlAssetId
+  const asset = assetId ? assets.find((a) => a.id === assetId) : undefined
+  const src = asset ? resolveMedia(asset.filePath) : null
+  const suggested = reqs?.components.find((c) => c.optional && !c.present) ?? null
+  const suggestedPct = suggestedDl ? Math.round(suggestedDl.fraction * 100) : null
+
+  return (
+    <>
+      <NodeBadgeRow dragNodeId={id}>
+        <NodeBadge icon={<BoxIcon />} title="Control Space">
+          Control Space
+        </NodeBadge>
+        {suggested && (
+          <button
+            onClick={() => openReqs(REQ_TYPE)}
+            title={`${suggested.label} - optional download so this map can steer a ControlNet gen`}
+            className="nodrag flex h-6 items-center gap-1 rounded-full border border-border bg-panel/80 px-2 text-[10px] font-medium text-zinc-300 shadow-sm backdrop-blur hover:border-emerald-500/40 hover:text-emerald-300"
+          >
+            <DownloadIcon className="h-3.5 w-3.5" />
+            {suggestedDl && !suggestedDl.error ? `ControlNet ${suggestedPct}%` : 'Get ControlNet'}
+          </button>
+        )}
+      </NodeBadgeRow>
+
+      <NodeFrame
+        id={id}
+        selected={!!selected}
+        minWidth={200}
+        minHeight={200}
+        padded={false}
+        subtleSelect
+      >
+        <div className="relative flex h-full w-full flex-col">
+          <div className="relative flex flex-1 items-center justify-center overflow-hidden bg-black">
+            {src ? (
+              <img src={src} alt="Pose control map" className="h-full w-full object-contain" />
+            ) : (
+              <div className="flex flex-col items-center gap-2 p-3 text-center">
+                <span className="text-[11px] text-zinc-500">
+                  Pose a 3D character, then render an OpenPose control map.
+                </span>
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center justify-end border-t border-border bg-surface/90 px-2 py-1">
+            <button
+              onClick={() => openEditor(id)}
+              title="Open the 3D pose editor"
+              className="nodrag flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-zinc-200 hover:bg-black/40 hover:text-white"
+            >
+              <BoxIcon className="h-3 w-3" />
+              {src ? 'Edit pose' : 'Open Control Space'}
+            </button>
+          </div>
+        </div>
+      </NodeFrame>
+
+      <Handle
+        type="source"
+        id="out"
+        position={Position.Right}
+        title="Control map"
+        className="group !h-3 !w-3 !border-2 !border-surface !bg-pink-300"
+      >
+        <span className="pointer-events-none absolute left-full top-1/2 ml-1.5 hidden -translate-y-1/2 items-center whitespace-nowrap rounded-md border border-border bg-panel/95 px-1.5 py-0.5 text-[10px] font-medium text-zinc-200 shadow-sm backdrop-blur group-hover:flex">
+          Control map
+        </span>
+      </Handle>
+    </>
+  )
+}

--- a/src/renderer/views/Moodboard/nodes/GraphNode.tsx
+++ b/src/renderer/views/Moodboard/nodes/GraphNode.tsx
@@ -14,6 +14,7 @@ import {
   AdjustIcon,
   AlertIcon,
   BoxIcon,
+  DownloadIcon,
   ImageGlyph,
   NodeBadge,
   NodeBadgeRow,
@@ -99,6 +100,7 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
   const { itemId } = data as GraphNodeData
   const item = useMoodboardStore((s) => s.items.find((i) => i.id === itemId))
   const updateItem = useMoodboardStore((s) => s.updateItem)
+  const setConnectedPromptText = useMoodboardStore((s) => s.setConnectedPromptText)
   const coreType = item?.type === 'core' ? item.data.core?.type : undefined
   const descriptor = useCoreNodesStore((s) =>
     coreType ? s.descriptors.find((d) => d.type === coreType) : undefined,
@@ -178,8 +180,16 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
   // carry a single `output` - treat that as a one-entry history. `output` marks the active take.
   const outputs = core.outputs ?? (core.output ? [core.output] : [])
   const activeTakeId = core.output?.takeId
+  // Switching a take restores that image's recipe non-destructively: its settings onto this node's
+  // params, and its prompt onto the wired prompt node (if one still exists). No nodes are created.
   const setActiveOutput = (o: NonNullable<typeof core.output>): void => {
-    void updateItem(itemId, { data: { ...item.data, core: { ...core, output: o } } })
+    const nextCore = {
+      ...core,
+      output: o,
+      params: o.params ? { ...core.params, ...o.params } : core.params,
+    }
+    void updateItem(itemId, { data: { ...item.data, core: nextCore } })
+    if (typeof o.prompt === 'string') void setConnectedPromptText(itemId, o.prompt)
   }
 
   // Real "models missing" signal from the requirements check (replaces the old options heuristic,
@@ -188,6 +198,14 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
   const modelsMissing = reqs ? !reqs.allPresent : false
   const download = downloadsForType ? activeDownload(downloadsForType, reqs) : null
   const downloadPct = download ? Math.round(download.fraction * 100) : null
+  // A suggested (optional) component that isn't on disk yet - e.g. the opt-in ControlNet. Surfaced
+  // as a soft chip (not the alarming "Models missing" one) so control is one click away.
+  const suggested = reqs?.components.find((c) => c.optional && !c.present) ?? null
+  const suggestedDl = suggested && downloadsForType ? downloadsForType[suggested.id] : undefined
+  const suggestedPct = suggestedDl ? Math.round(suggestedDl.fraction * 100) : null
+  // The soft chip's noun follows the download's category: the annotator weights for Apply ControlNet
+  // read "detectors", the opt-in ControlNet model reads "ControlNet".
+  const suggestNoun = suggested?.category === 'annotators' ? 'detectors' : 'ControlNet'
 
   // A loader/plumbing node (no media output) renders compact - no preview, no Run (it loads with
   // whatever downstream node runs). Generation nodes get the full preview card + the graph Run
@@ -346,6 +364,18 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
             Models
           </button>
         )}
+        {suggested && !modelsMissing && (
+          <button
+            onClick={() => openReqs(descriptor.type)}
+            title={`${suggested.label} - optional download`}
+            className="nodrag flex h-6 items-center gap-1 rounded-full border border-border bg-panel/80 px-2 text-[10px] font-medium text-zinc-300 shadow-sm backdrop-blur hover:border-emerald-500/40 hover:text-emerald-300"
+          >
+            <DownloadIcon className="h-3.5 w-3.5" />
+            {suggestedDl && !suggestedDl.error
+              ? `${suggestNoun} ${suggestedPct}%`
+              : `Get ${suggestNoun}`}
+          </button>
+        )}
       </NodeBadgeRow>
 
       <NodeFrame
@@ -443,6 +473,17 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
                   )}
                 </button>
               ))}
+            </div>
+          )}
+
+          {/* The active take's prompt (restored from its recipe on switch), so the shown image's
+              prompt is visible without opening Adjust. */}
+          {core.output?.prompt && (
+            <div
+              className="shrink-0 truncate border-t border-border bg-surface/90 px-2 py-1 text-[10px] text-zinc-400"
+              title={core.output.prompt}
+            >
+              {core.output.prompt}
             </div>
           )}
 

--- a/src/renderer/views/Moodboard/nodes/GraphNode.tsx
+++ b/src/renderer/views/Moodboard/nodes/GraphNode.tsx
@@ -139,7 +139,14 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
 
   if (!item || item.type !== 'core' || !item.data.core || !descriptor) {
     return (
-      <NodeFrame id={id} selected={!!selected} minWidth={200} minHeight={92} subtleSelect>
+      <NodeFrame
+        id={id}
+        selected={!!selected}
+        minWidth={200}
+        minHeight={92}
+        subtleSelect
+        running={busy}
+      >
         <div className="flex h-full flex-col items-center justify-center gap-1 p-3 text-center">
           {coreType && disabledPack ? (
             // The extension is installed but off, so this is a toggle away from working.
@@ -182,13 +189,17 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
   const activeTakeId = core.output?.takeId
   // Switching a take restores that image's recipe non-destructively: its settings onto this node's
   // params, and its prompt onto the wired prompt node (if one still exists). No nodes are created.
+  // The take's *seed* is deliberately NOT restored - keep the node's current seed so browsing history
+  // never pins a fixed seed (which would make every re-generation identical and turn on the node
+  // cache, so connection/control changes would stop taking effect until the seed was reset).
   const setActiveOutput = (o: NonNullable<typeof core.output>): void => {
-    const nextCore = {
-      ...core,
-      output: o,
-      params: o.params ? { ...core.params, ...o.params } : core.params,
+    let params = core.params
+    if (o.params) {
+      const restored: Record<string, unknown> = { ...o.params }
+      delete restored.seed
+      params = { ...core.params, ...restored }
     }
-    void updateItem(itemId, { data: { ...item.data, core: nextCore } })
+    void updateItem(itemId, { data: { ...item.data, core: { ...core, output: o, params } } })
     if (typeof o.prompt === 'string') void setConnectedPromptText(itemId, o.prompt)
   }
 
@@ -284,6 +295,7 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
           minHeight={44}
           padded={false}
           subtleSelect
+          running={busy}
         >
           <div className="flex h-full w-full flex-col gap-1 px-2 py-1.5">
             {selectParams.length > 0 ? (
@@ -385,6 +397,7 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
         minHeight={200}
         padded={false}
         subtleSelect
+        running={busy}
       >
         <div className="relative flex h-full w-full flex-col">
           {/* Edge-to-edge output preview. */}

--- a/src/renderer/views/Moodboard/nodes/GraphNode.tsx
+++ b/src/renderer/views/Moodboard/nodes/GraphNode.tsx
@@ -8,6 +8,8 @@ import { useGraphSelectionStore } from '../../../store/graphSelectionStore'
 import { useMoodboardStore } from '../../../store/moodboardStore'
 import { activeDownload, useModelRequirementsStore } from '../../../store/modelRequirementsStore'
 import { useExtensionsStore } from '../../../store/extensionsStore'
+import { useLightboxStore } from '../../../store/lightboxStore'
+import { matchControlAspect } from '../../../lib/matchControlAspect'
 import { NodeFrame } from './NodeFrame'
 import { NodeRunToolbar } from './NodeRunToolbar'
 import {
@@ -101,6 +103,8 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
   const item = useMoodboardStore((s) => s.items.find((i) => i.id === itemId))
   const updateItem = useMoodboardStore((s) => s.updateItem)
   const setConnectedPromptText = useMoodboardStore((s) => s.setConnectedPromptText)
+  const connectors = useMoodboardStore((s) => s.connectors)
+  const openLightbox = useLightboxStore((s) => s.open)
   const coreType = item?.type === 'core' ? item.data.core?.type : undefined
   const descriptor = useCoreNodesStore((s) =>
     coreType ? s.descriptors.find((d) => d.type === coreType) : undefined,
@@ -209,14 +213,32 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
   const modelsMissing = reqs ? !reqs.allPresent : false
   const download = downloadsForType ? activeDownload(downloadsForType, reqs) : null
   const downloadPct = download ? Math.round(download.fraction * 100) : null
-  // A suggested (optional) component that isn't on disk yet - e.g. the opt-in ControlNet. Surfaced
-  // as a soft chip (not the alarming "Models missing" one) so control is one click away.
-  const suggested = reqs?.components.find((c) => c.optional && !c.present) ?? null
+  // Apply ControlNet's detector download is scoped to the selected type, so canny never nags for a
+  // model and depth/pose only prompt for the one they use (component ids start with the detector).
+  const applyType = coreType === 'control/apply' ? String(core?.params?.type ?? 'pose') : null
+  const detectorNoun = applyType === 'depth' ? 'MiDaS' : applyType === 'pose' ? 'OpenPose' : null
+  const detectorPrefix = applyType === 'depth' ? 'midas' : applyType === 'pose' ? 'openpose' : null
+  // A suggested (optional) component that isn't on disk yet - the opt-in ControlNet, or (for Apply
+  // ControlNet) the detector its selected type needs. Surfaced as a soft chip, not the "missing" alarm.
+  const suggested = applyType
+    ? detectorPrefix
+      ? (reqs?.components.find((c) => !c.present && c.id.startsWith(detectorPrefix)) ?? null)
+      : null // canny needs no model
+    : (reqs?.components.find((c) => c.optional && !c.present) ?? null)
   const suggestedDl = suggested && downloadsForType ? downloadsForType[suggested.id] : undefined
   const suggestedPct = suggestedDl ? Math.round(suggestedDl.fraction * 100) : null
-  // The soft chip's noun follows the download's category: the annotator weights for Apply ControlNet
-  // read "detectors", the opt-in ControlNet model reads "ControlNet".
-  const suggestNoun = suggested?.category === 'annotators' ? 'detectors' : 'ControlNet'
+  // The chip's noun: the detector for Apply ControlNet, else the opt-in ControlNet model.
+  const suggestNoun =
+    detectorNoun ?? (suggested?.category === 'annotators' ? 'detectors' : 'ControlNet')
+
+  // Offer "Match aspect" only when a control map is actually wired into this node's Control input.
+  const controlWired =
+    (descriptor.inputs?.some((p) => p.id === 'control_image') ?? false) &&
+    connectors.some(
+      (c) =>
+        c.toItemId === itemId &&
+        (c.data as { targetHandle?: string }).targetHandle === 'control_image',
+    )
 
   // A loader/plumbing node (no media output) renders compact - no preview, no Run (it loads with
   // whatever downstream node runs). Generation nodes get the full preview card + the graph Run
@@ -406,7 +428,16 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
               <img
                 src={resolveMedia(core.output.filePath)}
                 alt=""
-                className="h-full w-full object-cover"
+                title="Double-click to expand"
+                onDoubleClick={() =>
+                  core.output &&
+                  openLightbox({
+                    src: resolveMedia(core.output.filePath),
+                    kind: 'image',
+                    name: core.output.prompt || descriptor.title,
+                  })
+                }
+                className="h-full w-full cursor-zoom-in object-cover"
               />
             ) : (
               <div className="flex h-full w-full items-center justify-center px-4">
@@ -505,14 +536,25 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
             <span className="truncate px-1 text-[10px] uppercase tracking-wide text-zinc-500">
               {descriptor.category}
             </span>
-            <button
-              onClick={() => toggleSettings(itemId)}
-              title="Settings"
-              data-gen-settings-toggle
-              className="nodrag flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-400 hover:bg-black/40 hover:text-zinc-100"
-            >
-              <AdjustIcon />
-            </button>
+            <div className="flex shrink-0 items-center gap-1">
+              {controlWired && (
+                <button
+                  onClick={() => void matchControlAspect(itemId)}
+                  title="Set Width/Height to the wired control map's aspect so the pose isn't stretched"
+                  className="nodrag flex h-6 items-center rounded px-1.5 text-[10px] text-zinc-400 hover:bg-black/40 hover:text-zinc-100"
+                >
+                  Match aspect
+                </button>
+              )}
+              <button
+                onClick={() => toggleSettings(itemId)}
+                title="Settings"
+                data-gen-settings-toggle
+                className="nodrag flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-400 hover:bg-black/40 hover:text-zinc-100"
+              >
+                <AdjustIcon />
+              </button>
+            </div>
           </div>
         </div>
       </NodeFrame>

--- a/src/renderer/views/Moodboard/nodes/ModelRequirementsModal.tsx
+++ b/src/renderer/views/Moodboard/nodes/ModelRequirementsModal.tsx
@@ -34,6 +34,15 @@ function ComponentRow({
           <span className="shrink-0 rounded-full bg-accent/15 px-2 py-0.5 text-[10px] font-medium text-accent">
             Ready
           </span>
+        ) : comp.optional && !busy ? (
+          <button
+            onClick={() => void download(nodeType, comp.id)}
+            title="Optional - enables ControlNet, but not required to generate"
+            className="flex shrink-0 items-center gap-1 rounded-md border border-border bg-panel px-2 py-1 text-[10px] font-medium text-zinc-300 hover:border-emerald-500/50 hover:text-emerald-300"
+          >
+            <DownloadIcon className="h-3.5 w-3.5" />
+            Suggested
+          </button>
         ) : busy ? (
           <span className="shrink-0 text-[10px] font-medium text-emerald-300">{pct}%</span>
         ) : (
@@ -73,7 +82,8 @@ export function ModelRequirementsModal(): React.JSX.Element | null {
   )
 
   if (!nodeType || !reqs) return null
-  const missing = reqs.components.filter((c) => !c.present)
+  // Optional (suggested) components never count as "missing" or block "Download all".
+  const missing = reqs.components.filter((c) => !c.present && !c.optional)
 
   return (
     <div

--- a/src/renderer/views/Moodboard/nodes/NodeFrame.tsx
+++ b/src/renderer/views/Moodboard/nodes/NodeFrame.tsx
@@ -21,6 +21,7 @@ export function NodeFrame({
   padded = true,
   transparent = false,
   subtleSelect = false,
+  running = false,
   overflowVisible = false,
   onResizeStart,
   onResize,
@@ -36,6 +37,8 @@ export function NodeFrame({
   transparent?: boolean
   /** Use a soft light-grey selection outline instead of the loud accent (for media-heavy nodes). */
   subtleSelect?: boolean
+  /** This node is currently executing - show a green border so it's clear which node is running. */
+  running?: boolean
   /** Let content overflow the card (e.g. a dropdown that spills past the frame). Off by default. */
   overflowVisible?: boolean
   /** Resize hooks. When `onResizeEnd` is given it replaces the default width/height persist. */
@@ -46,10 +49,13 @@ export function NodeFrame({
 }): React.JSX.Element {
   const { updateItem, deleteItem } = useBoardActions()
 
+  // A running node's green border wins over the selection colour so it's always clear what's executing.
   const selBorder = subtleSelect ? 'border-zinc-600' : 'border-accent'
+  const activeBorder = running ? 'border-emerald-400' : selected ? selBorder : 'border-border'
   const box = transparent
-    ? `bg-transparent ${selected ? `border border-dashed ${subtleSelect ? 'border-zinc-600/70' : 'border-accent/60'}` : 'border border-transparent'}`
-    : `border bg-surface ${selected ? selBorder : 'border-border'}`
+    ? `bg-transparent ${running ? 'border border-emerald-400' : selected ? `border border-dashed ${subtleSelect ? 'border-zinc-600/70' : 'border-accent/60'}` : 'border border-transparent'}`
+    : `border bg-surface ${activeBorder}`
+  const ring = running ? 'ring-2 ring-emerald-400/30' : ''
 
   return (
     <>
@@ -68,7 +74,7 @@ export function NodeFrame({
         }}
       />
       <div
-        className={`h-full w-full rounded-md ${overflowVisible ? 'overflow-visible' : 'overflow-hidden'} ${box} ${padded ? 'p-1' : ''}`}
+        className={`h-full w-full rounded-md ${overflowVisible ? 'overflow-visible' : 'overflow-hidden'} ${box} ${ring} ${padded ? 'p-1' : ''}`}
       >
         {children}
       </div>

--- a/src/renderer/views/Workspace/Workspace.tsx
+++ b/src/renderer/views/Workspace/Workspace.tsx
@@ -14,6 +14,7 @@ import { ExtensionsDialog } from '../Extensions/ExtensionsDialog'
 import { TrainerPanel } from '../Trainer/TrainerPanel'
 import { ContextMenu } from '../../components/ContextMenu'
 import { MediaLightbox } from '../../components/MediaLightbox'
+import { ControlSpaceEditorMount } from '../ControlSpace/ControlSpaceEditorMount'
 
 function TabButton({
   tab,
@@ -123,6 +124,7 @@ export function Workspace({ project }: { project: Project }): React.JSX.Element 
 
       <ContextMenu />
       <MediaLightbox />
+      <ControlSpaceEditorMount />
       <ExtensionsDialog />
     </div>
   )

--- a/src/shared/coreNodes.ts
+++ b/src/shared/coreNodes.ts
@@ -21,6 +21,7 @@ export type PortKind =
   | 'lora'
   | 'conditioning'
   | 'latent'
+  | 'control'
 
 export interface CorePort {
   id: string
@@ -95,6 +96,9 @@ export interface ModelComponent {
   repo: string
   /** "Which model" - the repo narrowed to the exact subfolder(s), e.g. `Owner/Repo/vae`. */
   source: string
+  /** A suggested (not required) component - e.g. the opt-in ControlNet. Never counts toward
+   * `allPresent`; the UI offers it as a separate download suggestion. */
+  optional?: boolean
 }
 
 /** A node's model requirements with live presence (from `models:requirements`). */
@@ -137,7 +141,10 @@ export function producesFrame(descriptor: NodeDescriptor): boolean {
 /** Whether an output of `source` kind may feed an input of `target` kind. Mirrors Core. */
 export function portsSatisfy(source: PortKind, target: PortKind): boolean {
   if (source === target) return true
-  return source === 'image' && target === 'image[]'
+  if (source === 'image' && target === 'image[]') return true
+  // A control input accepts any image output (a raw image, a preprocessed control map, or a
+  // Control Space render); the control map is just an image.
+  return source === 'image' && target === 'control'
 }
 
 const PORT_COLORS: Record<PortKind, string> = {
@@ -153,6 +160,7 @@ const PORT_COLORS: Record<PortKind, string> = {
   lora: '#2dd4bf',
   conditioning: '#c084fc',
   latent: '#60a5fa',
+  control: '#f9a8d4',
 }
 
 /** A stable color per port kind, for Comfy-style colored sockets and edges. */

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -191,6 +191,7 @@ export const IpcChannels = {
     addDirector: 'moodboard:addDirector',
     addTrim: 'moodboard:addTrim',
     addLoader: 'moodboard:addLoader',
+    addControlSpace: 'moodboard:addControlSpace',
     addGenNode: 'moodboard:addGenNode',
     addPrompt: 'moodboard:addPrompt',
     addCoreNode: 'moodboard:addCoreNode',
@@ -535,6 +536,8 @@ export interface InlineStudioApi {
     addTrim(x: number, y: number): Promise<Result<MoodboardItem>>
     /** Create a standalone "Load Assets" node (holds library asset refs in its data). */
     addLoader(x: number, y: number): Promise<Result<MoodboardItem>>
+    /** Create a "Control Space" 3D pose-editor node (renders an OpenPose control map). */
+    addControlSpace(x: number, y: number): Promise<Result<MoodboardItem>>
     /** Create a fal generation frame for `modelId` AND place its node on the canvas at (x, y). */
     addGenNode(modelId: string, x: number, y: number): Promise<Result<MoodboardItem>>
     /** Add a text-prompt node (feeds a Generate node's prompt input) at (x, y). */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -277,6 +277,9 @@ export interface MoodboardItemData {
     camera?: { position: [number, number, number]; target: [number, number, number] }
     /** Which control map the node last rendered: an OpenPose skeleton or a depth map. */
     output?: 'pose' | 'depth'
+    /** Output aspect (w/h) of the rendered map; must match the gen node's resolution or the pose
+     * comes out stretched. Defaults to 1 (square). */
+    aspect?: number
   }
   /** `trainDataset` / `caption` / `trainer` nodes: the training dataset they operate on. */
   datasetId?: string | null

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -280,6 +280,14 @@ export interface MoodboardItemData {
     /** Output aspect (w/h) of the rendered map; must match the gen node's resolution or the pose
      * comes out stretched. Defaults to 1 (square). */
     aspect?: number
+    /** How each character was turned relative to the camera when the map was rendered. */
+    facing?: ('front' | 'three-quarter' | 'profile' | 'back' | null)[]
+    /** Prompt text the facing needs, resolved at render time and appended to a downstream gen node's
+     * prompt / negative prompt. A control map cannot express "facing away" - only the text encoder
+     * can - so Control Space states it here. Null (or absent) = nothing to add. */
+    promptHint?: { positive: string; negative: string } | null
+    /** Whether the facing prompt hint is applied downstream (default true). */
+    applyPromptHint?: boolean
   }
   /** `trainDataset` / `caption` / `trainer` nodes: the training dataset they operate on. */
   datasetId?: string | null

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -136,6 +136,9 @@ export type MoodboardItemType =
   | 'core'
   /** A "Load Assets" node: holds library asset refs in `data.assetIds`, feeds its hero downstream. */
   | 'loader'
+  /** A "Control Space" node: a 3D pose editor whose rendered OpenPose map (`data.controlAssetId`)
+   * feeds a gen node's control input. */
+  | 'controlSpace'
   /** Trainer-canvas: picks a training dataset and feeds it downstream. */
   | 'trainDataset'
   /** Trainer-canvas: auto-captions a dataset's images. */
@@ -260,6 +263,21 @@ export interface MoodboardItemData {
   loader?: boolean
   /** `loader` node: the library asset ids it holds, in order (hero = first). */
   assetIds?: string[]
+  /** `controlSpace` node: the library asset id of the last rendered OpenPose control map, fed
+   * downstream into a gen node's control input. */
+  controlAssetId?: string
+  /** `controlSpace` node: the serialized 3D scene so the editor reopens on the saved pose.
+   * `characters` is the current multi-character form; `joints` is the legacy single-character field,
+   * still read for scenes saved before multi-character support. */
+  controlScene?: {
+    joints?: [number, number, number][]
+    characters?: { joints: [number, number, number][] }[]
+    fov?: number
+    /** Camera pose so a saved render reproduces the exact framing on reopen. */
+    camera?: { position: [number, number, number]; target: [number, number, number] }
+    /** Which control map the node last rendered: an OpenPose skeleton or a depth map. */
+    output?: 'pose' | 'depth'
+  }
   /** `trainDataset` / `caption` / `trainer` nodes: the training dataset they operate on. */
   datasetId?: string | null
   /** `caption` node: re-caption images that already have a caption. */
@@ -273,23 +291,26 @@ export interface MoodboardItemData {
   core?: {
     type: string
     params: Record<string, unknown>
-    /** The active media this node produced - shown large and flowed downstream. Project-relative.
-     * `createdAt` (ms) is stamped at generation; absent on renders made before it was tracked. */
-    output?: {
-      takeId: string
-      filePath: string
-      kind: 'image' | 'video' | 'audio'
-      createdAt?: number
-    }
+    /** The active media this node produced - shown large and flowed downstream. */
+    output?: CoreTakeRef
     /** Recent renders (newest first); `output` points at the active one. Drives the take-history
-     * strip on generation nodes. Same shape as `output`. */
-    outputs?: {
-      takeId: string
-      filePath: string
-      kind: 'image' | 'video' | 'audio'
-      createdAt?: number
-    }[]
+     * strip on generation nodes. */
+    outputs?: CoreTakeRef[]
   }
+}
+
+/** One render in a Core node's history: the media file plus the recipe fields that let switching to
+ * it restore the node's settings and its prompt (the reproducible-recipe feature). */
+export interface CoreTakeRef {
+  takeId: string
+  filePath: string
+  kind: 'image' | 'video' | 'audio'
+  /** Stamped at generation (ms); absent on renders made before it was tracked. */
+  createdAt?: number
+  /** The settings this take was generated with, so switching to it restores the node's params. */
+  params?: Record<string, unknown>
+  /** The prompt this take used (from the upstream prompt node), for display + restore. */
+  prompt?: string
 }
 
 export interface MoodboardItem {


### PR DESCRIPTION
## ControlNet support + Control Space

Four commits on top of `main`. Adds ControlNet to the local Core gen nodes, a new
3D editor to drive it, and generation recipes embedded in output images.

### Control Space (new)

A full-screen 3D editor for posing OpenPose characters and framing a camera, then
rendering that as a control map. Multi-character, presets, orbit camera, output
aspect picker, pose or depth output.

Depth output builds a volumetric body: limb capsules with anatomical thickness, a
closed torso, and a skull with a face and nose along its forward axis, standing on
a ground plane against a backdrop. Facing reads straight off the pixels, and the
face hides behind the skull when a character turns away.

Pulls in three.js, @react-three/fiber and drei.

### ControlNet

- **Z-Image**: Control input port, `controlnet` picker and conditioning scale.
  Loads the Fun Union checkpoint offline via a bundled config.
- **Krea 2**: depth control through the public `Patil/Krea-2-depth-controlnet`
  control-LoRA. Rank-64 on every block plus a wider input projection, so a
  VAE-encoded depth latent rides next to the noisy one.
- **Apply ControlNet node**: turns any image into a pose, depth or canny map.

Control maps are now typed `CONTROL` so they can only feed a Control input. Wiring
one into img2img was silently running image-to-image from a black map, which looked
exactly like "ControlNet not working".

### Generation recipes

- Drag drop generated image to load graph
- Generated assets now carries entire generation info & settings. 

