### PR TITLE
fixed venv ovewrite issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ cd Inline-Studio\core
 
 That's it: `--install` sets up the environment and installs everything once, then `webui.sh` / `webui.bat` runs the app on one port. See **[Command-line options](#command-line-options)** for every flag (`--listen`, `--port`, `--lowvram`, `--multi-gpu`, …).
 
+Everything lands in `core/.venv`, which Inline Studio owns. If you already have another virtualenv or conda env activated in that shell (a ComfyUI one, say), it is left completely untouched - `--install` says so and carries on. Re-running `--install` is safe: an existing `core/.venv` is reused, so adding an extra later is just another `--install --extra NAME`.
+
 Prefer pip over the launcher? `pip install -r requirements.txt` (from the repo root) installs the whole app - engine, UI, model runtime, and trainer - from PyPI; then run `inline-studio`.
 
 ### Hardware support
@@ -75,22 +77,24 @@ Nobody has verified Inline Studio on AMD yet, so treat this as a starting point 
 
 ```bash
 cd core
-uv venv
-uv pip install -e ".[runtime,server]"        # engine + runtime (pulls the default PyPI torch)
+./webui.sh --install --extra runtime         # engine + runtime (pulls the default PyPI torch)
 
 # Replace torch with the ROCm build. Pick the index that matches YOUR ROCm version -
 # check https://pytorch.org/get-started/locally/ (rocm6.2 shown here as an example).
-uv pip install --force-reinstall --index-url https://download.pytorch.org/whl/rocm6.2 torch
+# --python pins the install to Inline Studio's venv, whatever is activated in your shell.
+uv pip install --python .venv/bin/python --force-reinstall \
+  --index-url https://download.pytorch.org/whl/rocm6.2 torch
 
 # Verify you actually got a ROCm build (hip should print a version, not None):
-uv run python -c "import torch; print(torch.cuda.is_available(), torch.version.hip)"
+.venv/bin/python -c "import torch; print(torch.cuda.is_available(), torch.version.hip)"
 ```
 
 Then run `./webui.sh` as usual.
 
-Two gotchas:
+Three gotchas:
 
-- **Don't run `uv sync` afterwards** - it re-resolves the environment against the lockfile and will pull the PyPI torch back over your ROCm build. Use `uv pip install` for follow-up installs.
+- **Don't run `uv sync` afterwards** - it re-resolves the environment against the lockfile and will pull the PyPI torch back over your ROCm build. Use `uv pip install --python .venv/bin/python` for follow-up installs.
+- **Don't pass `--recreate`** - it rebuilds `.venv` from scratch and your ROCm torch goes with it. A plain `--install` re-run reuses the venv and is safe.
 - ROCm presents itself through `torch.cuda`, so the engine will treat it as a CUDA device and may largely work. But the dtype heuristics key off **NVIDIA** compute capability (`< 8.0` → fp16), which is meaningless on RDNA/CDNA, and the int8 (torchao) path is unverified on ROCm. If it works - or doesn't - [open an issue](https://github.com/inlineresearch/Inline-Studio/issues); that's the fastest way to get AMD properly supported.
 
 **Known limits, so you can judge before installing:**
@@ -120,6 +124,8 @@ cd core
 uv sync --extra server --extra runtime   # server + the local model runtime (torch/diffusers)
 uv run python main.py --front-end-root ../dist-web
 ```
+
+`uv sync` here manages `core/.venv` as a project environment - it is exact, so it removes anything not in the lockfile (including the `inline-studio-frontend` package a previous `--install` may have added, which doesn't matter when you're serving `--front-end-root ../dist-web`).
 
 Then open **http://127.0.0.1:8848**. Add your [fal.ai API key](https://fal.ai/dashboard/keys) in Settings for hosted models, and set up local generation as in [Two ways to generate](#two-ways-to-generate). The canvas and planning work without any models.
 
@@ -151,7 +157,7 @@ The friendly launcher (in `core/`) maps flags onto the engine's `INLINE_*` envir
 
 </details>
 
-`webui.sh` also has `--install` / `--extra NAME` to set up the venv. New to Inline Studio? The [Getting Started guide](https://inlinestudio.art/getting-started) walks you through your first render.
+`webui.sh` also has `--install` / `--extra NAME` to set up the venv, plus `--recreate` (rebuild `.venv` from scratch) and `--use-active-env` (install into / run from the environment activated in your shell instead of `.venv`). New to Inline Studio? The [Getting Started guide](https://inlinestudio.art/getting-started) walks you through your first render.
 
 ## Features
 

--- a/core/CLAUDE.md
+++ b/core/CLAUDE.md
@@ -211,14 +211,17 @@ real codec that moves tensors lives with the model runner.
 
 ```
 uv venv                                   # create ./.venv
-uv pip install -e ".[server,dev]"         # engine + server + test tooling
-uv pip install -e ".[runtime]"            # + torch, diffusers, transformers (real generation)
-uv pip install -e ".[runtime,parallel]"   # + xfuser, for multi-GPU denoise (2+ GPUs)
+# --python pins the target: without it uv installs into an activated venv/conda env, not ./.venv
+uv pip install --python .venv/bin/python -e ".[server,dev]"   # engine + server + test tooling
+uv pip install --python .venv/bin/python -e ".[runtime]"      # + torch, diffusers, transformers
+uv pip install --python .venv/bin/python -e ".[runtime,parallel]"  # + xfuser, multi-GPU denoise
 
 ./webui.sh                                # run (loopback:8848); friendly flags → INLINE_* env
 ./webui.sh --listen --port 9000           # bind all interfaces
 ./webui.sh --lowvram                      # tight-VRAM profile
 ./webui.sh --install --extra runtime      # set up ./.venv with the model runtime, then exit
+                                          # (reuses an existing ./.venv; --recreate rebuilds it, and
+                                          #  an activated foreign env is reported, never modified)
 python -m inline_core.server              # run the server directly (INLINE_HOST / INLINE_PORT)
 
 ruff check .                              # lint (zero warnings)

--- a/core/README.md
+++ b/core/README.md
@@ -39,12 +39,17 @@ a 6 GB laptop, pure CPU, or split across several GPUs, without touching the grap
 
 Requires Python 3.11+ and [uv](https://docs.astral.sh/uv/).
 
+`--python` pins each install to `./.venv`; without it uv targets whatever venv or conda env is
+activated in your shell, and installs land there instead.
+
 ```
 uv venv
-uv pip install -e ".[server]"     # engine + HTTP/websocket API
-uv pip install -e ".[runtime]"    # + torch, diffusers, transformers (for real generation)
-uv pip install -e ".[runtime,parallel]"  # + xfuser, to split one image across GPUs (2+ GPUs)
+uv pip install --python .venv/bin/python -e ".[server]"    # engine + HTTP/websocket API
+uv pip install --python .venv/bin/python -e ".[runtime]"   # + torch, diffusers, transformers
+uv pip install --python .venv/bin/python -e ".[runtime,parallel]"  # + xfuser, 2+ GPUs
 ```
+
+Or let the launcher do it: `./webui.sh --install --extra runtime` (Windows: `.\webui.bat`).
 
 ## Models
 

--- a/core/tests/test_webui_install.py
+++ b/core/tests/test_webui_install.py
@@ -1,0 +1,154 @@
+"""The launcher must never install into an environment it does not own.
+
+A venv activated in the user's shell used to absorb the whole install, because uv's pip interface
+targets an active ``VIRTUAL_ENV`` ahead of the local ``.venv``. Every uv call is pinned now, so
+these drive the real script against a stub ``uv`` and assert on the argv it receives.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+WEBUI = Path(__file__).resolve().parents[1] / "webui.sh"
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="webui.sh is the POSIX launcher; webui.bat is its twin"
+)
+
+
+@dataclass(frozen=True)
+class Sandbox:
+    """A throwaway copy of webui.sh with a stub uv, a stub python, and a foreign venv activated."""
+
+    script: Path
+    venv_python: Path
+    active_env: Path
+    uv_log: Path
+    python_log: Path
+    path: str
+
+    def run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S603 - fixed argv from our own code, no shell
+            ["bash", str(self.script), *args],
+            cwd=self.script.parent,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            env={
+                "PATH": self.path,
+                "HOME": str(self.script.parent.parent),
+                "VIRTUAL_ENV": str(self.active_env),
+                "PYTHON_LOG": str(self.python_log),
+            },
+        )
+
+    def uv_calls(self) -> list[str]:
+        if not self.uv_log.exists():
+            return []
+        return [line for line in self.uv_log.read_text(encoding="utf-8").splitlines() if line]
+
+    def make_venv_python(self) -> None:
+        self.venv_python.parent.mkdir(parents=True, exist_ok=True)
+        _stub(self.venv_python, 'echo "$*" >> "$PYTHON_LOG"\nexit 0\n')
+
+
+def _stub(path: Path, body: str) -> None:
+    path.write_text(f"#!/bin/sh\n{body}", encoding="utf-8")
+    path.chmod(0o755)
+
+
+@pytest.fixture
+def sandbox(tmp_path: Path) -> Sandbox:
+    core = tmp_path / "core"
+    core.mkdir()
+    shutil.copy(WEBUI, core / "webui.sh")
+    (core / ".python-version").write_text("3.11\n", encoding="utf-8")
+
+    active = tmp_path / "comfy-venv"
+    (active / "bin").mkdir(parents=True)
+    _stub(active / "bin" / "python", 'echo "FOREIGN $*" >> "$PYTHON_LOG"\nexit 0\n')
+
+    stubs = tmp_path / "stubs"
+    stubs.mkdir()
+    uv_log = tmp_path / "uv.log"
+    _stub(stubs / "uv", f'printf "%s\\n" "$*" >> "{uv_log}"\nexit 0\n')
+
+    return Sandbox(
+        script=core / "webui.sh",
+        venv_python=core / ".venv" / "bin" / "python",
+        active_env=active,
+        uv_log=uv_log,
+        python_log=tmp_path / "python.log",
+        path=f"{stubs}:/usr/bin:/bin",
+    )
+
+
+def test_install_never_targets_the_active_environment(sandbox: Sandbox) -> None:
+    done = sandbox.run("--install", "--extra", "all")
+
+    assert done.returncode == 0, done.stderr
+    installs = [call for call in sandbox.uv_calls() if call.startswith("pip install")]
+    assert installs, sandbox.uv_calls()
+    for call in installs:
+        assert f"--python {sandbox.venv_python}" in call
+    assert str(sandbox.active_env) not in "\n".join(sandbox.uv_calls())
+    assert "will NOT be modified" in done.stdout
+
+
+def test_repeat_install_reuses_the_existing_environment(sandbox: Sandbox) -> None:
+    """uv venv exits non-zero on an existing environment, which used to abort the whole install."""
+    sandbox.make_venv_python()
+
+    done = sandbox.run("--install", "--extra", "runtime")
+
+    assert done.returncode == 0, done.stderr
+    assert not [call for call in sandbox.uv_calls() if call.startswith("venv")]
+    assert "Reusing the existing environment" in done.stdout
+
+
+def test_recreate_clears_the_environment(sandbox: Sandbox) -> None:
+    sandbox.make_venv_python()
+
+    done = sandbox.run("--install", "--recreate")
+
+    assert done.returncode == 0, done.stderr
+    assert [call for call in sandbox.uv_calls() if call.startswith("venv --clear")]
+
+
+def test_use_active_env_opts_into_the_activated_environment(sandbox: Sandbox) -> None:
+    done = sandbox.run("--install", "--use-active-env")
+
+    assert done.returncode == 0, done.stderr
+    installs = [call for call in sandbox.uv_calls() if call.startswith("pip install")]
+    assert installs
+    for call in installs:
+        assert f"--python {sandbox.active_env}/bin/python" in call
+
+
+def test_unknown_extra_fails_with_the_valid_list(sandbox: Sandbox) -> None:
+    done = sandbox.run("--install", "--extra", "bogus")
+
+    assert done.returncode != 0
+    assert "unknown extra: bogus" in done.stderr
+    assert "runtime" in done.stderr
+    assert not sandbox.uv_calls()
+
+
+def test_launch_prefers_our_venv_over_the_active_environment(sandbox: Sandbox) -> None:
+    """The second leak: on-demand installs (torchao, the frontend) ran in the activated venv too."""
+    sandbox.make_venv_python()
+
+    done = sandbox.run("--smart-memory")
+
+    assert done.returncode == 0, done.stderr
+    ran = sandbox.python_log.read_text(encoding="utf-8")
+    assert "FOREIGN" not in ran
+    assert "-m inline_core.server" in ran
+    assert "not the environment active in this shell" in done.stdout

--- a/core/webui.bat
+++ b/core/webui.bat
@@ -16,6 +16,10 @@ rem ============================================================================
 setlocal enabledelayedexpansion
 cd /d "%~dp0"
 
+rem Absolute, so uv is pinned to this venv no matter what is activated in the shell.
+set "VENV_DIR=%~dp0.venv"
+set "VENV_PY=%~dp0.venv\Scripts\python.exe"
+
 set "HOST=127.0.0.1"
 set "PORT=8848"
 set "EXTRAS=server"
@@ -23,6 +27,8 @@ set "RUN_INSTALL=0"
 set "DEV_MODE=0"
 set "FORCE_REBUILD=0"
 set "SMART_MEMORY=0"
+set "USE_ACTIVE_ENV=0"
+set "RECREATE=0"
 
 :parse
 if "%~1"=="" goto after_parse
@@ -40,6 +46,8 @@ if /i "%~1"=="--models-dir"   ( set "INLINE_MODELS_DIR=%~2" & shift & shift & go
 if /i "%~1"=="--data-dir"     ( set "INLINE_DATA_DIR=%~2" & shift & shift & goto parse )
 if /i "%~1"=="--install"      ( set "RUN_INSTALL=1" & shift & goto parse )
 if /i "%~1"=="--extra"        ( set "EXTRAS=!EXTRAS!,%~2" & shift & shift & goto parse )
+if /i "%~1"=="--recreate"     ( set "RECREATE=1" & shift & goto parse )
+if /i "%~1"=="--use-active-env" ( set "USE_ACTIVE_ENV=1" & shift & goto parse )
 if /i "%~1"=="--dev"          ( set "DEV_MODE=1" & shift & goto parse )
 if /i "%~1"=="--rebuild"      ( set "FORCE_REBUILD=1" & shift & goto parse )
 if /i "%~1"=="-h"             ( call :usage & exit /b 0 )
@@ -77,6 +85,11 @@ set "INLINE_PORT=%PORT%"
 rem Expandable CUDA segments cut low-VRAM fragmentation OOMs (harmless on CPU). Respect a user value.
 if not defined PYTORCH_CUDA_ALLOC_CONF set "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True"
 
+set "ACTIVE_ENV="
+if defined CONDA_PREFIX set "ACTIVE_ENV=%CONDA_PREFIX%"
+if defined VIRTUAL_ENV set "ACTIVE_ENV=%VIRTUAL_ENV%"
+call :foreign_env
+
 if "%RUN_INSTALL%"=="1" goto do_install
 goto pick_python
 
@@ -84,7 +97,33 @@ rem --- Install: create .venv (via uv) and install, then exit ------------------
 rem Flat label-based control, not nested (...) blocks: multi-line parens inside parens break .bat.
 :do_install
 where uv >nul 2>nul || ( echo uv not found: https://docs.astral.sh/uv/ & goto fail )
-uv venv || goto fail
+call :normalize_extras || goto fail
+rem Every uv call below is pinned with --python. uv's pip interface otherwise targets an active
+rem VIRTUAL_ENV/CONDA_PREFIX ahead of the local .venv, which is how an unrelated venv activated in the
+rem user's shell silently absorbed the install and had its packages replaced.
+set "TARGET_PY=%VENV_PY%"
+if "%USE_ACTIVE_ENV%"=="1" goto install_active_env
+if defined FOREIGN_ENV echo NOTE: the environment active in this shell will NOT be modified:
+if defined FOREIGN_ENV echo         %FOREIGN_ENV%
+if defined FOREIGN_ENV echo       Installing into %VENV_DIR% instead ^(--use-active-env overrides this^).
+if "%RECREATE%"=="1" goto install_recreate
+rem uv venv refuses an existing environment and --clear would wipe manual installs, so a repeat
+rem --install (say, to add an extra) has to reuse what is already there.
+if exist "%VENV_PY%" ( echo Reusing the existing environment at %VENV_DIR% ^(--recreate rebuilds it from scratch^). & goto install_torch_args )
+uv venv "%VENV_DIR%" || goto fail
+goto install_torch_args
+
+:install_recreate
+echo Recreating %VENV_DIR% - anything installed into it by hand is lost.
+uv venv --clear "%VENV_DIR%" || goto fail
+goto install_torch_args
+
+:install_active_env
+if not defined ACTIVE_ENV ( echo --use-active-env needs an activated environment. & goto fail )
+set "TARGET_PY=%ACTIVE_ENV%\Scripts\python.exe"
+echo Installing into the active environment: %ACTIVE_ENV%
+
+:install_torch_args
 rem PyPI's default torch is CPU-only on Windows, so installing blind generates on the CPU ~100x
 rem slower with no error. When an NVIDIA GPU is present, resolve torch from the CUDA index.
 set "TORCH_ARGS="
@@ -98,18 +137,36 @@ goto install_pkgs
 :install_cpu
 echo No NVIDIA GPU detected - installing the default (CPU) build of PyTorch.
 :install_pkgs
-uv pip install !TORCH_ARGS! -e ".[!EXTRAS!]" || goto fail
-uv pip install inline-studio-frontend >nul 2>nul && echo Installed the prebuilt web UI (inline-studio-frontend). || echo Note: inline-studio-frontend not installed; the UI will build from source or run API-only.
+uv pip install --python "!TARGET_PY!" !TORCH_ARGS! -e ".[!EXTRAS!]" || goto fail
+uv pip install --python "!TARGET_PY!" inline-studio-frontend >nul 2>nul && echo Installed the prebuilt web UI (inline-studio-frontend). || echo Note: inline-studio-frontend not installed; the UI will build from source or run API-only.
 echo Installed extras: !EXTRAS!. Start with: .\webui.bat
 exit /b 0
 
 rem --- Pick the Python interpreter (and matching pip), in priority order -------------------------
+rem Our own .venv outranks an env that merely happens to be activated, so a foreign venv can never
+rem absorb the on-demand installs in :ensure_frontend / :ensure_smart_memory_deps.
 :pick_python
-if defined VIRTUAL_ENV ( set "PY=python" & set "PIP=python -m pip install" & goto have_python )
-if exist ".venv\Scripts\python.exe" ( set "PY=.venv\Scripts\python.exe" & set "PIP=.venv\Scripts\python.exe -m pip install" & goto have_python )
-where uv >nul 2>nul && ( set "PY=uv run python" & set "PIP=uv pip install" & goto have_python )
-echo No .venv found and uv is not installed. Run  .\webui.bat --install  first.
+if "%USE_ACTIVE_ENV%"=="1" goto pick_active_env
+if exist "%VENV_PY%" goto pick_venv
+if defined ACTIVE_ENV if exist "%ACTIVE_ENV%\Scripts\python.exe" ( set "PY=%ACTIVE_ENV%\Scripts\python.exe" & goto have_pip )
+python -c "import inline_core" >nul 2>nul && ( set "PY=python" & goto have_pip )
+echo No .venv found. Run  .\webui.bat --install  first.
 goto fail
+
+:pick_venv
+set "PY=%VENV_PY%"
+if defined FOREIGN_ENV echo NOTE: running from %VENV_DIR%, not the environment active in this shell ^(%FOREIGN_ENV%^).
+goto have_pip
+
+:pick_active_env
+if not defined ACTIVE_ENV ( echo --use-active-env needs an activated environment. & goto fail )
+set "PY=%ACTIVE_ENV%\Scripts\python.exe"
+
+:have_pip
+rem uv venvs are not seeded with pip, so 'python -m pip' can never work in one - go through uv instead.
+set PIP="%PY%" -m pip install
+where uv >nul 2>nul && set PIP=uv pip install --python "%PY%"
+goto have_python
 
 :have_python
 if "%DEV_MODE%"=="1" ( call :run_dev & exit /b !ERRORLEVEL! )
@@ -118,17 +175,46 @@ if "%SMART_MEMORY%"=="1" call :ensure_smart_memory_deps
 
 call :ensure_frontend
 
-%PY% -m inline_core.server
+"%PY%" -m inline_core.server
 set "RC=%ERRORLEVEL%"
 if not "%RC%"=="0" ( echo. & echo Inline Studio exited with code %RC%. & pause )
 exit /b %RC%
 
 rem ================================ subroutines =================================================
 
+:foreign_env
+rem Sets FOREIGN_ENV when the environment active in this shell is NOT ours. Everything keys off this:
+rem an env that merely happens to be activated must never absorb an install or a launch-time dep.
+set "FOREIGN_ENV="
+if not defined ACTIVE_ENV exit /b 0
+for %%I in ("%ACTIVE_ENV%") do set "ACTIVE_FULL=%%~fI"
+if /i "%ACTIVE_FULL%"=="%VENV_DIR%" exit /b 0
+set "FOREIGN_ENV=%ACTIVE_FULL%"
+exit /b 0
+
+:normalize_extras
+rem Validate and dedupe the extras, so a typo fails here with the valid list instead of reaching uv as
+rem a raw resolver error. The names must match [project.optional-dependencies] in pyproject.toml.
+set "EXTRAS_OUT="
+for %%E in ("%EXTRAS:,=" "%") do call :add_extra %%E || exit /b 1
+set "EXTRAS=!EXTRAS_OUT!"
+exit /b 0
+
+:add_extra
+echo runtime server parallel training dev all | findstr /r /c:"\<%~1\>" >nul || goto bad_extra
+if "!EXTRAS_OUT!"=="" ( set "EXTRAS_OUT=%~1" & exit /b 0 )
+echo !EXTRAS_OUT! | findstr /r /c:"\<%~1\>" >nul && exit /b 0
+set "EXTRAS_OUT=!EXTRAS_OUT!,%~1"
+exit /b 0
+
+:bad_extra
+echo unknown extra: %~1 ^(valid: runtime, server, parallel, training, dev, all^)
+exit /b 1
+
 :frontend_available
 rem Succeeds (errorlevel 0) when a web UI is resolvable; sets INLINE_FRONTEND_ROOT for a local build.
 if defined INLINE_FRONTEND_ROOT if exist "%INLINE_FRONTEND_ROOT%\index.html" exit /b 0
-%PY% -c "import os,sys; import inline_studio_frontend as f; sys.exit(0 if os.path.isfile(os.path.join(os.path.dirname(f.__file__),'static','index.html')) else 1)" >nul 2>nul && exit /b 0
+"%PY%" -c "import os,sys; import inline_studio_frontend as f; sys.exit(0 if os.path.isfile(os.path.join(os.path.dirname(f.__file__),'static','index.html')) else 1)" >nul 2>nul && exit /b 0
 if exist "..\dist-web\index.html" (
   for %%I in ("..\dist-web") do set "INLINE_FRONTEND_ROOT=%%~fI"
   exit /b 0
@@ -138,7 +224,7 @@ exit /b 1
 :ensure_frontend
 call :frontend_available && exit /b 0
 echo No web UI found - installing the prebuilt package (inline-studio-frontend)...
-%PIP% inline-studio-frontend >nul 2>nul
+%PIP% inline-studio-frontend >nul
 call :frontend_available && exit /b 0
 if exist "..\package.json" (
   where npm >nul 2>nul && (
@@ -150,7 +236,7 @@ if exist "..\package.json" (
   )
 )
 echo WARNING: no web UI available - serving API only. Install Node to build it, or run
-echo          "%PIP% inline-studio-frontend" once it's published.
+echo          %PIP% inline-studio-frontend   once it's published.
 exit /b 0
 
 :rebuild_frontend
@@ -165,9 +251,9 @@ for %%I in ("..\dist-web") do set "INLINE_FRONTEND_ROOT=%%~fI"
 exit /b 0
 
 :ensure_smart_memory_deps
-%PY% -c "import torchao" >nul 2>nul && exit /b 0
+"%PY%" -c "import torchao" >nul 2>nul && exit /b 0
 echo Smart memory: installing torchao (int8 quantization)...
-%PIP% torchao >nul 2>nul ^
+%PIP% torchao >nul ^
   && echo Installed torchao. ^
   || echo WARNING: could not install torchao; smart memory will run without int8 quant.
 exit /b 0
@@ -179,7 +265,7 @@ pushd ..
 if not exist node_modules call npm ci
 popd
 echo Starting Inline Core (API) on %HOST%:%PORT% in a new window...
-start "Inline Core (API)" %PY% -m inline_core.server
+start "Inline Core (API)" "%PY%" -m inline_core.server
 echo Starting the Vite dev server (HMR). Open http://localhost:5173  (NOT :%PORT%)
 pushd ..
 set "INLINE_CORE_URL=http://127.0.0.1:%PORT%"
@@ -212,8 +298,14 @@ echo   --models-dir PATH      where weights are scanned from (default .\models)
 echo   --data-dir PATH        where runs and takes are written (default .\.inline)
 echo.
 echo Setup
-echo   --install              create .venv (via uv) and install, then exit
+echo   --install              create .venv (via uv) and install, then exit. An existing .venv is
+echo                          reused, and an unrelated environment activated in your shell is never
+echo                          touched.
 echo   --extra NAME           add an install extra (repeatable): runtime, parallel, server, training
+echo   --recreate             with --install, rebuild .venv from scratch (discards anything installed
+echo                          into it by hand)
+echo   --use-active-env       install into / run from the environment activated in this shell instead
+echo                          of .venv
 echo   -h, --help             show this help
 echo.
 echo Development

--- a/core/webui.sh
+++ b/core/webui.sh
@@ -17,6 +17,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+VENV_DIR="$SCRIPT_DIR/.venv"
+VENV_PY="$VENV_DIR/bin/python"
+
 HOST="127.0.0.1"
 PORT="8848"
 EXTRAS="server"
@@ -24,6 +27,8 @@ RUN_INSTALL=0
 DEV_MODE=0
 FORCE_REBUILD=0
 SMART_MEMORY=0
+USE_ACTIVE_ENV=0
+RECREATE=0
 
 usage() {
   cat <<'EOF'
@@ -53,8 +58,14 @@ Paths
   --data-dir PATH        where runs and takes are written (default ./.inline)
 
 Setup
-  --install              create ./.venv (via uv) and install, then exit
+  --install              create ./.venv (via uv) and install, then exit. An existing ./.venv is
+                         reused, and an unrelated environment activated in your shell is never
+                         touched.
   --extra NAME           add an install extra (repeatable): runtime, parallel, server, training
+  --recreate             with --install, rebuild ./.venv from scratch (discards anything installed
+                         into it by hand, e.g. a ROCm build of PyTorch)
+  --use-active-env       install into / run from the environment activated in this shell instead of
+                         ./.venv
   -h, --help             show this help
 
 Development
@@ -99,6 +110,8 @@ while [[ $# -gt 0 ]]; do
     --data-dir) export INLINE_DATA_DIR="${2:?--data-dir needs a path}"; shift 2 ;;
     --install) RUN_INSTALL=1; shift ;;
     --extra) EXTRAS="$EXTRAS,${2:?--extra needs a name}"; shift 2 ;;
+    --recreate) RECREATE=1; shift ;;
+    --use-active-env) USE_ACTIVE_ENV=1; shift ;;
     --dev) DEV_MODE=1; shift ;;
     --rebuild) FORCE_REBUILD=1; shift ;;
     -h|--help) usage; exit 0 ;;
@@ -115,9 +128,60 @@ export INLINE_PORT="$PORT"
 # low-VRAM (e.g. T4) OOM. Harmless on CPU-only runs (torch just ignores it).
 export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
 
+ACTIVE_ENV="${VIRTUAL_ENV:-${CONDA_PREFIX:-}}"
+
+# Prints the environment active in this shell when it is NOT ours. Everything below keys off this: an
+# env that merely happens to be activated must never absorb an install or a launch-time dependency.
+foreign_env() {
+  [[ -n "$ACTIVE_ENV" ]] || return 1
+  [[ "$(cd "$ACTIVE_ENV" 2>/dev/null && pwd -P)" != "$(cd "$VENV_DIR" 2>/dev/null && pwd -P)" ]] || return 1
+  printf '%s\n' "$ACTIVE_ENV"
+}
+
+# Validate and dedupe the extras, so a typo fails here with the valid list instead of reaching uv as a
+# raw resolver error. The names must match [project.optional-dependencies] in pyproject.toml.
+normalize_extras() {
+  local name seen="" out=""
+  for name in ${EXTRAS//,/ }; do
+    case " runtime server parallel training dev all " in
+      *" $name "*) ;;
+      *) echo "unknown extra: $name (valid: runtime, server, parallel, training, dev, all)" >&2; exit 1 ;;
+    esac
+    case " $seen " in *" $name "*) continue ;; esac
+    seen="$seen $name"
+    out="${out:+$out,}$name"
+  done
+  EXTRAS="$out"
+}
+
 if [[ "$RUN_INSTALL" -eq 1 ]]; then
   command -v uv >/dev/null 2>&1 || { echo "uv not found: https://docs.astral.sh/uv/" >&2; exit 1; }
-  uv venv
+  normalize_extras
+  # Every uv call below is pinned with --python. uv's pip interface otherwise targets an active
+  # VIRTUAL_ENV/CONDA_PREFIX ahead of the local .venv, which is how an unrelated venv activated in the
+  # user's shell silently absorbed the install and had its packages replaced.
+  TARGET_PY="$VENV_PY"
+  if [[ "$USE_ACTIVE_ENV" -eq 1 ]]; then
+    [[ -n "$ACTIVE_ENV" ]] || { echo "--use-active-env needs an activated environment." >&2; exit 1; }
+    TARGET_PY="$ACTIVE_ENV/bin/python"
+    echo "Installing into the active environment: $ACTIVE_ENV"
+  else
+    if FOREIGN="$(foreign_env)"; then
+      echo "NOTE: the environment active in this shell will NOT be modified:"
+      echo "        $FOREIGN"
+      echo "      Installing into $VENV_DIR instead (--use-active-env overrides this)."
+    fi
+    if [[ "$RECREATE" -eq 1 ]]; then
+      echo "Recreating $VENV_DIR - anything installed into it by hand (e.g. a ROCm build of PyTorch) is lost."
+      uv venv --clear "$VENV_DIR"
+    elif [[ -x "$VENV_PY" ]]; then
+      # uv venv refuses an existing environment and --clear would wipe manual installs, so a repeat
+      # --install (say, to add an extra) has to reuse what is already there.
+      echo "Reusing the existing environment at $VENV_DIR (--recreate rebuilds it from scratch)."
+    else
+      uv venv "$VENV_DIR"
+    fi
+  fi
   # Pick the right torch wheel. PyPI's default torch is CPU-only on Windows (Linux wheels bundle
   # CUDA), so installing blind there yields a working install that generates on the CPU ~100x
   # slower, with no error. When an NVIDIA GPU is present, resolve torch from the CUDA index.
@@ -131,28 +195,39 @@ if [[ "$RUN_INSTALL" -eq 1 ]]; then
   else
     echo "No NVIDIA GPU detected - installing the default (CPU) build of PyTorch."
   fi
-  uv pip install "${TORCH_INDEX[@]}" -e ".[$EXTRAS]"
+  uv pip install --python "$TARGET_PY" "${TORCH_INDEX[@]}" -e ".[$EXTRAS]"
   # Pull the prebuilt web UI so there's no Node build (best-effort - it may not be published yet).
-  uv pip install inline-studio-frontend >/dev/null 2>&1 \
+  uv pip install --python "$TARGET_PY" inline-studio-frontend >/dev/null 2>&1 \
     && echo "Installed the prebuilt web UI (inline-studio-frontend)." \
     || echo "Note: inline-studio-frontend not installed; the UI will build from source or run API-only."
   echo "Installed extras: $EXTRAS. Start with: ./webui.sh"
   exit 0
 fi
 
-# Pick the Python interpreter and the matching pip, in priority order.
-if [[ -n "${VIRTUAL_ENV:-}" ]]; then
-  PY_CMD=(python)
-  PIP_INSTALL=(python -m pip install)
-elif [[ -x ".venv/bin/python" ]]; then
-  PY_CMD=(.venv/bin/python)
-  PIP_INSTALL=(.venv/bin/python -m pip install)
-elif command -v uv >/dev/null 2>&1; then
-  PY_CMD=(uv run python)
-  PIP_INSTALL=(uv pip install)
+# Pick the Python interpreter and the matching pip, in priority order. Our own .venv outranks an env
+# that merely happens to be activated, so a foreign venv can never absorb the on-demand installs below.
+if [[ "$USE_ACTIVE_ENV" -eq 1 ]]; then
+  [[ -n "$ACTIVE_ENV" ]] || { echo "--use-active-env needs an activated environment." >&2; exit 1; }
+  PY="$ACTIVE_ENV/bin/python"
+elif [[ -x "$VENV_PY" ]]; then
+  PY="$VENV_PY"
+  if FOREIGN="$(foreign_env)"; then
+    echo "NOTE: running from $VENV_DIR, not the environment active in this shell ($FOREIGN)."
+  fi
+elif [[ -n "$ACTIVE_ENV" && -x "$ACTIVE_ENV/bin/python" ]]; then
+  PY="$ACTIVE_ENV/bin/python"      # inline-core pip-installed into the user's own environment
+elif python3 -c "import inline_core" >/dev/null 2>&1; then
+  PY="$(command -v python3)"       # ...or onto the ambient interpreter (pip/pipx)
 else
-  echo "No .venv found and uv is not installed. Run './webui.sh --install' first." >&2
+  echo "No .venv found. Run './webui.sh --install' first." >&2
   exit 1
+fi
+PY_CMD=("$PY")
+# uv venvs are not seeded with pip, so 'python -m pip' can never work in one - go through uv instead.
+if command -v uv >/dev/null 2>&1; then
+  PIP_INSTALL=(uv pip install --python "$PY")
+else
+  PIP_INSTALL=("$PY" -m pip install)
 fi
 
 # True when a web UI is resolvable: an explicit --front-end-root, the installed frontend package, or
@@ -207,7 +282,7 @@ run_dev() {
 ensure_smart_memory_deps() {
   "${PY_CMD[@]}" -c "import torchao" >/dev/null 2>&1 && return 0
   echo "Smart memory: installing torchao (int8 quantization)…"
-  "${PIP_INSTALL[@]}" torchao >/dev/null 2>&1 \
+  "${PIP_INSTALL[@]}" torchao >/dev/null \
     && echo "Installed torchao." \
     || echo "WARNING: could not install torchao; smart memory will run without int8 quant." >&2
 }
@@ -216,7 +291,7 @@ ensure_smart_memory_deps() {
 ensure_frontend() {
   frontend_available && return 0
   echo "No web UI found - installing the prebuilt package (inline-studio-frontend)…"
-  "${PIP_INSTALL[@]}" inline-studio-frontend >/dev/null 2>&1 && frontend_available && return 0
+  "${PIP_INSTALL[@]}" inline-studio-frontend >/dev/null && frontend_available && return 0
   if [[ -f "../package.json" ]] && command -v npm >/dev/null 2>&1; then
     echo "Building the web UI from source (npm)…"
     ( cd .. && npm ci && npm run build:spa ) && frontend_available && return 0


### PR DESCRIPTION
## Summary

Fixes #19 . 

Root cause: the install path ran bare `uv pip install`. uv's pip interface targets an active `VIRTUAL_ENV`/`CONDA_PREFIX` ahead of the local `.venv`, so the activated env won. `core/.venv` was created and left empty.

Three related defects surfaced while verifying (uv 0.11.28):

- **A repeat `--install` could never succeed** - `uv venv` exits 2 on an existing `.venv`, and `set -euo pipefail` aborted before installing anything.
- **The launch path leaked too** - it branched on `VIRTUAL_ENV` first, so a later `./webui.sh` installed `torchao` / `inline-studio-frontend` into the foreign venv as well.
- **`PIP_INSTALL` was dead code** -`.venv/bin/python -m pip` can never work (uv venvs have no pip), and both call sites hid the failure with `2>&1`.

## Changes

`core/webui.sh` and its Windows twin `core/webui.bat`:

- Every `uv` call is pinned with `--python`, matching what the extension installer already does.
- An activated foreign env is detected and reported, never modified. `--use-active-env` opts in deliberately.
- `--install` reuses an existing `.venv`; new `--recreate` rebuilds it (warns that hand-installed ROCm torch is lost).
- The launcher prefers `core/.venv` over a merely-activated env; on-demand installs go through `uv pip install --python` and no longer swallow stderr. Dropped the `uv run python` fallback — it syncs exactly and would prune the frontend package and extras.
- `--extra` is validated and deduped, so a typo fails with the valid list instead of a raw resolver error.

## Behaviour

| Scenario | Before | After |
| --- | --- | --- |
| Foreign venv activated during `--install` | installed into it, versions replaced; `.venv` left empty | foreign env untouched, everything lands in `core/.venv` |
| `--install` run twice | exit 2, nothing installed | reuses `.venv`, adds the extras |
| `./webui.sh` with foreign venv active | ran that interpreter; torchao/frontend installed into it | runs `core/.venv`, prints why |
| Want a clean env | delete `.venv` by hand | `--recreate` |
| Want your own env used | not possible | `--use-active-env` |
| `--extra runtme` (typo) | raw uv resolver error mid-install | exits 1 with the valid list |

Closes #
#19 
