### PR TITLE
Flux 2: Generation & Training | Minimax H3: T2V, I2V & R2V via api nodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,14 @@ Fal node definitions stay studio-side (`src/shared/nodes/`): the browser builds 
 Core relays it to `queue.fal.run` with the API key server-side. Core nodes (e.g. Z-Image) run through
 Core's own graph engine.
 
+**List inputs.** A port of kind `image[]` accepts several wires, and their order is meaning, not
+decoration: FLUX.2 addresses reference images by position ("the jacket from image 2"). Ordering runs
+from `moodboard.list_board` (connectors ordered by `created_at`) through `graph_build._edges_for`
+(which accumulates on list ports and keeps last-wins everywhere else) to the numbered `ReferenceStrip`
+on the node face. A Load Assets node wired to a list port contributes **all** of its assets. If you
+touch any of those, keep `coreInputThumbs.ts` in step or the numbers on the card stop matching the
+numbers the prompt resolves.
+
 ### Directory map (TS side)
 
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 Inline Studio is a free, open-source app for **AI filmmaking on a node canvas**, powered by the built-in **Inline Core** engine (local diffusion models) and hosted [fal](https://fal.ai) models. It gives AI filmmakers a free-form canvas to build a whole visual pipeline, from moodboard to final cut.
 
 - **Non-destructive by default** - every render is kept as a versioned take; generating again adds one, nothing is overwritten.
-- **Local diffusion generation engine** - the built-in Inline Core engine runs popular diffusion models on your own GPU from a single model file, no external server. Currently supported: **Z-Image Turbo** and **Krea 2** (RAW + Turbo).
+- **Local diffusion generation engine** - the built-in Inline Core engine runs popular diffusion models on your own GPU from a single model file, no external server. Currently supported: **Z-Image Turbo**, **Krea 2** (RAW + Turbo), and **FLUX.2**.
 - **Hosted models via API Nodes** - reach for closed models with no GPU and no setup for instant creative range; see [API Nodes](#api-nodes).
 - **Mix both in the same film** - Inline Studio handles everything around the render: exploring options, keeping what works, and shaping a repeatable process you can iterate on and share.
 
@@ -99,9 +99,9 @@ Three gotchas:
 
 **Known limits, so you can judge before installing:**
 
-- **Local model coverage is Z-Image Turbo and Krea 2** today. Flux, SDXL and others are planned; hosted models via [API Nodes](#api-nodes) need no GPU at all.
+- **Local model coverage is Z-Image Turbo, Krea 2 and FLUX.2** today. SDXL and others are planned; hosted models via [API Nodes](#api-nodes) need no GPU at all.
 - **Krea 2 is a 12.9B model and needs a big card to generate.** The bf16 checkpoint is 26 GB on disk, and generation peaks around 36 GB at 1024 with guidance on, so a 40 GB+ GPU is the practical floor for inference. **Training is cheaper than generating**, because the 4-bit base path puts Krea 2 LoRA training at 512 inside 12 GB - see [Benchmark results](#benchmark-results). Z-Image remains the low-VRAM path for generation.
-- **1024² with Guidance (CFG) above 0 needs more than 16 GB.** CFG runs the prompt and negative prompt together, doubling the denoise. Z-Image Turbo is distilled to run CFG-free - at Guidance 0, 1024² fits in ~11.5 GB.
+- **1024² with Guidance (CFG) above 0 needs more than 16 GB.** CFG runs the prompt and negative prompt together, doubling the denoise. Z-Image Turbo is distilled to run CFG-free - at Guidance 0, 1024² fits in ~11.5 GB. FLUX.2 klein 4B peaks near 17.9 GB at bf16, so 24 GB holds it resident and a 16 GB card runs it quantized instead.
 
 </details>
 
@@ -165,7 +165,8 @@ The friendly launcher (in `core/`) maps flags onto the engine's `INLINE_*` envir
 - **Versioned, non-destructive takes** - every render is kept. Generating again adds a new take; nothing is overwritten. Star the keeper and it flows downstream.
 - **Chain frames into a generative pipeline** - wire one frame's output into the next frame's input. Refine a shot, feed it forward, regenerate the source, and everything downstream follows.
 - **Video editing on the canvas** - the **Video Director node** is a timeline-in-a-node that assembles your rendered frames into a single cut, with layered audio (the videos' own audio plus your own music/VO), per-input and per-layer volume, an in-node preview to scrub, and high-res export; the **Trim Video/Audio node** lets you drop in a clip, drag the in/out handles over its filmstrip/waveform, and pass just the trimmed segment downstream.
-- **Local generation, built in** - the Inline Core engine runs diffusion models on your own GPU. Z-Image Turbo and Krea 2 from single model files, no external server to set up.
+- **Local generation, built in** - the Inline Core engine runs diffusion models on your own GPU. Z-Image Turbo, Krea 2, and FLUX.2 from single model files (or a diffusers folder for a prequantized build), no external server to set up.
+- **Multi-reference composition** - with **FLUX.2**, wire several images into one node and compose from them: "the character from image 1 wearing the jacket from image 2". The node numbers the references on its face so the prompt can address them by position. One image edits it, several combine them. See [FLUX.2](#flux2).
 - **Train your own LoRAs** - the Trainer tab is a second canvas where the dataset, captioning, training run, and loss curve are all nodes. The finished LoRA drops into `models/loras/` and shows up in the LoRA loader node, ready to generate with. See [LoRA training](#lora-training).
 - **API Nodes for hosted models** - run closed models right on the canvas with no GPU. Add a Generate node, pick a model, and bring your own provider key. See [API Nodes](#api-nodes).
 - **Community extensions** - install custom nodes from a GitHub repo in one click, security-reviewed and dependency-isolated. Browse the [registry](https://github.com/inlineresearch/Inline-Registry) or [build your own](https://github.com/inlineresearch/Inline-Studio-Extension-Guide).
@@ -185,12 +186,12 @@ From the home screen, **Export** zips a project into one archive. Import it on t
 
 Pick whatever fits the shot, and mix both in one film. However you render, the frame keeps its full take history, so you never lose a good version.
 
-| How you render                          | What it's like                                                                                                                                                                                                                                                                                                  | What you need                                                                                                                                                                                    |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Local GPU: Inline Core** _(built in)_ | Drop a **Z-Image Turbo** or **Krea 2** node, wire a prompt, hit Run: one node, no loader/sampler wiring. A single `.safetensors` is all you bring; the engine pairs it with a VAE + text-encoder and downloads nothing behind your back. Two or more GPUs? It can split one image's denoise across them (xDiT). | Your own GPU. No account, no external server. Low-VRAM friendly: it auto-fits the model to your card (streaming weights + int8) so a model too big for full precision still runs, with no flags. |
-| **Hosted: API Nodes**                   | Add a Generate node and pick a model: hosted, closed models across image, video, and audio. No GPU, instant range. See [API Nodes](#api-nodes) for the model list and providers.                                                                                                                                | A provider key (currently [fal](https://fal.ai/dashboard/keys)); it stays on your machine, and you pay per render (each node estimates the price first).                                         |
+| How you render                          | What it's like                                                                                                                                                                                                                                                                                                                                                                        | What you need                                                                                                                                                                                             |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Local GPU: Inline Core** _(built in)_ | Drop a **Z-Image Turbo**, **Krea 2**, or **FLUX.2** node, wire a prompt, hit Run: one node, no loader/sampler wiring. A single `.safetensors` is usually all you bring (a prequantized build can be a diffusers folder); the engine pairs it with a VAE + text-encoder and downloads nothing behind your back. Two or more GPUs? It can split one image's denoise across them (xDiT). | Your own GPU. No account, no external server. Low-VRAM friendly: it auto-fits the model to your card (streaming weights, int8, then NF4) so a model too big for full precision still runs, with no flags. |
+| **Hosted: API Nodes**                   | Add a Generate node and pick a model: hosted, closed models across image, video, and audio. No GPU, instant range. See [API Nodes](#api-nodes) for the model list and providers.                                                                                                                                                                                                      | A provider key (currently [fal](https://fal.ai/dashboard/keys)); it stays on your machine, and you pay per render (each node estimates the price first).                                                  |
 
-For local generation, either drop a `.safetensors` into `core/models/diffusion_models/`, or add a model node and use its **model popup** (a blinking hint shows up when something's missing) to download the diffusion model, VAE, and text-encoder into `core/models/`, with visible progress. The canvas and planning work with no models at all. See [Krea 2](#krea-2) for that model's files and VRAM.
+For local generation, either drop a `.safetensors` into `core/models/diffusion_models/`, or add a model node and use its **model popup** (a blinking hint shows up when something's missing) to download the diffusion model, VAE, and text-encoder into `core/models/`, with visible progress. The canvas and planning work with no models at all. See [Krea 2](#krea-2) and [FLUX.2](#flux2) for those models' files and VRAM.
 
 ## Inline Core generation engine
 
@@ -229,6 +230,40 @@ Two things are worth knowing before you download 26 GB twice:
 
 Nothing here needs a Hugging Face token: every repo involved is public, and Krea's own gated repos are never touched.
 
+### FLUX.2
+
+[FLUX.2](https://bfl.ai/blog/flux-2) from Black Forest Labs is the first family here that is natively **multi-reference**: reference images ride in the denoiser's token sequence, so "the character from image 1 wearing the jacket from image 2" is a first-class capability rather than a workaround.
+
+One node, **FLUX.2**, covers the whole family. Pick a checkpoint in the node's Adjust sidebar and it identifies itself: klein 4B, klein 9B, either Base build, the KV variant, or dev. Steps and guidance default to "from model", so switching a distilled checkpoint for its Base build moves 4 steps at guidance 1.0 to 50 at guidance 4.0 without touching a setting.
+
+- **Reference images** - wire one image to edit it, or several to compose from them. The node numbers them on its face, and the prompt addresses them by position. There is no denoise-strength slider because FLUX.2 has no img2img: a single reference _is_ the edit.
+- **klein 4B is Apache 2.0** and the recommended starting point. It renders 1024px in four steps. At bf16 it is 16.1 GB of weights peaking around 17.9 GB, so a 24 GB card holds it resident; on a 16 GB card the fit ladder drops it to int8 or fp16 and it still runs. Its text encoder is the same Qwen3-4B file Z-Image already uses, so if you have run Z-Image you have most of it.
+- **dev is 32B.** The fp8 build the model popup offers wants around 32 GB. Bring a prequantized NF4 folder yourself and it fits a 24 GB card instead, because the prompt is encoded first and the text encoder freed before the transformer loads.
+
+Files come from the ungated ComfyUI repacks. The model popup fetches klein 4B, its text encoder and the VAE in one click, and offers the rest of the family as optional extras:
+
+```
+core/models/
+  diffusion_models/  flux-2-klein-4b.safetensors                      <- the default, Apache 2.0
+                     flux-2-klein-base-4b.safetensors                 <- the base build, for LoRA training
+                     flux-2-klein-9b-int8-ConvRot-comfyui.safetensors <- klein 9B, int8, ~12 GB
+                     flux2_dev_fp8mixed.safetensors                   <- dev, fp8, ~32 GB
+  text_encoders/     qwen_3_4b.safetensors                            <- the 4B builds, shared with Z-Image
+                     qwen_3_8b.safetensors                            <- klein 9B
+                     mistral_3_small_flux2_fp8.safetensors            <- dev
+  vae/               flux2-vae.safetensors
+```
+
+Each klein size needs its own text encoder, and dev uses Mistral-3 rather than Qwen3.
+
+For dev on a 24 GB card, take the ungated [`diffusers/FLUX.2-dev-bnb-4bit`](https://huggingface.co/diffusers/FLUX.2-dev-bnb-4bit) instead: an 18.1 GB NF4 transformer beside a 15.4 GB NF4 encoder, far cheaper than the fp8 single file. Clone it into `diffusion_models/` as a folder. The popup does not fetch it, and a diffusers folder is a valid checkpoint anywhere a single file is.
+
+Worth knowing:
+
+- **Prompts are prose, not tags.** FLUX.2 wants natural language, and keyword stuffing works against it. Word order carries weight.
+- **Only the Base klein checkpoints take a negative prompt.** The distilled builds run no classifier-free guidance and dev is guidance-distilled, so a negative prompt is logged and ignored there rather than silently pretending to apply.
+- **dev and every 9B build are non-commercial.** klein 4B, its Base build, and the VAE are Apache 2.0.
+
 ### ControlNet
 
 Steer a local render with a pose, depth, or edge map. Wire a control map into a gen node's **Control** input and pick a ControlNet in the node's Adjust sidebar.
@@ -237,6 +272,7 @@ Steer a local render with a pose, depth, or edge map. Wire a control map into a 
 - **Apply ControlNet** - turn any image into a control map (OpenPose, Depth-Anything V2, MiDaS depth, or Canny edges). Detector weights download once on first use.
 - **Z-Image Turbo** - full ControlNet via the Fun Union model. Use the distilled `-2602-8steps` build; the plain one is blurry at 8 steps.
 - **Krea 2** - depth control via the [`Patil/Krea-2-depth-controlnet`](https://huggingface.co/Patil/Krea-2-depth-controlnet) control-LoRA.
+- **FLUX.2** - two routes. On any variant, a control map wired into **Control** is used as a reference image, which steers loosely and costs nothing extra. On **dev**, pick the [`alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union`](https://huggingface.co/alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union) model for tight structural adherence: one union model covering canny, depth, pose, HED, MLSD, scribble and gray, with no mode to select. It needs real headroom, rendering at 512px on a 24 GB card.
 - **Control strength** - dial how hard the map is followed, per node.
 
 Drop ControlNet files into `core/models/controlnet/`, or use the node's model popup to download them.
@@ -271,7 +307,7 @@ For the full engineering story (the graph/sampler/device-policy design, the node
 
 **API Nodes** bring hosted, closed models onto the same canvas: no GPU, no setup, instant creative range. Add a Generate node, pick a model, and bring your own provider key (it stays on your machine); you pay the provider per render, and each node estimates the price before you run.
 
-The initial provider is **[fal](https://fal.ai)**, with models across image, video, and audio: **GPT Image 2**, **Nano Banana**, **Seedance**, **LTX**, **Sonilo**, and many more. Add your [fal.ai key](https://fal.ai/dashboard/keys) in Settings to use them. More providers will follow behind the same API Node surface.
+The initial provider is **[fal](https://fal.ai)**, with models across image, video, and audio: **FLUX.2**, **FLUX.2 Edit**, **GPT Image 2**, **Nano Banana**, **Seedance**, **LTX**, **Sonilo**, and many more. Add your [fal.ai key](https://fal.ai/dashboard/keys) in Settings to use them. More providers will follow behind the same API Node surface.
 
 However you render, the frame keeps its full, non-destructive take history, so you can mix API Nodes and local generation in the same film without ever losing a good version.
 
@@ -314,12 +350,16 @@ A dataset's trigger word is prepended to every caption during training, so the m
 
 ### Architecture and base model modes
 
-The Trainer's Adjust panel picks the **architecture** first (Z-Image or Krea 2), then a base within it. Training directly on a step-distilled checkpoint breaks the distillation down (turbo drift), so each architecture offers a way around that.
+The Trainer's Adjust panel picks the **architecture** first (Z-Image, Krea 2, or FLUX.2), then a base within it. Training directly on a step-distilled checkpoint breaks the distillation down (turbo drift), so each architecture offers a way around that.
 
 **Krea 2** avoids the problem outright, which is why it is the recommended path:
 
 - **Krea 2 RAW** trains on the undistilled base. Nothing to fuse, nothing to drift. Put `krea2_raw_bf16.safetensors` in `models/diffusion_models/`, train, then generate with the **Krea 2 Turbo** node - the LoRA carries over unchanged.
 - **Krea 2 Turbo + training adapter** exists for people who only hold Turbo. Put [ostris/krea2_turbo_training_adapter](https://huggingface.co/ostris/krea2_turbo_training_adapter) in `models/loras/`, or point `INLINE_KREA2_TRAIN_ADAPTER` at it.
+
+**FLUX.2** works like Krea 2, with no adapter to download:
+
+- **FLUX.2 Base** is the only option, and the trainer refuses a distilled checkpoint rather than letting a run produce a bad adapter hours later. Put `flux-2-klein-base-4b.safetensors` in `models/diffusion_models/`, train, then generate with the distilled **klein 4B** checkpoint. The LoRA carries over unchanged.
 
 **Z-Image** is distilled either way:
 
@@ -367,6 +407,8 @@ The LoRA a run produces lands in `models/loras/` and shows up in the LoRA loader
 
 A training adapter is free: it is fused into the base before training starts, so Turbo-plus-adapter and the undistilled base peak identically.
 
+FLUX.2 training figures have not been measured yet, so this table covers Z-Image and Krea 2 only.
+
 Which card fits what (24GB and 32GB are interpolated, not measured):
 
 | Card | Z-Image 512 | Z-Image 1024 | Krea 2 512 | Krea 2 1024 |
@@ -406,7 +448,7 @@ Krea 2's base is 26GB at bf16, which is what makes it expensive to fine-tune. Th
 - **Full precision (bf16)** forces the unquantized base.
 - **4-bit (NF4)** forces the quantized base.
 
-Z-Image has no 4-bit path and does not need one, so the setting only appears for Krea 2.
+The setting appears for Krea 2 and FLUX.2. Z-Image has no 4-bit path and does not need one: it trains in about 15 GB at 1024, so bf16 already fits the cards people have.
 
 To keep the peak down, the VAE and text encoder are loaded first, used to cache latents and captions, then freed before the transformer loads, so the peak is the transformer on its own rather than all three resident at once. If you do hit an out-of-memory error, lower the training resolution before changing anything else.
 
@@ -422,7 +464,7 @@ Only for **local** generation. The built-in Inline Core engine renders on the GP
 
 ### What models can I run?
 
-See [Two ways to generate](#two-ways-to-generate): local Z-Image or [Krea 2](#krea-2) on your own GPU, or hosted fal models. Adding a new local model is a Core change (a model runner), no UI release.
+See [Two ways to generate](#two-ways-to-generate): local Z-Image, [Krea 2](#krea-2), or [FLUX.2](#flux2) on your own GPU, or hosted fal models. Adding a new local model is a Core change (a model runner), no UI release.
 
 ## Contributing
 
@@ -438,6 +480,8 @@ The LoRA trainer's approach to training on a step-distilled model follows [**ai-
 
 Krea 2 support follows the reference implementations in [**diffusers**](https://github.com/huggingface/diffusers) (`Krea2Pipeline` and the Krea 2 DreamBooth LoRA example). Krea 2 is released by [Krea AI](https://www.krea.ai/) under the [Krea AI Community License](https://www.krea.ai/krea-2-licensing); the weights are the user's to obtain and use under that license.
 
+[**FLUX.2**](https://bfl.ai/blog/flux-2) is released by Black Forest Labs. klein 4B, its Base build, and the VAE are Apache 2.0; dev and the 9B builds carry non-commercial terms. The weights are the user's to obtain and use under those.
+
 ## Help shape Inline Studio
 
 Are you an AI filmmaker who wants to help us make this better? We run a **paid trial feedback program**: use Inline Studio on real work, tell us what helps and what gets in your way, and get paid for your time.
@@ -450,4 +494,4 @@ Come say hi on our [Discord](https://discord.gg/cSUS88VdY9) and reach out, we'll
 
 Copyright (C) 2026 Inline Studio. Licensed under the [GNU General Public License v3.0](LICENSE): you may use, study, share and modify it, and any work you distribute that builds on it must also be GPL-3.0.
 
-The models you run carry their own licenses, which the GPL does not change: Krea 2 is under the [Krea AI Community License](https://www.krea.ai/krea-2-licensing) and Z-Image under Tongyi's terms. You bring your own weights and use them under those.
+The models you run carry their own licenses, which the GPL does not change: Krea 2 is under the [Krea AI Community License](https://www.krea.ai/krea-2-licensing), Z-Image under Tongyi's terms, and FLUX.2 is split - klein 4B, its Base build, and the VAE are Apache 2.0, while dev and every 9B build are non-commercial. You bring your own weights and use them under those.

--- a/README.md
+++ b/README.md
@@ -307,9 +307,19 @@ For the full engineering story (the graph/sampler/device-policy design, the node
 
 **API Nodes** bring hosted, closed models onto the same canvas: no GPU, no setup, instant creative range. Add a Generate node, pick a model, and bring your own provider key (it stays on your machine); you pay the provider per render, and each node estimates the price before you run.
 
-The initial provider is **[fal](https://fal.ai)**, with models across image, video, and audio: **FLUX.2**, **FLUX.2 Edit**, **GPT Image 2**, **Nano Banana**, **Seedance**, **LTX**, **Sonilo**, and many more. Add your [fal.ai key](https://fal.ai/dashboard/keys) in Settings to use them. More providers will follow behind the same API Node surface.
+The initial provider is **[fal](https://fal.ai)**, with models across image, video, and audio: **FLUX.2**, **FLUX.2 Edit**, **GPT Image 2**, **Nano Banana**, **Seedance**, **MiniMax H3**, **LTX**, **Sonilo**, and many more. Add your [fal.ai key](https://fal.ai/dashboard/keys) in Settings to use them. More providers will follow behind the same API Node surface.
 
 However you render, the frame keeps its full, non-destructive take history, so you can mix API Nodes and local generation in the same film without ever losing a good version.
+
+### MiniMax H3
+
+H3 (Hailuo 03) is on the canvas as three nodes, all at 2K, 5 to 15 seconds:
+
+- **Text → Video** for a shot from nothing but a prompt.
+- **Image → Video** for a still you already like. It has two image dots: wire a start frame on its own, or add an end frame and H3 interpolates between the two.
+- **Reference → Video** for consistency across shots. Wire up to nine images, plus reference video and audio, and address them by position in the prompt: "Image 1 is the lead, Image 2 is her dog". Wiring order is the numbering you see on the node.
+
+Video costs $0.26 per second at 2K, so the node's price badge reads about $1.30 for a five second clip. Reference images past the first five and any reference video cost extra on top of that.
 
 ![Inline Studio dashboard with recent AI film projects](https://raw.githubusercontent.com/inlineresearch/Inline-Studio/main/screenshots/screenshot-dashboard.png)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="LICENSE"><img alt="License: GPLv3" src="https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge"></a>
   <a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/Python-3.11%2B-blue?style=for-the-badge&logo=python&logoColor=white"></a>
-  <a href="../../releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/Release-v1.2.53-blue?style=for-the-badge"></a>
+  <a href="../../releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/Release-v1.2.6-blue?style=for-the-badge"></a>
   <a href="https://discord.gg/cSUS88VdY9"><img alt="Join our Discord" src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white&style=for-the-badge"></a>
 </p>
 

--- a/core/CLAUDE.md
+++ b/core/CLAUDE.md
@@ -95,7 +95,16 @@ HTTP/WS  →  server/app.py  →  RunManager  →  Executor  →  Registry (desc
   the ComfyUI-equivalent decomposed graph and the intended long-term surface. **Descriptor-only
   today - their runners land in C2.** A graph built from them validates and type-checks but raises
   `No runner registered` at execution.
-- **Model runners** (`models/<name>/`) - high-level single generation nodes. **`alibaba/z-image-turbo`
+- **Model runners** (`models/<name>/`) - high-level single generation nodes. **`black-forest-labs/flux-2`
+  (`models/flux2/`) is the reference for a _family_:** one node covers klein 4B/9B, their base builds,
+  the KV variant and dev, because the picked checkpoint is identified from its own tensor shapes
+  (`flux2/variants.py`) and everything else follows. Adding a checkpoint is a row in that table.
+  Two rules it establishes: **identify a checkpoint by content, never by filename** (`diffusion_models/`
+  is shared across architectures, and Qwen3-4B and Qwen3-VL-4B have byte-identical embedding shapes),
+  and **derive geometry from the checkpoint** rather than bundling a config per variant, so a future
+  build loads with no code change. A **diffusers folder** is a valid checkpoint too, which is the only
+  way a 32B model reaches a 24 GB card: its NF4 shards stream through `from_pretrained`, where
+  `from_single_file` cannot quantize at all. **`alibaba/z-image-turbo`
   (`models/zimage/`) is the one runnable generation path today** (prompt + optional image → one take,
   backed by diffusers' `ZImagePipeline`/`ZImageImg2ImgPipeline`). This is the "Z-Image pipeline that
   already works" - the primitives will reach parity in C2. It loads from a **single diffusion
@@ -143,6 +152,18 @@ between nodes and are never takes.
   (Turing/Volta - compute capability < 8.0, e.g. a T4): same footprint, but it uses the fp16 tensor
   cores instead of bf16's slow path. The **VAE stays upcast** (bf16, or fp32 when the denoiser is
   fp16) because fp16 VAE decode can overflow to black/NaN images (`_compute_dtype` in `device/`).
+- **Quantization rungs** - the fit ladder is full-precision resident → int8 resident → **NF4 resident**
+  → sequential offload → wont-fit. NF4 is what makes a 32B model viable on a 24 GB card. Note int8
+  forces bf16 (torchao's weight-only int8 silently no-ops under fp16) while NF4 does not, so a Turing
+  card keeps its fp16 tensor cores under NF4.
+- **Prequantized checkpoints must not be re-quantized.** A checkpoint that ships already quantized
+  (`flux2/variants.is_prequantized`) has an on-disk size that already _is_ its resident size, so the
+  ladder's assumption that quantization halves it does not hold, and handing diffusers a second,
+  different quantization config is a hard error. Pass `Quantization.NONE` for those.
+- **Staged loading** - when the text encoder and the transformer cannot be co-resident (dev is a
+  15 GB encoder beside an 18 GB transformer), the prompt is encoded first and the encoder freed before
+  the transformer loads. The decision has to be made _before_ the load: by the time an OOM fires there
+  is nothing left to free.
 - **Multi-GPU** - `INLINE_PARALLEL` (e.g. `pipefusion=2`, `pipefusion=2,ulysses=2`); degrees multiply
   to the world size, which must equal the GPU count.
 
@@ -202,6 +223,11 @@ real codec that moves tensors lives with the model runner.
   Don't scatter it.
 - **Bring-your-own models.** Nothing is downloaded by the engine. The catalog scans; the user places
   files. A model picker is a `SELECT` param with `options_from="<category>"`.
+- **Verify image models by rendering.** The FLUX.2 work shipped five bugs past a green test suite,
+  and every one produced a _wrong image rather than an error_: a mis-keyed checkpoint, a
+  vision-language encoder loaded in place of a text one, an unnormalized latent, and a control context
+  cast to a quantized weight's `uint8` storage dtype. A unit test cannot see a plausible-but-wrong
+  image. Render something and look at it.
 - **Tests (pytest).** Cover the logic that matters: graph validate/topo/executor/cache, the catalog
   scan, the run store + server contract, the device/memory policy, the parallel group + xfuser seam,
   and each model runner (import-guarded, no GPU needed). See `tests/`.

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 # PyPI name; the import package is `inline_core` (src/inline_core).
 name = "inline-core"
-version = "1.2.53"
+version = "1.2.6"
 description = "The generation engine behind Inline Studio."
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -127,4 +127,6 @@ typeCheckingMode = "strict"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["src"]
+# "." so `tests` imports as a package: several suites share fixtures via `from tests.x import y`,
+# and without it those modules fail to collect and silently stop running.
+pythonpath = ["src", "."]

--- a/core/src/inline_core/device/memory.py
+++ b/core/src/inline_core/device/memory.py
@@ -47,6 +47,10 @@ _SMART_RESIDENT_MIN_VRAM_GB = 6.0
 # ~half the fp16 weight bytes. Deliberately generous so the estimate errs toward a lighter plan.
 _ACTIVATION_HEADROOM_GB = 2.5
 _INT8_FACTOR = 0.5
+# NF4 (bitsandbytes) stores 4-bit weights plus per-block scales, so ~0.55 bytes per parameter
+# against fp16's 2. The rung exists for the very large checkpoints (FLUX.2 dev and friends) that
+# int8 still cannot fit; it is CUDA-only and, like int8, never combined with CPU offload.
+_NF4_FACTOR = 0.28
 
 
 def _system_ram_gb() -> float | None:
@@ -222,7 +226,14 @@ class MemoryPolicy(DevicePolicy):
                 int8, budget, True,
                 "Weights are int8-quantized to fit this GPU's VRAM.",
             )
-        # int8 still won't fit resident -> CPU-offload streaming. Only viable if the (unquantized)
+        nf4 = big * _NF4_FACTOR + fixed
+        if nf4 <= cap:
+            return FitEstimate(
+                "nf4", Quantization.NF4, OffloadMode.NONE, prof(Profile.LOWVRAM),
+                nf4, budget, True,
+                "Weights are 4-bit (NF4) quantized to fit this GPU's VRAM.",
+            )
+        # Even 4-bit won't fit resident -> CPU-offload streaming. Only viable if the (unquantized)
         # model fits in system RAM, since sequential offload holds the off-GPU weights there.
         ram = self._ram_gb
         if ram is not None and full > ram:

--- a/core/src/inline_core/models/catalog.py
+++ b/core/src/inline_core/models/catalog.py
@@ -15,6 +15,8 @@ import hashlib
 import json
 from pathlib import Path
 
+from ..config import models_dir
+
 # Category subfolders scanned under the models root. These are the keys a param's `options_from`
 # may reference (see graph/primitives.py); ensure_dirs() creates them so drop-in is obvious.
 CATEGORIES: tuple[str, ...] = (
@@ -96,3 +98,22 @@ class ModelCatalog:
                 # A sharded model (config + shards) is one entry, named for its folder.
                 names.append(entry.name)
         return sorted(names)
+
+
+def resolve_picked(category: str, chosen: object) -> Path | None:
+    """A model dropdown's stored value, resolved to a file under ``category``.
+
+    The select serves bare filenames, but projects written before it did store the full relative
+    path, and joining one of those under the category doubles the prefix into a path that cannot
+    exist. So: try the value as given under the category, then its bare name there, then the value
+    as a path in its own right. Returns None when nothing matches, which callers must not stringify
+    (``str(None)`` reaching a loader reads as a corrupt file rather than a stale pick).
+    """
+    name = str(chosen or "").strip()
+    if not name:
+        return None
+    root = models_dir() / category
+    for candidate in (root / name, root / Path(name).name, Path(name)):
+        if candidate.exists():
+            return candidate
+    return None

--- a/core/src/inline_core/models/checkpoint.py
+++ b/core/src/inline_core/models/checkpoint.py
@@ -59,6 +59,11 @@ class CheckpointReader:
     def keys(self) -> list[str]:
         return list(self._index)
 
+    def shapes(self) -> dict[str, list[int]]:
+        """Every tensor's shape, from the header alone - no torch, no tensor read. Lets a caller
+        infer a checkpoint's architecture (layer counts, widths) before deciding how to load it."""
+        return {key: list(entry.get("shape") or []) for key, entry in self._index.items()}
+
     def get_tensor(self, key: str, device: str | None = None) -> Any:
         """One tensor, read straight from its byte range into a fresh buffer."""
         import torch

--- a/core/src/inline_core/models/flux2/__init__.py
+++ b/core/src/inline_core/models/flux2/__init__.py
@@ -1,0 +1,1 @@
+"""FLUX.2: one node over the whole checkpoint family (klein 4B/9B, their base builds, KV, dev)."""

--- a/core/src/inline_core/models/flux2/controlnet.py
+++ b/core/src/inline_core/models/flux2/controlnet.py
@@ -1,0 +1,234 @@
+"""The FLUX.2 Fun ControlNet Union: structural control for the dev checkpoint.
+
+`alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union` is a **VACE-style side branch**, not an inline
+adapter. Four extra double-stream blocks run in parallel with the base transformer's first four
+even-numbered blocks, and each contributes a residual back into the main image stream:
+
+    control_img_in(control_context) -> c
+    c = before_proj(c) + hidden_states          (block 0 only; before_proj is zero-init)
+    for each control block:  c = block(c);  hint = after_proj(c)
+    base block i (i in 0, 2, 4, 6):  hidden_states += hints[i // 2] * scale
+
+It is a genuine *union*: there is no mode index. Canny, depth, pose, HED, MLSD, scribble, gray and
+inpainting all arrive as the same VAE-encoded ``control_context``, and the model infers the modality
+from the image.
+
+Ported rather than imported: upstream this lives in ``videox_fun``, which would drag a whole video
+stack into the shared runtime extra. Only the control branch is ported - the blocks themselves are
+diffusers' own ``Flux2TransformerBlock``, whose keys the checkpoint matches exactly - and it hooks
+onto a stock ``Flux2Transformer2DModel``, so diffusers' denoise is untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from torch import nn
+
+from ...errors import ComponentError
+
+#: Which base double blocks receive a hint. The checkpoint carries four control blocks and the
+#: reference config maps them onto every other base block.
+CONTROL_LAYERS: tuple[int, ...] = (0, 2, 4, 6)
+
+#: Width of the packed control context: a 128-channel control latent, a 128-channel inpaint latent
+#: and a 4-channel mask, concatenated. Matches ``control_in_dim`` in the reference config.
+CONTROL_IN_DIM = 260
+
+
+class Flux2ControlBranch(nn.Module):
+    """The side branch: an input projection plus the control blocks and their residual taps."""
+
+    def __init__(self, inner_dim: int, num_attention_heads: int, attention_head_dim: int,
+                 mlp_ratio: float = 3.0, eps: float = 1e-6, layers: int = 4) -> None:
+        super().__init__()
+        from diffusers.models.transformers.transformer_flux2 import Flux2TransformerBlock
+
+        self.control_img_in = nn.Linear(CONTROL_IN_DIM, inner_dim)
+        self.control_transformer_blocks = nn.ModuleList(
+            Flux2TransformerBlock(
+                dim=inner_dim,
+                num_attention_heads=num_attention_heads,
+                attention_head_dim=attention_head_dim,
+                mlp_ratio=mlp_ratio,
+                eps=eps,
+            )
+            for _ in range(layers)
+        )
+        # Zero-init projections, so an untrained branch is exactly a no-op on the base model.
+        self.before_proj = nn.Linear(inner_dim, inner_dim)
+        self.after_proj = nn.ModuleList(nn.Linear(inner_dim, inner_dim) for _ in range(layers))
+        for layer in (self.before_proj, *self.after_proj):
+            nn.init.zeros_(layer.weight)
+            nn.init.zeros_(layer.bias)
+
+    def hints(self, hidden_states: torch.Tensor, control_context: torch.Tensor,
+              **block_kwargs: Any) -> list[torch.Tensor]:
+        """One residual per control layer, in ``CONTROL_LAYERS`` order."""
+        # Not ``.to(self.control_img_in.weight.dtype)``: once the branch is NF4 that weight is a
+        # bitsandbytes Params4bit with **uint8** storage, and casting the context to uint8 destroys
+        # it silently - the render completes and returns noise. The caller builds the context in the
+        # compute dtype already.
+        c = self.control_img_in(control_context)
+        c = self.before_proj(c) + hidden_states
+        encoder_hidden_states = block_kwargs.pop("encoder_hidden_states")
+        out: list[torch.Tensor] = []
+        for block, tap in zip(self.control_transformer_blocks, self.after_proj, strict=True):
+            # The branch carries its own text stream, exactly as the reference does.
+            encoder_hidden_states, c = block(
+                hidden_states=c, encoder_hidden_states=encoder_hidden_states, **block_kwargs
+            )
+            out.append(tap(c))
+        return out
+
+
+def load_control_branch(file: str, config: dict[str, Any], dtype: Any,
+                        device: str | None = None, quant: Any = None) -> Flux2ControlBranch:
+    """Build the branch from a single ``.safetensors`` and the base transformer's geometry.
+
+    Loaded to the CPU and quantized before it moves, so its 8.2 GB never has to sit on the card
+    beside an already-resident transformer - which on a 24 GB board is the difference between
+    fitting and not.
+    """
+    from accelerate import init_empty_weights
+    from safetensors.torch import load_file
+
+    heads = int(config["num_attention_heads"])
+    head_dim = int(config["attention_head_dim"])
+    with init_empty_weights():
+        branch = Flux2ControlBranch(
+            inner_dim=heads * head_dim,
+            num_attention_heads=heads,
+            attention_head_dim=head_dim,
+            mlp_ratio=float(config.get("mlp_ratio", 3.0)),
+            eps=float(config.get("eps", 1e-6)),
+        )
+    state = _remap(load_file(file, device="cpu"))
+    missing = set(branch.state_dict()) - set(state)
+    if missing:
+        raise ComponentError(
+            f"'{file}' is not a FLUX.2 Fun ControlNet Union ({len(missing)} tensors missing, e.g. "
+            f"{sorted(missing)[0]}). The 'lite' variants use a different geometry."
+        )
+    branch.load_state_dict({k: v.to(dtype) for k, v in state.items()}, strict=True, assign=True)
+    state.clear()
+    branch = branch.eval()
+
+    from ...device.policy import Quantization
+    from .. import loaders
+
+    if quant is Quantization.NF4:
+        # Swap on the CPU, then move: bitsandbytes quantizes during the move, so the full-size
+        # weights never touch the card.
+        loaders._swap_to_4bit(branch)
+        if device:
+            branch.to(device)
+    else:
+        if device:
+            branch.to(device)
+        loaders._quantize_in_place(branch, quant)  # torchao; no-op unless INT8
+    return branch
+
+
+def _remap(state: dict[str, Any]) -> dict[str, Any]:
+    """Checkpoint keys -> this module's layout.
+
+    Upstream keeps ``before_proj``/``after_proj`` inside each control block; here they are separate
+    module lists so the blocks stay stock diffusers ``Flux2TransformerBlock``s that a plain
+    ``load_state_dict`` can fill.
+    """
+    out: dict[str, Any] = {}
+    for key, value in state.items():
+        if ".before_proj." in key:
+            out["before_proj." + key.split(".before_proj.")[1]] = value
+        elif ".after_proj." in key:
+            index = key.split(".")[1]
+            out[f"after_proj.{index}." + key.split(".after_proj.")[1]] = value
+        else:
+            out[key] = value
+    return out
+
+
+def attach(transformer: Any, branch: Flux2ControlBranch, control_context: torch.Tensor,
+           scale: float = 0.75) -> list[Any]:
+    """Hook the branch onto a stock transformer; returns handles the caller must remove.
+
+    Hooks rather than a subclass: diffusers owns the denoise, and a forked ``forward`` would rot
+    silently the next time that file changes. The first base block's inputs are the branch's inputs
+    too, so a pre-hook there captures them and computes every hint in one pass.
+    """
+    blocks = transformer.transformer_blocks
+    if len(blocks) <= max(CONTROL_LAYERS):
+        raise ComponentError(
+            f"This ControlNet expects at least {max(CONTROL_LAYERS) + 1} double blocks, but the "
+            f"checkpoint has {len(blocks)}. It is built for FLUX.2 dev."
+        )
+    state: dict[str, list[torch.Tensor]] = {}
+
+    def compute(_module: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
+        hidden = kwargs.get("hidden_states", args[0] if args else None)
+        passthrough = {
+            k: kwargs[k]
+            for k in ("encoder_hidden_states", "temb_mod_img", "temb_mod_txt", "image_rotary_emb")
+            if k in kwargs
+        }
+        state["hints"] = branch.hints(hidden, control_context, **passthrough)
+
+    def add(index: int):
+        def hook(_module: Any, _args: Any, output: tuple[torch.Tensor, torch.Tensor]):
+            encoder_hidden_states, hidden = output
+            hint = state["hints"][CONTROL_LAYERS.index(index)]
+            return encoder_hidden_states, hidden + hint.to(hidden.dtype) * scale
+
+        return hook
+
+    handles = [blocks[0].register_forward_pre_hook(compute, with_kwargs=True)]
+    handles += [blocks[i].register_forward_hook(add(i)) for i in CONTROL_LAYERS]
+    return handles
+
+
+def build_context(pipe: Any, control_image: Any, height: int, width: int, dtype: Any,
+                  device: str, reference_tokens: int = 0) -> torch.Tensor:
+    """Pack a control map into the 260-channel context the branch consumes.
+
+    Layout, in this order: the VAE-encoded control map (128), a mask channel set (4), and an inpaint
+    latent (128). We only drive the control path, so the mask and inpaint slots are the zeros the
+    reference implementation uses when neither is supplied - the union model reads them as "no
+    inpainting requested" rather than as missing input.
+
+    The control latent is normalized by the VAE's running batch-norm statistics, the same way every
+    other FLUX.2 latent is; skipping that trains the branch's expectations off-manifold.
+
+    ``reference_tokens`` pads the context so it lines up with the sequence when reference images are
+    also wired: those tokens get no control signal.
+    """
+    import torch.nn.functional as functional
+    from diffusers import Flux2KleinPipeline as Packing
+
+    processed = pipe.image_processor.preprocess(control_image, height=height, width=width)
+    processed = processed.to(device=device, dtype=dtype)
+    latents = pipe.vae.encode(processed)[0].mode()
+
+    # Zeros mean "no inpainting": the reference builds an all-ones mask then inverts it.
+    mask = torch.zeros(
+        (latents.shape[0], 1, *latents.shape[-2:]), device=latents.device, dtype=latents.dtype
+    )
+    mask = functional.interpolate(mask, size=latents.shape[-2:], mode="nearest")
+    mask = Packing._pack_latents(Packing._patchify_latents(mask))
+    inpaint = Packing._pack_latents(Packing._patchify_latents(torch.zeros_like(latents)))
+
+    mean = pipe.vae.bn.running_mean.view(1, -1, 1, 1).to(latents.device, latents.dtype)
+    std = torch.sqrt(pipe.vae.bn.running_var.view(1, -1, 1, 1) + pipe.vae.config.batch_norm_eps)
+    control = Packing._patchify_latents(latents)
+    control = (control - mean) / std.to(latents.device, latents.dtype)
+    control = Packing._pack_latents(control)
+
+    context = torch.cat([control, mask, inpaint], dim=2)
+    if reference_tokens:
+        pad = torch.zeros(
+            (context.shape[0], reference_tokens, context.shape[2]),
+            device=context.device, dtype=context.dtype,
+        )
+        context = torch.cat([context, pad], dim=1)
+    return context

--- a/core/src/inline_core/models/flux2/embeds.py
+++ b/core/src/inline_core/models/flux2/embeds.py
@@ -1,0 +1,165 @@
+"""Prompt embeddings for FLUX.2, cached on disk so iterating never reloads the text encoder.
+
+FLUX.2's encoder is a large fraction of the model: Qwen3-4B is roughly half of klein 4B's total
+footprint, and dev's Mistral-3 dwarfs even the 32B transformer. The encoder is also the one
+component whose output depends on nothing but the prompt, so re-encoding it to change a seed or a
+resolution is pure waste - and on a tight card it is the difference between the denoise fitting and
+not.
+
+So the embedding is computed once, written to the engine data dir keyed by everything that can
+change it, and read back on later runs. A cache hit skips the encoder entirely: the pipeline is
+built with the encoder detached and the denoise gets its VRAM. Roughly 8 MB per klein prompt and
+16 MB per dev prompt, pruned oldest-first against a size cap.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from typing import Any
+
+from ...config import data_dir
+from ...device.policy import DevicePolicy
+from .. import pipeline_runtime as rt
+
+logger = logging.getLogger("inline_core.flux2")
+
+#: Total bytes of cached embeddings to keep. Small next to a checkpoint, and one entry per distinct
+#: prompt, so this holds hundreds of prompts before anything is evicted.
+_CACHE_LIMIT_BYTES = 2 * 1024**3
+
+
+def _root() -> Path:
+    return data_dir() / "embeds" / "flux2"
+
+
+def cache_key(
+    *, prompt: str, text_encoder_file: str, layers: tuple[int, ...], max_sequence_length: int,
+    dtype: str,
+) -> str:
+    """Everything that changes the embedding. The encoder *file* is in the key, not just the
+    variant, so swapping in a different Qwen3 build invalidates rather than silently reusing."""
+    parts = (
+        prompt, text_encoder_file, ",".join(str(n) for n in layers), str(max_sequence_length), dtype
+    )
+    return hashlib.sha256("\x1f".join(parts).encode()).hexdigest()[:32]
+
+
+def load(key: str) -> Any | None:
+    """A cached embedding tensor, or None. A corrupt or unreadable entry just misses."""
+    path = _root() / f"{key}.pt"
+    if not path.is_file():
+        return None
+    try:
+        import torch
+
+        embeds = torch.load(path, map_location="cpu", weights_only=True)
+    except Exception:  # noqa: BLE001 - a bad cache entry must never break a run
+        logger.warning("Discarding unreadable prompt-embed cache entry %s", path.name)
+        path.unlink(missing_ok=True)
+        return None
+    path.touch()  # keep recently used entries away from the pruner
+    return embeds
+
+
+def store(key: str, embeds: Any) -> None:
+    """Write an embedding to the cache. Best-effort - a full or read-only disk is not an error."""
+    try:
+        import torch
+
+        root = _root()
+        root.mkdir(parents=True, exist_ok=True)
+        path = root / f"{key}.pt"
+        staging = path.with_suffix(".part")
+        torch.save(rt.embeds_to(embeds, "cpu"), staging)
+        staging.replace(path)  # atomic, so a crash mid-write never leaves a half entry
+        _prune(root)
+    except Exception as error:  # noqa: BLE001 - caching is an optimization, never a requirement
+        logger.debug("Could not cache prompt embeddings: %s", error)
+
+
+def _prune(root: Path) -> None:
+    entries = sorted(
+        (p for p in root.glob("*.pt") if p.is_file()), key=lambda p: p.stat().st_mtime, reverse=True
+    )
+    total = 0
+    for entry in entries:
+        total += entry.stat().st_size
+        if total > _CACHE_LIMIT_BYTES:
+            entry.unlink(missing_ok=True)
+
+
+def prompt_kwargs(
+    pipe: Any,
+    policy: DevicePolicy,
+    *,
+    prompt: str,
+    negative: str | None,
+    text_encoder_file: str,
+    layers: tuple[int, ...],
+    max_sequence_length: int = 512,
+) -> dict[str, Any]:
+    """Pipeline call kwargs carrying precomputed embeddings, from cache when possible.
+
+    Falls back to handing the pipeline the raw prompt if anything goes wrong, so this optimization
+    can never be the reason a render fails.
+    """
+    device = str(policy.placement("denoiser").device)
+    dtype = policy.placement("text_encoder").dtype.value
+    key = cache_key(
+        prompt=prompt,
+        text_encoder_file=text_encoder_file,
+        layers=layers,
+        max_sequence_length=max_sequence_length,
+        dtype=dtype,
+    )
+    negative_key = (
+        None
+        if negative is None
+        else cache_key(
+            prompt=negative,
+            text_encoder_file=text_encoder_file,
+            layers=layers,
+            max_sequence_length=max_sequence_length,
+            dtype=dtype,
+        )
+    )
+
+    cached = load(key)
+    cached_negative = load(negative_key) if negative_key else None
+    if cached is not None and (negative_key is None or cached_negative is not None):
+        logger.info("Prompt-embed cache hit - skipping the text encoder entirely")
+        kwargs: dict[str, Any] = {"prompt_embeds": rt.embeds_to(cached, device)}
+        if cached_negative is not None:
+            kwargs["negative_prompt_embeds"] = rt.embeds_to(cached_negative, device)
+        return kwargs
+
+    def raw() -> dict[str, Any]:
+        return {"prompt": prompt}
+
+    def encode(target: str) -> dict[str, Any]:
+        # encode_prompt is not wrapped in the pipeline's @torch.no_grad (only __call__ is); the
+        # caller (encoded_prompt_kwargs) supplies it.
+        import torch
+
+        embeds, _ids = pipe.encode_prompt(
+            prompt=prompt,
+            device=torch.device(target),
+            max_sequence_length=max_sequence_length,
+            text_encoder_out_layers=layers,
+        )
+        store(key, embeds)
+        out: dict[str, Any] = {"prompt_embeds": rt.embeds_to(embeds, target)}
+        if negative is not None and negative_key is not None:
+            negative_embeds, _negative_ids = pipe.encode_prompt(
+                prompt=negative,
+                device=torch.device(target),
+                max_sequence_length=max_sequence_length,
+                text_encoder_out_layers=layers,
+            )
+            store(negative_key, negative_embeds)
+            out["negative_prompt_embeds"] = rt.embeds_to(negative_embeds, target)
+        return out
+
+    return rt.encoded_prompt_kwargs(pipe, policy, encode=encode, fallback=raw)

--- a/core/src/inline_core/models/flux2/provider.py
+++ b/core/src/inline_core/models/flux2/provider.py
@@ -8,11 +8,14 @@ from typing import Any
 from ...config import models_dir
 from ..requirements import ModelComponent
 from .requirements import (
+    flux2_checkpoints,
+    flux2_encoders,
     flux2_requirements,
     footprint_bytes,
     resolve_diffusion,
     resolve_text_encoder,
     resolve_vae,
+    resolved_variant,
 )
 
 
@@ -28,6 +31,29 @@ class Flux2Provider:
 
     def download_target(self, component: ModelComponent) -> Path:
         return models_dir() / component.category
+
+    def resolved(self) -> dict[str, str]:
+        """What the node would load right now, so its pickers open on the real files rather than
+        on "auto". Names are relative to their category folder, matching the dropdown values."""
+        picks = {
+            "model": resolve_diffusion(None),
+            "vae": resolve_vae(None),
+            "text_encoder": resolve_text_encoder(None),
+        }
+        out = {key: path.name for key, path in picks.items() if path is not None}
+        variant = resolved_variant(None)
+        if variant is not None:
+            out["variant"] = variant.key
+        return out
+
+    def catalog_options(self, category: str) -> list[str] | None:
+        """Only the files this node can actually load. The categories are shared with Z-Image and
+        Krea 2, so an unfiltered list offers checkpoints that would fail on load."""
+        if category == "diffusion_models":
+            return [p.name for p in flux2_checkpoints()]
+        if category == "text_encoders":
+            return [p.name for p in flux2_encoders()]
+        return None
 
     def estimate(self, policy: Any) -> dict[str, Any] | None:
         """Whether the installed checkpoint fits this machine, and how, so the popup warns before a

--- a/core/src/inline_core/models/flux2/provider.py
+++ b/core/src/inline_core/models/flux2/provider.py
@@ -1,0 +1,58 @@
+"""FLUX.2's answer to "what do I need on disk" - the model popup's data source for the node."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ...config import models_dir
+from ..requirements import ModelComponent
+from .requirements import (
+    flux2_requirements,
+    footprint_bytes,
+    resolve_diffusion,
+    resolve_text_encoder,
+    resolve_vae,
+)
+
+
+class Flux2Provider:
+    """Requirements + fit estimate for the FLUX.2 node.
+
+    One provider covers every variant: the popup shows the required set for whichever checkpoint is
+    installed, plus the rest of the family as optional downloads.
+    """
+
+    def components(self, params: dict[str, object] | None = None) -> list[ModelComponent]:
+        return flux2_requirements(params)
+
+    def download_target(self, component: ModelComponent) -> Path:
+        return models_dir() / component.category
+
+    def estimate(self, policy: Any) -> dict[str, Any] | None:
+        """Whether the installed checkpoint fits this machine, and how, so the popup warns before a
+        load. Pure ``stat`` plus a live VRAM/RAM probe; None when it cannot be sized."""
+        if policy is None:
+            return None
+        try:
+            from ...device.policy import ModelFootprint
+        except ImportError:
+            return None
+        footprint = ModelFootprint(
+            **footprint_bytes(
+                resolve_diffusion(None), resolve_vae(None), resolve_text_encoder(None)
+            )
+        )
+        fit = policy.estimate_fit(footprint)  # pure - never mutates the shared policy
+        if fit is None:
+            return None
+        soft = not fit.fits or fit.plan in ("int8", "nf4", "offload")
+        return {
+            "plan": fit.plan,
+            "fits": fit.fits,
+            "requiredVramMb": int(fit.required_vram_gb * 1024),
+            "totalVramMb": int(fit.total_vram_gb * 1024) if fit.total_vram_gb else None,
+            "freeVramMb": policy.free_vram_mb(),
+            "freeRamMb": policy.free_ram_mb(),
+            "warning": fit.note if soft else None,
+        }

--- a/core/src/inline_core/models/flux2/requirements.py
+++ b/core/src/inline_core/models/flux2/requirements.py
@@ -1,0 +1,354 @@
+"""What FLUX.2 needs on disk, and whether it is there - the data behind the node's model popup.
+
+**No hidden downloads.** A component counts as present only because the user placed the file under
+``models/`` or fetched it through the popup. Nothing here ever reaches the network.
+
+Torch-free (pure filesystem + safetensors headers) so the popup works on an install with no ML
+stack. One node covers the whole family, so the popup lists it as: three required components that
+default to the Apache-2.0 klein 4B build, plus the rest of the family as optional extras that never
+block a run. Which components are *required* follows whichever checkpoint is actually installed, so
+a user who downloaded klein 9B is asked for the Qwen3-8B encoder rather than the 4B one.
+
+Files are matched by reading each candidate's header rather than trusting its name, which is what
+lets a Z-Image, Krea 2 and FLUX.2 checkpoint share ``diffusion_models/`` safely.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+from ...config import models_dir
+from ..requirements import ModelComponent
+from . import variants as V
+
+__all__ = [
+    "DIFFUSION_FILE",
+    "SPLIT_REPO",
+    "TEXT_ENCODER_FILE",
+    "VAE_FILE",
+    "download_target",
+    "flux2_requirements",
+    "footprint_bytes",
+    "resolve_diffusion",
+    "resolve_text_encoder",
+    "resolve_vae",
+    "resolved_variant",
+]
+
+#: ComfyUI's repackaged single files: ungated, one consolidated ``.safetensors`` per component, and
+#: the same layout Z-Image already downloads from. BFL's own repos are gated for every build except
+#: klein 4B, which would break the one-click popup.
+SPLIT_REPO = "Comfy-Org/flux2-klein-4B"
+_SPLIT_PREFIX = "split_files"
+
+#: The default one-click set: klein 4B is Apache-2.0, four steps, and the only build that fits a
+#: 16 GB card comfortably. Everything else is offered as an optional extra below.
+DIFFUSION_FILE = "flux-2-klein-4b.safetensors"
+TEXT_ENCODER_FILE = "qwen_3_4b.safetensors"
+VAE_FILE = "flux2-vae.safetensors"
+
+_WEIGHT_SUFFIXES = (".safetensors", ".sft", ".gguf")
+
+#: The rest of the family, offered as suggestions. Each is (id, label, category, repo, repo_file).
+_EXTRAS: tuple[tuple[str, str, str, str, str], ...] = (
+    (
+        "diffusion_klein_4b_base",
+        "Klein 4B Base (for LoRA training)",
+        "diffusion_models",
+        "Comfy-Org/flux2-klein-4B",
+        f"{_SPLIT_PREFIX}/diffusion_models/flux-2-klein-base-4b.safetensors",
+    ),
+    (
+        "diffusion_klein_9b",
+        "Klein 9B (int8, needs ~12 GB VRAM)",
+        "diffusion_models",
+        "Sakujo/FLUX.2-Klein-9B-INT8-ConvRot",
+        "flux-2-klein-9b-int8-ConvRot-comfyui.safetensors",
+    ),
+    (
+        "text_encoder_qwen3_8b",
+        "Qwen3-8B text encoder (for Klein 9B)",
+        "text_encoders",
+        "Comfy-Org/flux2-klein-9B",
+        f"{_SPLIT_PREFIX}/text_encoders/qwen_3_8b.safetensors",
+    ),
+    (
+        "diffusion_dev",
+        "FLUX.2 dev (fp8, needs ~32 GB VRAM)",
+        "diffusion_models",
+        "Comfy-Org/flux2-dev",
+        f"{_SPLIT_PREFIX}/diffusion_models/flux2_dev_fp8mixed.safetensors",
+    ),
+    (
+        "text_encoder_mistral",
+        "Mistral-3 text encoder (for dev)",
+        "text_encoders",
+        "Comfy-Org/flux2-dev",
+        f"{_SPLIT_PREFIX}/text_encoders/mistral_3_small_flux2_fp8.safetensors",
+    ),
+)
+
+
+# --- filesystem resolution -----------------------------------------------------------------------
+
+
+def _category(name: str) -> Path:
+    return models_dir() / name
+
+
+def _weight_files(category: str) -> list[Path]:
+    root = _category(category)
+    if not root.is_dir():
+        return []
+    return sorted(
+        p for p in root.iterdir() if p.is_file() and p.suffix.lower() in _WEIGHT_SUFFIXES
+    )
+
+
+#: Header reads are cheap but the popup opens often, so identification is memoized on
+#: (path, size, mtime) - a replaced file re-identifies, an untouched one does not.
+_IDENTIFIED: dict[tuple[str, int, int], V.Flux2Variant | None] = {}
+
+
+def _identify(path: Path) -> V.Flux2Variant | None:
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    key = (str(path), stat.st_size, int(stat.st_mtime))
+    if key not in _IDENTIFIED:
+        # A GGUF header is not safetensors, so those fall back to the filename.
+        gguf = path.suffix.lower() == ".gguf"
+        _IDENTIFIED[key] = _identify_gguf(path) if gguf else V.detect(path)
+    return _IDENTIFIED[key]
+
+
+def _identify_gguf(path: Path) -> V.Flux2Variant | None:
+    """A ``.gguf`` checkpoint has no safetensors header to size, so it is identified by name.
+    Only files that clearly say FLUX.2 are claimed; anything else is left for another node."""
+    name = "-" + re.sub(r"[^a-z0-9]+", "-", path.name.lower()) + "-"
+    if "-flux" not in name or "2" not in name:
+        return None
+    is_base, is_kv = "-base-" in name, "-kv-" in name
+    if "-dev-" in name:
+        return V.get("dev")
+    size = "9b" if "-9b-" in name else "4b"
+    if is_kv and size == "9b":
+        return V.get("klein-9b-kv")
+    return V.get(f"klein-{size}-base" if is_base else f"klein-{size}")
+
+
+def _encoder_width(path: Path) -> int | None:
+    """The hidden width of a **plain** text-only Qwen3 checkpoint, or None if it is anything else.
+
+    Width alone is not enough to identify an encoder. Qwen3-4B and Qwen3-VL-4B (which Krea 2 uses,
+    and which sits in the same ``text_encoders/`` folder) share an embedding matrix of exactly
+    151936 x 2560, so matching on width alone silently loaded the vision-language model into
+    FLUX.2's text-only encoder and rendered structured noise. A multimodal checkpoint carries a
+    vision tower and nests its text stack under ``language_model``; both are rejected here.
+    """
+    if path.suffix.lower() not in (".safetensors", ".sft"):
+        return None
+    try:
+        from ..checkpoint import CheckpointReader
+
+        keys = CheckpointReader(path).shapes()
+    except Exception:  # noqa: BLE001 - an unreadable file simply does not match
+        return None
+    if any(".visual." in k or ".vision_" in k or ".language_model." in k for k in keys):
+        return None
+    for key, shape in keys.items():
+        if key.endswith("embed_tokens.weight") and len(shape) == 2:
+            return shape[1]
+    return None
+
+
+def resolve_diffusion(params: dict[str, object] | None = None) -> Path | None:
+    """The FLUX.2 checkpoint to load: an explicit dropdown pick, ``INLINE_FLUX2_MODEL``, else the
+    first file in ``diffusion_models/`` that identifies as FLUX.2. Files belonging to another
+    architecture are skipped rather than mis-loaded."""
+    env = os.environ.get("INLINE_FLUX2_MODEL", "").strip()
+    if env:
+        path = Path(env)
+        return path if path.exists() else None
+    chosen = str((params or {}).get("model") or "").strip()
+    if chosen:
+        picked = _category("diffusion_models") / chosen
+        return picked if picked.is_file() else None
+    return next((p for p in _weight_files("diffusion_models") if _identify(p) is not None), None)
+
+
+def resolved_variant(params: dict[str, object] | None = None) -> V.Flux2Variant | None:
+    """Which variant the node will actually run: the explicit ``variant`` param, else whatever the
+    resolved checkpoint identifies as."""
+    forced = V.get(str((params or {}).get("variant") or ""))
+    if forced is not None:
+        return forced
+    diffusion = resolve_diffusion(params)
+    return _identify(diffusion) if diffusion is not None else None
+
+
+def resolve_vae(params: dict[str, object] | None = None) -> Path | None:
+    """The FLUX.2 VAE file. Matched on the exact recommended name first, since ``vae/`` is shared
+    with Z-Image's ``ae.safetensors`` and Krea 2's."""
+    env = os.environ.get("INLINE_FLUX2_VAE", "").strip()
+    if env:
+        path = Path(env)
+        return path if path.exists() else None
+    chosen = str((params or {}).get("vae") or "").strip()
+    if chosen:
+        picked = _category("vae") / chosen
+        return picked if picked.is_file() else None
+    files = _weight_files("vae")
+    exact = _category("vae") / VAE_FILE
+    if exact.is_file():
+        return exact
+    named = [p for p in files if "flux" in p.name.lower()]
+    return named[0] if named else None
+
+
+def resolve_text_encoder(params: dict[str, object] | None = None) -> Path | None:
+    """The text encoder matching the resolved checkpoint. Matched by embedding width (the
+    transformer's joint width is 3x the encoder's hidden size), so the Qwen3-4B file Z-Image already
+    uses is picked for klein 4B and never for klein 9B."""
+    env = os.environ.get("INLINE_FLUX2_TEXT_ENCODER", "").strip()
+    if env:
+        path = Path(env)
+        return path if path.exists() else None
+    chosen = str((params or {}).get("text_encoder") or "").strip()
+    if chosen:
+        picked = _category("text_encoders") / chosen
+        return picked if picked.is_file() else None
+    files = _weight_files("text_encoders")
+    if not files:
+        return None
+    variant = resolved_variant(params) or V.get("klein-4b")
+    if variant is None:
+        return files[0]
+    wanted = variant.joint_attention_dim // 3
+    sized = [p for p in files if _encoder_width(p) == wanted]
+    if sized:
+        return sized[0]
+    # klein stops here on purpose. A name fallback would re-admit the vision-language model this
+    # check exists to exclude ("qwen" matches "qwen3vl"), and reporting the encoder as missing is
+    # far better than rendering noise from the wrong one.
+    if variant.pipeline != "dev":
+        return None
+    # dev's Mistral-3 encoder is legitimately multimodal and is sharded, so it has no single
+    # embedding matrix to size; the name is the only signal available.
+    named = [p for p in files if "mistral" in p.name.lower()]
+    return named[0] if named else None
+
+
+# --- the requirements view (the popup's data) -----------------------------------------------------
+
+
+def _component(
+    *, id: str, label: str, category: str, filename: str, present: bool, repo: str, repo_file: str,
+    optional: bool = False,
+) -> ModelComponent:
+    return ModelComponent(
+        id=id,
+        label=label,
+        category=category,
+        present=present,
+        filename=filename,
+        repo=repo,
+        repo_file=repo_file,
+        optional=optional,
+    )
+
+
+def _split(category: str, filename: str) -> str:
+    return f"{_SPLIT_PREFIX}/{category}/{filename}"
+
+
+def flux2_requirements(params: dict[str, object] | None = None) -> list[ModelComponent]:
+    """The popup's rows: the three required components for whichever checkpoint is installed (or
+    klein 4B's when none is), then the rest of the family as optional downloads."""
+    variant = resolved_variant(params)
+    text_encoder = resolve_text_encoder(params)
+    encoder_label = "Text encoder"
+    if variant is not None:
+        encoder_label = f"Text encoder ({'Mistral-3' if variant.pipeline == 'dev' else 'Qwen3'})"
+
+    required = [
+        _component(
+            id="diffusion",
+            label="Diffusion model" + (f" ({variant.label})" if variant else ""),
+            category="diffusion_models",
+            filename=DIFFUSION_FILE,
+            present=variant is not None,
+            repo=SPLIT_REPO,
+            repo_file=_split("diffusion_models", DIFFUSION_FILE),
+        ),
+        _component(
+            id="text_encoder",
+            label=encoder_label,
+            category="text_encoders",
+            filename=TEXT_ENCODER_FILE,
+            present=text_encoder is not None,
+            repo=SPLIT_REPO,
+            repo_file=_split("text_encoders", TEXT_ENCODER_FILE),
+        ),
+        _component(
+            id="vae",
+            label="VAE",
+            category="vae",
+            filename=VAE_FILE,
+            present=resolve_vae(params) is not None,
+            repo=SPLIT_REPO,
+            repo_file=_split("vae", VAE_FILE),
+        ),
+    ]
+    extras = [
+        _component(
+            id=extra_id,
+            label=label,
+            category=category,
+            filename=Path(repo_file).name,
+            present=(_category(category) / Path(repo_file).name).is_file(),
+            repo=repo,
+            repo_file=repo_file,
+            optional=True,
+        )
+        for extra_id, label, category, repo, repo_file in _EXTRAS
+    ]
+    return required + extras
+
+
+def download_target(component: ModelComponent) -> Path:
+    """Where the component's file lands: its category folder, flat, under the models root."""
+    return _category(component.category)
+
+
+# --- memory footprint ----------------------------------------------------------------------------
+
+
+def _file_bytes(path: object) -> int:
+    text = str(path or "").strip()
+    if not text:
+        return 0
+    try:
+        p = Path(text)
+        return p.stat().st_size if p.is_file() else 0
+    except OSError:
+        return 0
+
+
+def footprint_bytes(
+    diffusion: object = None,
+    vae: object = None,
+    text_encoder: object = None,
+    controlnet: object = None,
+) -> dict[str, int]:
+    """On-disk sizes keyed to match ``ModelFootprint``, for the device policy's fit estimate. A
+    torch-free ``stat``, so the popup can size the load without the runtime installed."""
+    return {
+        "diffusion_bytes": _file_bytes(diffusion),
+        "text_encoder_bytes": _file_bytes(text_encoder),
+        "vae_bytes": _file_bytes(vae),
+        "controlnet_bytes": _file_bytes(controlnet),
+    }

--- a/core/src/inline_core/models/flux2/requirements.py
+++ b/core/src/inline_core/models/flux2/requirements.py
@@ -29,6 +29,8 @@ __all__ = [
     "TEXT_ENCODER_FILE",
     "VAE_FILE",
     "download_target",
+    "flux2_checkpoints",
+    "flux2_encoders",
     "flux2_requirements",
     "footprint_bytes",
     "resolve_diffusion",
@@ -99,11 +101,19 @@ def _category(name: str) -> Path:
 
 
 def _weight_files(category: str) -> list[Path]:
+    """Every candidate in a category: consolidated single files, plus diffusers-format folders.
+
+    A prequantized dev checkpoint ships as a folder of shards, which is the only practical way to
+    put a 32B model on a 24 GB card - the NF4 weights are already quantized on disk, so nothing has
+    to be materialized at full size first."""
     root = _category(category)
     if not root.is_dir():
         return []
     return sorted(
-        p for p in root.iterdir() if p.is_file() and p.suffix.lower() in _WEIGHT_SUFFIXES
+        p
+        for p in root.iterdir()
+        if (p.is_file() and p.suffix.lower() in _WEIGHT_SUFFIXES)
+        or (p.is_dir() and (p / "config.json").is_file())
     )
 
 
@@ -114,13 +124,15 @@ _IDENTIFIED: dict[tuple[str, int, int], V.Flux2Variant | None] = {}
 
 def _identify(path: Path) -> V.Flux2Variant | None:
     try:
-        stat = path.stat()
+        target = path / "config.json" if path.is_dir() else path
+        stat = target.stat()
     except OSError:
         return None
     key = (str(path), stat.st_size, int(stat.st_mtime))
     if key not in _IDENTIFIED:
-        # A GGUF header is not safetensors, so those fall back to the filename.
-        gguf = path.suffix.lower() == ".gguf"
+        # A GGUF header is not safetensors, so those fall back to the filename. A folder carries a
+        # config.json, which V.detect reads directly.
+        gguf = path.is_file() and path.suffix.lower() == ".gguf"
         _IDENTIFIED[key] = _identify_gguf(path) if gguf else V.detect(path)
     return _IDENTIFIED[key]
 
@@ -149,6 +161,8 @@ def _encoder_width(path: Path) -> int | None:
     FLUX.2's text-only encoder and rendered structured noise. A multimodal checkpoint carries a
     vision tower and nests its text stack under ``language_model``; both are rejected here.
     """
+    if path.is_dir():
+        return _folder_encoder_width(path)
     if path.suffix.lower() not in (".safetensors", ".sft"):
         return None
     try:
@@ -165,6 +179,48 @@ def _encoder_width(path: Path) -> int | None:
     return None
 
 
+
+def _folder_encoder_width(folder: Path) -> int | None:
+    """A diffusers-format encoder folder states its width, and whether it is multimodal, in its
+    config. dev's Mistral-3 encoder legitimately is multimodal, so unlike the single-file check this
+    does not disqualify a vision tower - it reports the text stack's width."""
+    marker = folder / "config.json"
+    if not marker.is_file():
+        return None
+    try:
+        import json
+
+        config = json.loads(marker.read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(config, dict):
+        return None
+    text = config.get("text_config")
+    if isinstance(text, dict) and isinstance(text.get("hidden_size"), int):
+        return int(text["hidden_size"])
+    size = config.get("hidden_size")
+    return int(size) if isinstance(size, int) else None
+
+
+def flux2_checkpoints() -> list[Path]:
+    """Every FLUX.2 checkpoint installed, identified by content rather than by name."""
+    return [p for p in _weight_files("diffusion_models") if _identify(p) is not None]
+
+
+def flux2_encoders() -> list[Path]:
+    """Text encoders matching an installed FLUX.2 checkpoint's width, plus dev's Mistral."""
+    variants = {v.joint_attention_dim // 3 for v in map(_identify, flux2_checkpoints()) if v} or {
+        2560
+    }
+    out = [p for p in _weight_files("text_encoders") if _encoder_width(p) in variants]
+    out += [
+        p
+        for p in _weight_files("text_encoders")
+        if p not in out and "mistral" in p.name.lower()
+    ]
+    return out
+
+
 def resolve_diffusion(params: dict[str, object] | None = None) -> Path | None:
     """The FLUX.2 checkpoint to load: an explicit dropdown pick, ``INLINE_FLUX2_MODEL``, else the
     first file in ``diffusion_models/`` that identifies as FLUX.2. Files belonging to another
@@ -176,7 +232,7 @@ def resolve_diffusion(params: dict[str, object] | None = None) -> Path | None:
     chosen = str((params or {}).get("model") or "").strip()
     if chosen:
         picked = _category("diffusion_models") / chosen
-        return picked if picked.is_file() else None
+        return picked if picked.exists() else None
     return next((p for p in _weight_files("diffusion_models") if _identify(p) is not None), None)
 
 
@@ -200,7 +256,7 @@ def resolve_vae(params: dict[str, object] | None = None) -> Path | None:
     chosen = str((params or {}).get("vae") or "").strip()
     if chosen:
         picked = _category("vae") / chosen
-        return picked if picked.is_file() else None
+        return picked if picked.exists() else None
     files = _weight_files("vae")
     exact = _category("vae") / VAE_FILE
     if exact.is_file():
@@ -220,7 +276,7 @@ def resolve_text_encoder(params: dict[str, object] | None = None) -> Path | None
     chosen = str((params or {}).get("text_encoder") or "").strip()
     if chosen:
         picked = _category("text_encoders") / chosen
-        return picked if picked.is_file() else None
+        return picked if picked.exists() else None
     files = _weight_files("text_encoders")
     if not files:
         return None
@@ -333,6 +389,8 @@ def _file_bytes(path: object) -> int:
         return 0
     try:
         p = Path(text)
+        if p.is_dir():
+            return sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
         return p.stat().st_size if p.is_file() else 0
     except OSError:
         return 0

--- a/core/src/inline_core/models/flux2/requirements.py
+++ b/core/src/inline_core/models/flux2/requirements.py
@@ -20,6 +20,7 @@ import re
 from pathlib import Path
 
 from ...config import models_dir
+from ..catalog import resolve_picked
 from ..requirements import ModelComponent
 from . import variants as V
 
@@ -229,10 +230,9 @@ def resolve_diffusion(params: dict[str, object] | None = None) -> Path | None:
     if env:
         path = Path(env)
         return path if path.exists() else None
-    chosen = str((params or {}).get("model") or "").strip()
-    if chosen:
-        picked = _category("diffusion_models") / chosen
-        return picked if picked.exists() else None
+    chosen = (params or {}).get("model")
+    if str(chosen or "").strip():
+        return resolve_picked("diffusion_models", chosen)
     return next((p for p in _weight_files("diffusion_models") if _identify(p) is not None), None)
 
 
@@ -253,10 +253,9 @@ def resolve_vae(params: dict[str, object] | None = None) -> Path | None:
     if env:
         path = Path(env)
         return path if path.exists() else None
-    chosen = str((params or {}).get("vae") or "").strip()
-    if chosen:
-        picked = _category("vae") / chosen
-        return picked if picked.exists() else None
+    chosen = (params or {}).get("vae")
+    if str(chosen or "").strip():
+        return resolve_picked("vae", chosen)
     files = _weight_files("vae")
     exact = _category("vae") / VAE_FILE
     if exact.is_file():
@@ -273,10 +272,9 @@ def resolve_text_encoder(params: dict[str, object] | None = None) -> Path | None
     if env:
         path = Path(env)
         return path if path.exists() else None
-    chosen = str((params or {}).get("text_encoder") or "").strip()
-    if chosen:
-        picked = _category("text_encoders") / chosen
-        return picked if picked.exists() else None
+    chosen = (params or {}).get("text_encoder")
+    if str(chosen or "").strip():
+        return resolve_picked("text_encoders", chosen)
     files = _weight_files("text_encoders")
     if not files:
         return None
@@ -336,7 +334,11 @@ def flux2_requirements(params: dict[str, object] | None = None) -> list[ModelCom
             label="Diffusion model" + (f" ({variant.label})" if variant else ""),
             category="diffusion_models",
             filename=DIFFUSION_FILE,
-            present=variant is not None,
+            # Presence is whether a file resolves, NOT whether a variant does: `variant` defaults to
+            # a concrete build, and resolved_variant honours that param without opening anything. So
+            # keying off it reported a checkpoint present when the picked file was gone, letting the
+            # run past this pre-flight to fail later with an opaque message.
+            present=resolve_diffusion(params) is not None,
             repo=SPLIT_REPO,
             repo_file=_split("diffusion_models", DIFFUSION_FILE),
         ),

--- a/core/src/inline_core/models/flux2/runner.py
+++ b/core/src/inline_core/models/flux2/runner.py
@@ -92,26 +92,31 @@ FLUX2 = NodeDescriptor(
         ),
         # FLUX.2 is flow-match, so these tune the FlowMatchEuler scheduler - see models/sampling.py.
         *sampling_param_fields(SamplingFamily.FLOW_MATCH),
+        # A FLUX.2 ControlNet Union (dev only). Empty = off, and a wired control map is then fed
+        # through the reference channel instead, which works on every variant.
+        ParamField("controlnet", "ControlNet (dev only)", Widget.SELECT, "",
+                   options_from="controlnet"),
+        ParamField("control_strength", "Control strength", Widget.NUMBER, 0.75,
+                   min=0.0, max=2.0, step=0.05),
         ParamField("seed", "Seed (-1 = random)", Widget.SEED, -1),
-        # "" = identify the picked checkpoint from its tensor shapes. The explicit options exist for
-        # a file whose name hides whether it is a base or distilled build.
+        # Normally identified from the checkpoint's tensor shapes and served as the default, so this
+        # only needs overriding for a file whose name hides whether it is a base or distilled build
+        # (the one thing shapes cannot tell apart). A pick that contradicts the file is ignored.
         ParamField(
             "variant", "Model variant", Widget.SELECT, "",
-            options=(Option("", "Auto (detect from file)"), *(
-                Option(v.key, f"FLUX.2 {v.label}") for v in V.VARIANTS
-            )),
+            options=tuple(Option(v.key, f"FLUX.2 {v.label}") for v in V.VARIANTS),
             advanced=True,
         ),
         ParamField(
-            "model", "Diffusion file (auto)", Widget.SELECT, "",
+            "model", "Diffusion model", Widget.SELECT, "",
             options_from="diffusion_models", advanced=True,
         ),
         ParamField(
-            "text_encoder", "Text-encoder file (auto)", Widget.SELECT, "",
+            "text_encoder", "Text encoder", Widget.SELECT, "",
             options_from="text_encoders", advanced=True,
         ),
         ParamField(
-            "vae", "VAE file (auto)", Widget.SELECT, "", options_from="vae", advanced=True,
+            "vae", "VAE", Widget.SELECT, "", options_from="vae", advanced=True,
         ),
     ),
 )
@@ -177,9 +182,12 @@ class Flux2Runner(NodeRunner):
         # map is just one more reference; FLUX.2 conditions on it the same way.
         refs = list(inputs.get("image") or [])
         control = rt.first(inputs.get("control_image"))
-        if control is not None:
+        control_file = _resolve_controlnet(params, variant, control)
+        # Without a ControlNet the map is just another reference, which is how klein does control.
+        if control is not None and control_file is None:
             refs.append(control)
         images = [rt.load_image(ref, _LABEL) for ref in refs]
+        control_map = rt.load_image(control, _LABEL) if control_file else None
 
         # Size-aware placement: hand the policy the on-disk sizes so it fits dtype/quant/offload to
         # THIS GPU, then refuse an impossible load up front rather than OOM-killing the server.
@@ -190,6 +198,11 @@ class Flux2Runner(NodeRunner):
         if fit is not None and not fit.fits:
             raise ComponentError(rt.wont_fit_message(fit))
 
+        staged = _needs_staged_encode(source, vae_file, te_file, self._policy)
+        # A checkpoint that ships already quantized loads as-is: re-quantizing it is a hard error,
+        # and its on-disk weights are already the resident ones.
+        prequantized = V.is_prequantized(source)
+        quant = Quantization.NONE if prequantized else self._policy.quantization()
         logger.info(
             "%s (%s) run: %dx%d, %d steps, guidance=%.1f, %d reference(s) | %s",
             _LABEL, variant.label, width, height, steps, guidance, len(images),
@@ -206,8 +219,9 @@ class Flux2Runner(NodeRunner):
                 config=config,
                 vae=vae_file,
                 text=te_file,
-                quant=self._policy.quantization(),
+                quant=quant,
                 loras=loras,
+                staged=staged,
                 cancel_check=lambda: rt.raise_if_cancelled(ctx),
             )
         except CancelledError:
@@ -262,6 +276,27 @@ class Flux2Runner(NodeRunner):
                 layers=variant.text_encoder_layers,
             )
         )
+        if staged and getattr(pipe, "transformer", None) is None:
+            if "prompt_embeds" not in call:
+                raise ComponentError(
+                    f"{_LABEL} {variant.label} needs its prompt encoded before the transformer "
+                    "loads, but encoding did not produce embeddings. Free some VRAM and retry."
+                )
+            ctx.emitter.emit(
+                rt.progress_event(ctx, node, Phase.LOADING, 0.5, status="Loading transformer…")
+            )
+            loaders.attach_flux2_transformer(
+                pipe,
+                arch=variant.arch,
+                diffusion_file=source,
+                config=config,
+                vae_file=vae_file,
+                dtype=rt.torch_dtype(self._policy.placement("denoiser")),
+                quant=quant,
+                device=None if placement.offload else str(placement.device),
+                loras=loras,
+            )
+            rt.capture_base_scheduler_config(pipe)
 
         # Rebuild the scheduler for the chosen sampler/scheduler from the pipe's pristine base
         # config (immutable across cache hits).
@@ -279,6 +314,41 @@ class Flux2Runner(NodeRunner):
         )
         rt.raise_if_cancelled(ctx)  # cancelled during load? don't start the denoise
         sample_start = time.perf_counter()
+        handles: list[Any] = []
+        if control_map is not None and control_file:
+            from . import controlnet as cn
+
+            ctx.emitter.emit(
+                rt.progress_event(ctx, node, Phase.LOADING, 0.8, status="Loading ControlNet…")
+            )
+            # The branch is 8.2 GB at bf16, which does not fit beside a resident dev transformer.
+            # Whenever the base is itself quantized, the branch takes NF4 too: it is a frozen side
+            # branch, so 4-bit costs it less than not running at all.
+            branch_quant = (
+                Quantization.NF4
+                if prequantized or quant is not Quantization.NONE
+                else Quantization.NONE
+            )
+            branch = cn.load_control_branch(
+                control_file, config, rt.torch_dtype(placement),
+                device=None if placement.offload else str(placement.device),
+                quant=branch_quant,
+            )
+            reference_tokens = sum(
+                (img.height // 16) * (img.width // 16) for img in images
+            )
+            context = cn.build_context(
+                pipe, control_map, height, width, rt.torch_dtype(placement),
+                str(placement.device), reference_tokens=reference_tokens,
+            )
+            handles = cn.attach(
+                pipe.transformer, branch, context,
+                scale=float(params.get("control_strength", 0.75)),
+            )
+            logger.info(
+                "ControlNet Union attached at layers %s, strength %.2f",
+                cn.CONTROL_LAYERS, float(params.get("control_strength", 0.75)),
+            )
         try:
             with rt.text_encoder_detached(pipe, "prompt_embeds" in call):
                 image = pipe(**call).images[0]
@@ -291,6 +361,11 @@ class Flux2Runner(NodeRunner):
         except MemoryError as error:
             rt.free_vram()
             raise ComponentError(_oom(width, height, len(images), host=True)) from error
+        finally:
+            # The pipeline is cached, so leaving hooks attached would silently control every later
+            # run on this checkpoint.
+            for handle in handles:
+                handle.remove()
         elapsed = time.perf_counter() - sample_start
         peak_gb = rt.peak_vram_gb()
         peak_note = f", peak VRAM {peak_gb:.1f}GB" if peak_gb else ""
@@ -321,6 +396,12 @@ class Flux2Runner(NodeRunner):
                 "seed": seed,
                 **({"references": len(images)} if images else {}),
                 **(
+                    {"controlnet": control_file,
+                     "control_strength": float(params.get("control_strength", 0.75))}
+                    if control_file
+                    else {}
+                ),
+                **(
                     {"loras": [{"file": lo.file, "strength": lo.strength} for lo in loras]}
                     if loras
                     else {}
@@ -346,13 +427,25 @@ def _identify(source: str, params: dict[str, Any]) -> tuple[V.Flux2Variant, dict
     a mislabeled variant should still load with the right shapes.
     """
     shapes = _shapes(source)
-    config = V.derive_transformer_config(shapes) if shapes else None
+    # A folder states its geometry in config.json; a single file has it derived from tensor shapes.
+    config = V.derive_transformer_config(shapes) if shapes else V.config_for(source)
     if config is None:
         raise ComponentError(
             f"'{source}' is not a FLUX.2 diffusion model. Pick a FLUX.2 checkpoint in the "
             "Diffusion file dropdown, or download one from the node's model popup."
         )
-    variant = V.get(str(params.get("variant") or "")) or V.detect(source, shapes)
+    forced = V.get(str(params.get("variant") or ""))
+    # An explicit pick that contradicts the file is dropped rather than honoured. The dropdown
+    # defaults to a concrete variant, so applying any setting persists one; without this guard,
+    # swapping the checkpoint later would build the old variant pipeline for the new file.
+    if forced is not None and forced.joint_attention_dim != config["joint_attention_dim"]:
+        logger.warning(
+            "Ignoring the Model variant override (%s): this checkpoint is not that build. "
+            "Identifying it from the file instead.",
+            forced.label,
+        )
+        forced = None
+    variant = forced or V.detect(source, shapes)
     if variant is None:
         raise ComponentError(
             "Could not tell which FLUX.2 variant this checkpoint is. Pick one explicitly in the "
@@ -364,6 +457,8 @@ def _identify(source: str, params: dict[str, Any]) -> tuple[V.Flux2Variant, dict
 def _shapes(source: str) -> dict[str, list[int]] | None:
     from pathlib import Path
 
+    if Path(source).is_dir():
+        return None  # a folder carries a config.json instead; see V.config_for
     if Path(source).suffix.lower() == ".gguf":
         return _gguf_shapes(source)
     try:
@@ -415,6 +510,36 @@ def _resolve_negative(params: dict[str, Any], variant: V.Flux2Variant) -> str | 
     return negative
 
 
+
+def _resolve_controlnet(
+    params: dict[str, Any], variant: V.Flux2Variant, control: Any
+) -> str | None:
+    """The Fun ControlNet Union file to run, or None to send the map down the reference channel.
+
+    The Union is built against dev's block geometry, so it is refused on klein rather than loaded
+    into a model it does not fit. That is not a dead end: klein still gets structural control from
+    the reference channel, just more loosely.
+    """
+    from ...config import models_dir
+
+    chosen = str(params.get("controlnet") or "").strip()
+    if not chosen or control is None:
+        return None
+    if variant.pipeline != "dev":
+        logger.warning(
+            "The FLUX.2 ControlNet Union is built for dev's geometry, so it is skipped on %s. "
+            "The control map is being used as a reference image instead.",
+            variant.label,
+        )
+        return None
+    path = models_dir() / "controlnet" / chosen
+    if not path.is_file():
+        logger.warning("ControlNet %s not found in models/controlnet/; using it as a reference.",
+                       chosen)
+        return None
+    return str(path)
+
+
 def _oom(width: int, height: int, references: int, *, host: bool = False) -> str:
     message = rt.oom_message(width, height, host=host)
     if references:
@@ -423,6 +548,35 @@ def _oom(width: int, height: int, references: int, *, host: bool = False) -> str
             "every step, so removing one is often the cheapest fix."
         )
     return message
+
+
+
+def _needs_staged_encode(
+    diffusion: str, vae: str, text_encoder: str, policy: DevicePolicy
+) -> bool:
+    """Whether the text encoder and the transformer are too big to be resident together.
+
+    dev is the case this exists for: an 18 GB NF4 transformer beside a 15 GB encoder is 33 GB on a
+    24 GB card, so the whole-pipeline build OOMs during the load - before anything can be freed.
+    When they do not fit, the prompt is encoded first and the encoder dropped to make room.
+
+    On-disk size is the right measure here because the checkpoints that trigger this are already
+    quantized on disk, so what they weigh is what they will occupy.
+    """
+    budget_mb = policy.vram_budget_mb()
+    if not budget_mb:
+        return False  # CPU or an unmeasurable device takes the normal path
+    total = budget_mb / 1024
+    sizes = reqs.footprint_bytes(diffusion, vae, text_encoder)
+    gb = 1024**3
+    whole = sum(sizes.values()) / gb
+    without_encoder = (sizes["diffusion_bytes"] + sizes["vae_bytes"]) / gb
+    budget = total - _ACTIVATION_HEADROOM_GB
+    return whole > budget and without_encoder <= budget
+
+
+#: Room left for activations, matching the device policy's own reserve.
+_ACTIVATION_HEADROOM_GB = 2.5
 
 
 # --- pipeline build -------------------------------------------------------------------------------
@@ -438,6 +592,7 @@ def _load_pipeline(
     text: str,
     quant: Quantization = Quantization.NONE,
     loras: tuple[LoraRef, ...] = (),
+    staged: bool = False,
     cancel_check: Callable[[], None] | None = None,
 ) -> Any:
     key = rt.PipelineKey(
@@ -467,6 +622,24 @@ def _load_pipeline(
         # doesn't stack VRAM.
         rt.PIPELINES.evict_stale(key)
         placement = policy.placement("denoiser")
+        if staged:
+            logger.info(
+                "%s %s: encoding before the transformer loads - they do not fit together",
+                _LABEL, variant.label,
+            )
+            pipe = loaders.assemble_flux2_encoders(
+                arch=variant.arch,
+                pipeline=variant.pipeline,
+                distilled=variant.distilled,
+                vae_file=vae,
+                text_encoder_file=text,
+                dtype=rt.torch_dtype(placement),
+                quant=quant,
+                vae_dtype=rt.torch_dtype(policy.placement("vae")),
+                device=None if placement.offload else str(placement.device),
+            )
+            rt.capture_base_scheduler_config(pipe)
+            return pipe
         # Resident placement streams weights straight to the GPU; the offload path loads to CPU so
         # accelerate can install its hooks before placing.
         pipe = loaders.assemble_flux2_pipeline(

--- a/core/src/inline_core/models/flux2/runner.py
+++ b/core/src/inline_core/models/flux2/runner.py
@@ -163,7 +163,20 @@ class Flux2Runner(NodeRunner):
                 + ". Download them from the node's model popup (the hint on the node)."
             )
 
-        source = model_ref.file if model_ref else str(reqs.resolve_diffusion(params))
+        if model_ref:
+            source = model_ref.file
+        else:
+            picked = reqs.resolve_diffusion(params)
+            # Never stringify the miss: str(None) reached _identify as the literal "None" and
+            # surfaced as "'None' is not a FLUX.2 diffusion model", which reads like a bad file
+            # rather than a stale pick.
+            if picked is None:
+                raise ComponentError(
+                    f"{_LABEL} cannot find the picked diffusion model on disk. Choose a FLUX.2 "
+                    "checkpoint in the Diffusion model dropdown, or download one from the node's "
+                    "model popup."
+                )
+            source = str(picked)
         variant, config = _identify(source, params)
         vae_file = vae_ref.file if vae_ref else rt.path_or_none(reqs.resolve_vae(params))
         te_file = te_ref.file if te_ref else rt.path_or_none(reqs.resolve_text_encoder(params))

--- a/core/src/inline_core/models/flux2/runner.py
+++ b/core/src/inline_core/models/flux2/runner.py
@@ -1,0 +1,491 @@
+"""FLUX.2 runner: prompt (+ any number of reference images) -> one rendered take.
+
+**One node for the whole family.** ``black-forest-labs/flux-2`` covers klein 4B/9B, their base
+builds, the KV variant and dev, because none of them differ in anything the descriptor expresses -
+the ports are identical and only the pipeline class, sampler defaults and encoder change. The picked
+checkpoint is identified from its own tensor shapes (see ``variants.py``) and everything else
+follows from that, so a later FLUX.2 build (or FLUX.3) is a row in the variant table.
+
+Two consequences worth knowing when reading this file:
+
+- ``steps`` and ``guidance`` default to sentinels meaning "ask the checkpoint", so switching a
+  distilled build for its base build in the dropdown moves 4 steps / guidance 1 to 50 / 4 without
+  the user touching the settings panel.
+- FLUX.2 has no img2img denoise strength. A reference image is conditioning that rides in the token
+  sequence for the whole denoise, so one reference is an edit and several are a composition. The
+  prompt addresses them by position ("the jacket from image 2"), which is why order is preserved.
+
+torch + diffusers import at module top on purpose: an absent ``runtime`` extra makes this import
+raise and ``server.bootstrap`` skips the model, so the engine still boots.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+from ...device.policy import DevicePolicy, ModelFootprint, Profile, Quantization
+from ...errors import CancelledError, ComponentError
+from ...graph.descriptor import NodeDescriptor, Option, ParamField, Port, Widget
+from ...graph.loader_runners import LoraRef
+from ...graph.runners import NodeResult, NodeRunner
+from ...graph.schema import Node, PortKind
+from ...media import MediaKind
+from ...runtime.context import ExecutionContext
+from ...runtime.progress import Phase
+from ...runtime.store import TakeStore
+from .. import loaders
+from .. import pipeline_runtime as rt
+from ..sampling import SamplingFamily, apply_sampling, sampling_param_fields
+from . import embeds
+from . import requirements as reqs
+from . import variants as V
+
+_LABEL = "FLUX.2"
+_NODE_TYPE = "black-forest-labs/flux-2"
+
+#: ``steps`` / ``guidance`` values meaning "take the checkpoint's own default". Mirrors the seed
+#: field's -1 = random: one sentinel the user can see and override.
+_AUTO_STEPS = 0
+_AUTO_GUIDANCE = -1.0
+
+logger = logging.getLogger("inline_core.flux2")
+
+
+FLUX2 = NodeDescriptor(
+    type=_NODE_TYPE,
+    title="FLUX.2",
+    category="Generate",
+    icon="wand",
+    output_kind=MediaKind.IMAGE,
+    inputs=(
+        Port("prompt", "Prompt", PortKind.TEXT, required=True),
+        # Optional component handles from load/* subnodes - wire one to override the dropdown.
+        Port("model", "Diffusion model", PortKind.MODEL, required=False),
+        Port("vae", "VAE", PortKind.VAE, required=False),
+        Port("text_encoder", "Text encoder", PortKind.TEXT_ENCODER, required=False),
+        Port("lora", "LoRA", PortKind.LORA, required=False),
+        # A list port: wire several images to compose from them. One is an edit of that image.
+        Port("image", "Reference image(s)", PortKind.IMAGE_LIST, required=False),
+        # A pose/depth/canny map from Apply ControlNet or Control Space. FLUX.2 has no separate
+        # ControlNet input: the map is appended as a reference, which is what the family's own
+        # in-context conditioning is for. Name it in the prompt to steer with it.
+        Port("control_image", "Structure map", PortKind.CONTROL, required=False),
+    ),
+    outputs=(Port("image", "Image", PortKind.IMAGE),),
+    params=(
+        # Only an undistilled klein checkpoint runs real CFG; on dev and the distilled builds this
+        # is ignored (dev is guidance-distilled and its pipeline has no negative path at all).
+        ParamField("negative_prompt", "Negative prompt (base models only)", Widget.TEXTAREA, ""),
+        ParamField("width", "Width", Widget.NUMBER, 1024, min=256, max=2048, step=64),
+        ParamField("height", "Height", Widget.NUMBER, 1024, min=256, max=2048, step=64),
+        ParamField(
+            "steps", "Steps (0 = from model)", Widget.NUMBER, _AUTO_STEPS, min=0, max=100, step=1
+        ),
+        ParamField(
+            "guidance", "Guidance (-1 = from model)", Widget.NUMBER, _AUTO_GUIDANCE,
+            min=-1.0, max=20.0, step=0.5,
+        ),
+        # FLUX.2 is flow-match, so these tune the FlowMatchEuler scheduler - see models/sampling.py.
+        *sampling_param_fields(SamplingFamily.FLOW_MATCH),
+        ParamField("seed", "Seed (-1 = random)", Widget.SEED, -1),
+        # "" = identify the picked checkpoint from its tensor shapes. The explicit options exist for
+        # a file whose name hides whether it is a base or distilled build.
+        ParamField(
+            "variant", "Model variant", Widget.SELECT, "",
+            options=(Option("", "Auto (detect from file)"), *(
+                Option(v.key, f"FLUX.2 {v.label}") for v in V.VARIANTS
+            )),
+            advanced=True,
+        ),
+        ParamField(
+            "model", "Diffusion file (auto)", Widget.SELECT, "",
+            options_from="diffusion_models", advanced=True,
+        ),
+        ParamField(
+            "text_encoder", "Text-encoder file (auto)", Widget.SELECT, "",
+            options_from="text_encoders", advanced=True,
+        ),
+        ParamField(
+            "vae", "VAE file (auto)", Widget.SELECT, "", options_from="vae", advanced=True,
+        ),
+    ),
+)
+
+
+def register_flux2(registry: Any, store: TakeStore, policy: DevicePolicy) -> None:
+    """Register the FLUX.2 node and its runner. Called best-effort by server.bootstrap."""
+    registry.register(FLUX2, Flux2Runner(store, policy))
+
+
+class Flux2Runner(NodeRunner):
+    produces_takes = True
+
+    def __init__(self, store: TakeStore, policy: DevicePolicy) -> None:
+        self._store = store
+        self._policy = policy
+
+    def run(self, node: Node, inputs: dict[str, list[Any]], ctx: ExecutionContext) -> NodeResult:
+        prompt = rt.first_str(inputs.get("prompt"))
+        if not prompt:
+            raise ComponentError(f"{_LABEL} needs a prompt.")
+        params = {**FLUX2.defaults(), **node.params}
+        width, height = _snap(int(params["width"])), _snap(int(params["height"]))
+        seed = rt.resolve_seed(params.get("seed"))
+        sampler, scheduler = str(params["sampler"]), str(params["scheduler"])
+
+        # Wired component handles from load/* subnodes override the dropdowns.
+        model_ref = rt.component_ref(inputs, "model", "diffusion", _LABEL)
+        vae_ref = rt.component_ref(inputs, "vae", "vae", _LABEL)
+        te_ref = rt.component_ref(inputs, "text_encoder", "text_encoder", _LABEL)
+        loras = rt.lora_stack(inputs, _LABEL)
+        wired = {ref.kind for ref in (model_ref, vae_ref, te_ref) if ref is not None}
+
+        # No hidden downloads: a required component that is neither wired nor on disk fails fast.
+        missing = [
+            c.label
+            for c in reqs.flux2_requirements(params)
+            if not c.present and not c.optional and c.id not in wired
+        ]
+        if missing:
+            raise ComponentError(
+                f"{_LABEL} models missing: "
+                + ", ".join(missing)
+                + ". Download them from the node's model popup (the hint on the node)."
+            )
+
+        source = model_ref.file if model_ref else str(reqs.resolve_diffusion(params))
+        variant, config = _identify(source, params)
+        vae_file = vae_ref.file if vae_ref else rt.path_or_none(reqs.resolve_vae(params))
+        te_file = te_ref.file if te_ref else rt.path_or_none(reqs.resolve_text_encoder(params))
+        if not vae_file or not te_file:
+            raise ComponentError(
+                f"{_LABEL} needs a local VAE and text-encoder file. Download them from the node's "
+                "model popup."
+            )
+
+        steps = _resolve_steps(params, variant)
+        guidance = _resolve_guidance(params, variant)
+        negative = _resolve_negative(params, variant)
+
+        # References ride in the token sequence for the whole denoise, so they are conditioning
+        # rather than a starting point - there is no img2img strength to apply. A wired structure
+        # map is just one more reference; FLUX.2 conditions on it the same way.
+        refs = list(inputs.get("image") or [])
+        control = rt.first(inputs.get("control_image"))
+        if control is not None:
+            refs.append(control)
+        images = [rt.load_image(ref, _LABEL) for ref in refs]
+
+        # Size-aware placement: hand the policy the on-disk sizes so it fits dtype/quant/offload to
+        # THIS GPU, then refuse an impossible load up front rather than OOM-killing the server.
+        self._policy.set_footprint(
+            ModelFootprint(**reqs.footprint_bytes(source, vae_file, te_file))
+        )
+        fit = self._policy.fit_estimate()
+        if fit is not None and not fit.fits:
+            raise ComponentError(rt.wont_fit_message(fit))
+
+        logger.info(
+            "%s (%s) run: %dx%d, %d steps, guidance=%.1f, %d reference(s) | %s",
+            _LABEL, variant.label, width, height, steps, guidance, len(images),
+            rt.device_report(self._policy),
+        )
+        rt.reset_peak_vram()
+        rt.raise_if_cancelled(ctx)  # bail before a multi-GB load if already cancelled
+        ctx.emitter.emit(rt.progress_event(ctx, node, Phase.LOADING, 0.0, status="Loading model…"))
+        try:
+            pipe = _load_pipeline(
+                self._policy,
+                variant=variant,
+                source=source,
+                config=config,
+                vae=vae_file,
+                text=te_file,
+                quant=self._policy.quantization(),
+                loras=loras,
+                cancel_check=lambda: rt.raise_if_cancelled(ctx),
+            )
+        except CancelledError:
+            rt.free_vram()  # a cancelled load must return whatever VRAM it placed
+            raise
+        except torch.cuda.OutOfMemoryError as error:
+            rt.free_vram()
+            raise ComponentError(_oom(width, height, len(images))) from error
+        except MemoryError as error:
+            rt.free_vram()
+            raise ComponentError(_oom(width, height, len(images), host=True)) from error
+
+        placement = self._policy.placement("denoiser")
+        on_cpu = placement.offload or self._policy.profile is Profile.CPU
+        gen_device = "cpu" if on_cpu else str(placement.device)
+        generator = torch.Generator(device=gen_device).manual_seed(seed)
+
+        def on_step_end(_pipe: Any, step: int, _t: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
+            if ctx.cancel.cancelled:
+                raise CancelledError("Run cancelled.")
+            done = step + 1
+            ctx.emitter.emit(
+                rt.progress_event(
+                    ctx, node, Phase.SAMPLE, done / steps,
+                    step=done, step_count=steps, status=f"Step {done}/{steps}",
+                )
+            )
+            return kwargs
+
+        call: dict[str, Any] = dict(
+            height=height,
+            width=width,
+            num_inference_steps=steps,
+            generator=generator,
+            output_type="pil",
+            callback_on_step_end=on_step_end,
+            max_sequence_length=512,
+            text_encoder_out_layers=variant.text_encoder_layers,
+        )
+        # The KV pipeline is distilled-only and takes no guidance argument at all.
+        if variant.pipeline != "klein-kv":
+            call["guidance_scale"] = guidance
+        if images:
+            call["image"] = images
+        call.update(
+            embeds.prompt_kwargs(
+                pipe,
+                self._policy,
+                prompt=prompt,
+                negative=negative,
+                text_encoder_file=te_file,
+                layers=variant.text_encoder_layers,
+            )
+        )
+
+        # Rebuild the scheduler for the chosen sampler/scheduler from the pipe's pristine base
+        # config (immutable across cache hits).
+        base_config = getattr(pipe, "_inline_base_scheduler_config", None)
+        if base_config is not None:
+            sigmas = apply_sampling(
+                pipe, base_config, SamplingFamily.FLOW_MATCH, sampler, scheduler, steps
+            )
+            if sigmas is not None:
+                call["sigmas"] = sigmas
+
+        logger.info(
+            "%s sampling %d steps on %s (sampler=%s, scheduler=%s)…",
+            _LABEL, steps, gen_device, sampler, scheduler,
+        )
+        rt.raise_if_cancelled(ctx)  # cancelled during load? don't start the denoise
+        sample_start = time.perf_counter()
+        try:
+            with rt.text_encoder_detached(pipe, "prompt_embeds" in call):
+                image = pipe(**call).images[0]
+        except CancelledError:
+            rt.free_vram()  # release partial-denoise activations so the next run isn't starved
+            raise
+        except torch.cuda.OutOfMemoryError as error:
+            rt.free_vram()
+            raise ComponentError(_oom(width, height, len(images))) from error
+        except MemoryError as error:
+            rt.free_vram()
+            raise ComponentError(_oom(width, height, len(images), host=True)) from error
+        elapsed = time.perf_counter() - sample_start
+        peak_gb = rt.peak_vram_gb()
+        peak_note = f", peak VRAM {peak_gb:.1f}GB" if peak_gb else ""
+        logger.info(
+            "%s sampled %dx%d in %.1fs (%.2fs/step)%s | %s",
+            _LABEL, width, height, elapsed, elapsed / steps, peak_note,
+            rt.device_report(self._policy),
+        )
+        rt.free_vram()  # return fragmented free blocks to the driver (keeps the model resident)
+
+        save_status = "Saving…" + (f" (peak VRAM {peak_gb:.1f}GB)" if peak_gb else "")
+        ctx.emitter.emit(rt.progress_event(ctx, node, Phase.SAVE, 1.0, status=save_status))
+        take = self._store.save(
+            ctx.run_id,
+            node.id,
+            image,
+            {
+                "model": source,
+                "variant": variant.key,
+                "prompt": prompt,
+                "negative_prompt": negative or "",
+                "width": width,
+                "height": height,
+                "steps": steps,
+                "guidance": guidance,
+                "sampler": sampler,
+                "scheduler": scheduler,
+                "seed": seed,
+                **({"references": len(images)} if images else {}),
+                **(
+                    {"loras": [{"file": lo.file, "strength": lo.strength} for lo in loras]}
+                    if loras
+                    else {}
+                ),
+            },
+        )
+        return NodeResult(outputs={"image": take}, takes=[take])
+
+
+# --- resolving what the checkpoint wants ----------------------------------------------------------
+
+
+def _snap(value: int) -> int:
+    """FLUX.2 packs latents 2x2 on top of an 8x VAE, so both sides must be multiples of 16. The
+    param step is 64, but a recipe or a "match aspect" write can land elsewhere."""
+    return max(64, (value // 16) * 16)
+
+
+def _identify(source: str, params: dict[str, Any]) -> tuple[V.Flux2Variant, dict[str, Any]]:
+    """The variant and transformer geometry for the picked checkpoint.
+
+    An explicit ``variant`` param wins over detection, but the geometry always comes from the file:
+    a mislabeled variant should still load with the right shapes.
+    """
+    shapes = _shapes(source)
+    config = V.derive_transformer_config(shapes) if shapes else None
+    if config is None:
+        raise ComponentError(
+            f"'{source}' is not a FLUX.2 diffusion model. Pick a FLUX.2 checkpoint in the "
+            "Diffusion file dropdown, or download one from the node's model popup."
+        )
+    variant = V.get(str(params.get("variant") or "")) or V.detect(source, shapes)
+    if variant is None:
+        raise ComponentError(
+            "Could not tell which FLUX.2 variant this checkpoint is. Pick one explicitly in the "
+            "Model variant dropdown."
+        )
+    return variant, config
+
+
+def _shapes(source: str) -> dict[str, list[int]] | None:
+    from pathlib import Path
+
+    if Path(source).suffix.lower() == ".gguf":
+        return _gguf_shapes(source)
+    try:
+        from ..checkpoint import CheckpointReader
+
+        return CheckpointReader(source).shapes()
+    except Exception:  # noqa: BLE001 - an unreadable file is reported as "not FLUX.2" by the caller
+        return None
+
+
+def _gguf_shapes(source: str) -> dict[str, list[int]] | None:
+    """Tensor shapes from a GGUF checkpoint, so the same geometry derivation works for those too.
+    GGUF stores dimensions fastest-varying first, the reverse of safetensors, so they are flipped
+    back here."""
+    try:
+        import gguf  # pyright: ignore[reportMissingImports] - optional dependency, guarded
+
+        reader: Any = gguf.GGUFReader(source)
+        tensors: list[Any] = list(reader.tensors)
+        return {str(t.name): [int(d) for d in reversed(list(t.shape))] for t in tensors}
+    except Exception as error:  # noqa: BLE001 - surfaced as a node error with an install hint
+        logger.warning("Could not read GGUF header for %s: %s", source, error)
+        return None
+
+
+def _resolve_steps(params: dict[str, Any], variant: V.Flux2Variant) -> int:
+    steps = int(params.get("steps", _AUTO_STEPS))
+    return variant.steps if steps <= _AUTO_STEPS else steps
+
+
+def _resolve_guidance(params: dict[str, Any], variant: V.Flux2Variant) -> float:
+    guidance = float(params.get("guidance", _AUTO_GUIDANCE))
+    return variant.guidance if guidance < 0 else guidance
+
+
+def _resolve_negative(params: dict[str, Any], variant: V.Flux2Variant) -> str | None:
+    """A negative prompt, but only where it does something. A distilled checkpoint runs no CFG and
+    dev's pipeline has no negative path, so we log and drop it rather than pretending it applied."""
+    negative = str(params.get("negative_prompt") or "").strip()
+    if not negative:
+        return None
+    if not variant.supports_negative_prompt:
+        logger.info(
+            "Ignoring the negative prompt: FLUX.2 %s runs no classifier-free guidance. Describe "
+            "what you want instead, or use a Base checkpoint.",
+            variant.label,
+        )
+        return None
+    return negative
+
+
+def _oom(width: int, height: int, references: int, *, host: bool = False) -> str:
+    message = rt.oom_message(width, height, host=host)
+    if references:
+        message += (
+            f" This render also carried {references} reference image(s); each one adds tokens to "
+            "every step, so removing one is often the cheapest fix."
+        )
+    return message
+
+
+# --- pipeline build -------------------------------------------------------------------------------
+
+
+def _load_pipeline(
+    policy: DevicePolicy,
+    *,
+    variant: V.Flux2Variant,
+    source: str,
+    config: dict[str, Any],
+    vae: str,
+    text: str,
+    quant: Quantization = Quantization.NONE,
+    loras: tuple[LoraRef, ...] = (),
+    cancel_check: Callable[[], None] | None = None,
+) -> Any:
+    key = rt.PipelineKey(
+        arch=variant.arch,
+        diffusion=source,
+        vae=vae,
+        text_encoder=text,
+        # One pipeline shape per variant: references are a call argument, not a different class,
+        # so t2i and editing share a build. Only the KV/base split changes the class or its config.
+        variant=variant.key,
+        quant=quant.value,
+        loras=loaders.lora_cache_key(loras),
+    )
+    with rt.PIPELINES.lock:
+        cached = rt.PIPELINES.get(key)
+        if cached is not None:
+            logger.info("Pipeline cache hit (%s) - reusing loaded weights", source)
+            return cached
+        if cancel_check is not None:
+            cancel_check()  # bail before the disk read if the run was cancelled while queued
+        started = time.perf_counter()
+        logger.info(
+            "Loading %s %s pipeline: source=%s | %s",
+            _LABEL, variant.label, source, rt.device_report(policy),
+        )
+        # Free any *other* model still resident before loading this one, so switching checkpoints
+        # doesn't stack VRAM.
+        rt.PIPELINES.evict_stale(key)
+        placement = policy.placement("denoiser")
+        # Resident placement streams weights straight to the GPU; the offload path loads to CPU so
+        # accelerate can install its hooks before placing.
+        pipe = loaders.assemble_flux2_pipeline(
+            arch=variant.arch,
+            pipeline=variant.pipeline,
+            distilled=variant.distilled,
+            diffusion_file=source,
+            config=config,
+            vae_file=vae,
+            text_encoder_file=text,
+            dtype=rt.torch_dtype(placement),
+            quant=quant,
+            vae_dtype=rt.torch_dtype(policy.placement("vae")),
+            device=None if placement.offload else str(placement.device),
+            loras=loras,
+            cancel_check=cancel_check,
+        )
+        rt.configure_pipeline(pipe, policy)
+        rt.capture_base_scheduler_config(pipe)
+        rt.PIPELINES.put(key, pipe)
+        logger.info("%s pipeline ready in %.1fs", _LABEL, time.perf_counter() - started)
+        return pipe

--- a/core/src/inline_core/models/flux2/variants.py
+++ b/core/src/inline_core/models/flux2/variants.py
@@ -21,7 +21,10 @@ from pathlib import Path
 __all__ = [
     "VARIANTS",
     "Flux2Variant",
+    "config_for",
     "derive_transformer_config",
+    "folder_config",
+    "is_prequantized",
     "detect",
     "get",
     "text_encoder_kind",
@@ -242,24 +245,80 @@ def _name_flags(name: str) -> tuple[bool, bool]:
     return "-base-" in padded, "-kv-" in padded
 
 
-def detect(path: str | Path, shapes: dict[str, list[int]] | None = None) -> Flux2Variant | None:
-    """Which FLUX.2 variant a checkpoint file is, or None if it is not one.
+def folder_config(path: str | Path) -> dict[str, object] | None:
+    """The transformer config of a diffusers-format checkpoint **folder**, or None.
 
-    Pass ``shapes`` when the header has already been read, so it is not read twice. Never reads
-    tensor data and never imports torch.
+    A prequantized dev checkpoint ships as a folder of shards plus a ``config.json`` rather than one
+    consolidated file, so there is no header to derive geometry from - and no need, because the
+    config is right there. Recognised by its ``_class_name``, so a folder belonging to another
+    architecture is left alone.
+    """
+    folder = Path(path)
+    marker = folder / "config.json"
+    if not folder.is_dir() or not marker.is_file():
+        return None
+    try:
+        import json
+
+        config = json.loads(marker.read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(config, dict):
+        return None
+    if config.get("_class_name") != "Flux2Transformer2DModel":
+        return None
+    return {k: v for k, v in config.items() if not k.startswith("_")}
+
+
+def is_prequantized(path: str | Path) -> bool:
+    """Whether a checkpoint folder carries its own quantization (an NF4 dev build, say).
+
+    Such a checkpoint must not be quantized again: its on-disk size already is its resident size,
+    and handing diffusers a second, different quantization config is a hard error. It also means the
+    fit ladder's assumption - that on-disk size is bf16 and quantization can halve it - does not
+    hold here, so the caller passes ``Quantization.NONE`` and loads the weights as they are.
+    """
+    folder = Path(path)
+    if not folder.is_dir():
+        return False
+    try:
+        import json
+
+        config = json.loads((folder / "config.json").read_text())
+    except (OSError, ValueError):
+        return False
+    return isinstance(config, dict) and bool(config.get("quantization_config"))
+
+
+def config_for(path: str | Path) -> dict[str, object] | None:
+    """The transformer geometry for a checkpoint, whether it is a single file or a folder."""
+    folder = folder_config(path)
+    if folder is not None:
+        return folder
+    shapes = _shapes_of(path)
+    return derive_transformer_config(shapes) if shapes else None
+
+
+def _shapes_of(path: str | Path) -> dict[str, list[int]] | None:
+    file = Path(path)
+    if not file.is_file() or file.suffix.lower() not in _WEIGHT_SUFFIXES:
+        return None
+    try:
+        from ..checkpoint import CheckpointReader
+
+        return CheckpointReader(file).shapes()
+    except Exception:  # noqa: BLE001 - an unreadable or foreign file is simply "not FLUX.2"
+        return None
+
+
+def detect(path: str | Path, shapes: dict[str, list[int]] | None = None) -> Flux2Variant | None:
+    """Which FLUX.2 variant a checkpoint is, or None if it is not one.
+
+    Handles both a single ``.safetensors`` and a diffusers folder. Pass ``shapes`` when the header
+    has already been read, so it is not read twice. Never reads tensor data, never imports torch.
     """
     file = Path(path)
-    if shapes is None:
-        if not file.is_file() or file.suffix.lower() not in _WEIGHT_SUFFIXES:
-            return None
-        try:
-            from ..checkpoint import CheckpointReader
-
-            shapes = CheckpointReader(file).shapes()
-        except Exception:  # noqa: BLE001 - an unreadable or foreign file is simply "not FLUX.2"
-            return None
-
-    config = derive_transformer_config(shapes)
+    config = derive_transformer_config(shapes) if shapes is not None else config_for(file)
     if config is None:
         return None
     is_base, is_kv = _name_flags(file.name)

--- a/core/src/inline_core/models/flux2/variants.py
+++ b/core/src/inline_core/models/flux2/variants.py
@@ -1,0 +1,275 @@
+"""Which FLUX.2 checkpoint a file actually is, and what it needs to run.
+
+FLUX.2 ships as one family with two incompatible halves: ``dev`` uses a Mistral-3 text encoder and
+``Flux2Pipeline``; every ``klein`` build uses Qwen3 and ``Flux2KleinPipeline``. They also differ in
+step count, guidance semantics, and which encoder layers get tapped. One node covers all of them by
+identifying the picked file here and looking the rest up.
+
+Identification reads the **safetensors header only** (tensor names and shapes, never tensor data,
+never torch), so it is cheap enough to run on every model-popup open and works on a torch-less
+install. Deriving the transformer geometry from the checkpoint instead of shipping a config per
+variant is what keeps a future FLUX.3 build - or a community fine-tune - loadable with no code
+change, and it avoids depending on the gated BFL repos for a config we can already see.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "VARIANTS",
+    "Flux2Variant",
+    "derive_transformer_config",
+    "detect",
+    "get",
+    "text_encoder_kind",
+]
+
+#: Geometry shared by every FLUX.2 transformer that tensor shapes cannot reveal. Everything else in
+#: the config is derived from the checkpoint (see ``derive_transformer_config``).
+_FIXED_GEOMETRY: dict[str, object] = {
+    "axes_dims_rope": [32, 32, 32, 32],
+    "eps": 1e-06,
+    "patch_size": 1,
+    "rope_theta": 2000,
+    "out_channels": None,
+}
+
+
+@dataclass(frozen=True)
+class Flux2Variant:
+    """One FLUX.2 checkpoint family: how to build it, and what it wants at sampling time."""
+
+    key: str
+    label: str
+    #: Which diffusers pipeline family to build: "klein" | "klein-kv" | "dev".
+    pipeline: str
+    #: Step- and guidance-distilled. Drives the auto sampler defaults and whether real CFG runs.
+    distilled: bool
+    #: The concatenated text-encoder width (3x the encoder's hidden size). The identifying number.
+    joint_attention_dim: int
+    #: Which intermediate encoder layers the pipeline stacks. dev taps deeper than klein.
+    text_encoder_layers: tuple[int, ...]
+    #: The loader arch key - selects the tokenizer/config asset bundle in models/loaders.py.
+    arch: str
+    steps: int
+    guidance: float
+
+    @property
+    def supports_negative_prompt(self) -> bool:
+        """Only an undistilled klein checkpoint runs real CFG. dev is guidance-distilled and its
+        pipeline has no negative path at all; a distilled klein ignores guidance above 1."""
+        return not self.distilled and self.pipeline in ("klein", "klein-kv")
+
+
+#: Every variant the node knows. Adding a checkpoint (one we missed, or FLUX.3) is a row here plus a
+#: download entry in requirements.py - no new node, descriptor, or runner branch.
+VARIANTS: tuple[Flux2Variant, ...] = (
+    Flux2Variant(
+        key="klein-4b",
+        label="Klein 4B",
+        pipeline="klein",
+        distilled=True,
+        joint_attention_dim=7680,
+        text_encoder_layers=(9, 18, 27),
+        arch="flux2-klein-4b",
+        steps=4,
+        guidance=1.0,
+    ),
+    Flux2Variant(
+        key="klein-4b-base",
+        label="Klein 4B Base",
+        pipeline="klein",
+        distilled=False,
+        joint_attention_dim=7680,
+        text_encoder_layers=(9, 18, 27),
+        arch="flux2-klein-4b",
+        steps=50,
+        guidance=4.0,
+    ),
+    Flux2Variant(
+        key="klein-9b",
+        label="Klein 9B",
+        pipeline="klein",
+        distilled=True,
+        joint_attention_dim=12288,
+        text_encoder_layers=(9, 18, 27),
+        arch="flux2-klein-9b",
+        steps=4,
+        guidance=1.0,
+    ),
+    Flux2Variant(
+        key="klein-9b-base",
+        label="Klein 9B Base",
+        pipeline="klein",
+        distilled=False,
+        joint_attention_dim=12288,
+        text_encoder_layers=(9, 18, 27),
+        arch="flux2-klein-9b",
+        steps=50,
+        guidance=4.0,
+    ),
+    Flux2Variant(
+        key="klein-9b-kv",
+        label="Klein 9B KV",
+        pipeline="klein-kv",
+        distilled=True,
+        joint_attention_dim=12288,
+        text_encoder_layers=(9, 18, 27),
+        arch="flux2-klein-9b",
+        steps=4,
+        guidance=1.0,
+    ),
+    Flux2Variant(
+        key="dev",
+        label="dev",
+        pipeline="dev",
+        distilled=False,
+        joint_attention_dim=15360,
+        text_encoder_layers=(10, 20, 30),
+        arch="flux2-dev",
+        steps=28,
+        guidance=4.0,
+    ),
+)
+
+_BY_KEY = {v.key: v for v in VARIANTS}
+
+
+def get(key: str | None) -> Flux2Variant | None:
+    return _BY_KEY.get((key or "").strip())
+
+
+def text_encoder_kind(variant: Flux2Variant) -> str:
+    """Which encoder class the loader builds for this variant."""
+    return "mistral3" if variant.pipeline == "dev" else "qwen3"
+
+
+# --- identifying a checkpoint --------------------------------------------------------------------
+
+#: Prefixes ComfyUI-style repacks put in front of the diffusers keys. Stripped before matching so a
+#: Comfy single file and a diffusers export identify the same way.
+_PREFIXES = ("model.diffusion_model.", "diffusion_model.", "model.")
+
+_BLOCK_RE = re.compile(r"^transformer_blocks\.(\d+)\.")
+_SINGLE_BLOCK_RE = re.compile(r"^single_transformer_blocks\.(\d+)\.")
+_WEIGHT_SUFFIXES = (".safetensors", ".sft")
+
+#: The shipped checkpoints use BFL's original key layout, not diffusers'. diffusers converts it at
+#: load time (``convert_flux2_transformer_checkpoint_to_diffusers``), but identification runs on the
+#: raw header, so the handful of keys we read are renamed here first. Only the identifying keys are
+#: mapped - this is not a checkpoint converter, and it must not become one.
+_BFL_RENAMES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^double_blocks\."), "transformer_blocks."),
+    (re.compile(r"^single_blocks\."), "single_transformer_blocks."),
+    (re.compile(r"^txt_in\.weight$"), "context_embedder.weight"),
+    (re.compile(r"^img_in\.weight$"), "x_embedder.weight"),
+    (
+        re.compile(r"^time_in\.in_layer\.weight$"),
+        "time_guidance_embed.timestep_embedder.linear_1.weight",
+    ),
+    (re.compile(r"(img_)?attn\.norm\.query_norm\.scale$"), "attn.norm_q.weight"),
+    (re.compile(r"(?<=\.)norm\.query_norm\.scale$"), "attn.norm_q.weight"),
+    (re.compile(r"img_mlp\.0\.weight$"), "ff.linear_in.weight"),
+)
+
+
+def _strip(key: str) -> str:
+    for prefix in _PREFIXES:
+        if key.startswith(prefix):
+            key = key[len(prefix) :]
+            break
+    for pattern, replacement in _BFL_RENAMES:
+        key = pattern.sub(replacement, key)
+    return key
+
+
+def derive_transformer_config(shapes: dict[str, list[int]]) -> dict[str, object] | None:
+    """Reconstruct a ``Flux2Transformer2DModel`` config from a checkpoint's tensor shapes.
+
+    Returns None when the file is not a FLUX.2 transformer. The stream widths come from
+    ``context_embedder``/``x_embedder``, the head size from a per-head QK-norm vector, and the block
+    counts from the indices present, so the same code sizes a 4B and a 32B checkpoint.
+    """
+    keys = {_strip(key): shape for key, shape in shapes.items()}
+    context = keys.get("context_embedder.weight")
+    x_embed = keys.get("x_embedder.weight")
+    if not context or not x_embed or len(context) != 2 or len(x_embed) != 2:
+        return None
+
+    inner_dim, joint_attention_dim = context[0], context[1]
+    head_dim = next(
+        (shape[0] for key, shape in keys.items() if key.endswith("attn.norm_q.weight") and shape),
+        0,
+    )
+    if not head_dim or inner_dim % head_dim:
+        return None
+
+    layers = {int(m.group(1)) for key in keys if (m := _BLOCK_RE.match(key))}
+    single_layers = {int(m.group(1)) for key in keys if (m := _SINGLE_BLOCK_RE.match(key))}
+    if not layers or not single_layers:
+        return None
+
+    # SwiGLU packs gate and value into one projection, so linear_in is 2 x mlp_ratio x inner_dim.
+    ff_in = next(
+        (shape[0] for key, shape in keys.items() if key.endswith("ff.linear_in.weight") and shape),
+        0,
+    )
+    time_in = keys.get("time_guidance_embed.timestep_embedder.linear_1.weight") or []
+
+    return {
+        **_FIXED_GEOMETRY,
+        "attention_head_dim": head_dim,
+        "guidance_embeds": any(
+            "guidance_embedder" in key or key.startswith("guidance_in.") for key in keys
+        ),
+        "in_channels": x_embed[1],
+        "joint_attention_dim": joint_attention_dim,
+        "mlp_ratio": round(ff_in / (2 * inner_dim), 4) if ff_in else 3.0,
+        "num_attention_heads": inner_dim // head_dim,
+        "num_layers": len(layers),
+        "num_single_layers": len(single_layers),
+        "timestep_guidance_channels": time_in[1] if len(time_in) == 2 else 256,
+    }
+
+
+def _name_flags(name: str) -> tuple[bool, bool]:
+    """(is_base, is_kv) read from a filename. Base and distilled builds are architecturally
+    identical, so the name is the only signal - BFL and every repacker mark it the same way."""
+    padded = "-" + re.sub(r"[^a-z0-9]+", "-", name.lower()) + "-"
+    return "-base-" in padded, "-kv-" in padded
+
+
+def detect(path: str | Path, shapes: dict[str, list[int]] | None = None) -> Flux2Variant | None:
+    """Which FLUX.2 variant a checkpoint file is, or None if it is not one.
+
+    Pass ``shapes`` when the header has already been read, so it is not read twice. Never reads
+    tensor data and never imports torch.
+    """
+    file = Path(path)
+    if shapes is None:
+        if not file.is_file() or file.suffix.lower() not in _WEIGHT_SUFFIXES:
+            return None
+        try:
+            from ..checkpoint import CheckpointReader
+
+            shapes = CheckpointReader(file).shapes()
+        except Exception:  # noqa: BLE001 - an unreadable or foreign file is simply "not FLUX.2"
+            return None
+
+    config = derive_transformer_config(shapes)
+    if config is None:
+        return None
+    is_base, is_kv = _name_flags(file.name)
+    family = [v for v in VARIANTS if v.joint_attention_dim == config["joint_attention_dim"]]
+    if not family:
+        return None
+    # dev has no base/distilled or KV split, so those name flags must not filter it away.
+    exact = [
+        v
+        for v in family
+        if v.distilled is not is_base and (v.pipeline == "klein-kv") is (is_kv and v.distilled)
+    ]
+    return (exact or family)[0]

--- a/core/src/inline_core/models/krea2/provider.py
+++ b/core/src/inline_core/models/krea2/provider.py
@@ -28,6 +28,17 @@ class Krea2Provider:
     def download_target(self, component: ModelComponent) -> Path:
         return models_dir() / component.category
 
+    def resolved(self) -> dict[str, str]:
+        """What this node would load right now, so the pickers show real files instead of "auto"."""
+        from pathlib import Path as _Path
+
+        picks = {
+            "model": resolve_diffusion(self._variant),
+            "vae": resolve_vae(None),
+            "text_encoder": resolve_text_encoder(None),
+        }
+        return {k: _Path(str(v)).name for k, v in picks.items() if v}
+
     def estimate(self, policy: Any) -> dict[str, Any] | None:
         """Whether the model will fit this machine, so the popup can warn before a 26GB load.
         ``None`` whenever it can't be sized - a wrong estimate is worse than none."""

--- a/core/src/inline_core/models/krea2/runner.py
+++ b/core/src/inline_core/models/krea2/runner.py
@@ -94,15 +94,15 @@ def _descriptor(variant: str) -> NodeDescriptor:
             ),
             ParamField("seed", "Seed (-1 = random)", Widget.SEED, -1),
             ParamField(
-                "model", "Diffusion file (auto)", Widget.SELECT, "",
+                "model", "Diffusion model", Widget.SELECT, "",
                 options_from="diffusion_models", advanced=True,
             ),
             ParamField(
-                "text_encoder", "Text-encoder file (auto)", Widget.SELECT, "",
+                "text_encoder", "Text encoder", Widget.SELECT, "",
                 options_from="text_encoders", advanced=True,
             ),
             ParamField(
-                "vae", "VAE file (auto)", Widget.SELECT, "",
+                "vae", "VAE", Widget.SELECT, "",
                 options_from="vae", advanced=True,
             ),
         ),

--- a/core/src/inline_core/models/loaders.py
+++ b/core/src/inline_core/models/loaders.py
@@ -1091,6 +1091,19 @@ def load_flux2_transformer(
     def build() -> Any:
         from diffusers import Flux2Transformer2DModel
 
+        if Path(file).is_dir():
+            # A diffusers folder carries its own config and, for the prequantized dev checkpoints,
+            # already-NF4 shards. from_pretrained streams them shard by shard, which is the only
+            # way a 32B model reaches a 24 GB card: nothing is ever materialized at full size.
+            # (from_single_file cannot do this - it ignores quantization_config entirely.)
+            return Flux2Transformer2DModel.from_pretrained(
+                file,
+                torch_dtype=dtype,
+                low_cpu_mem_usage=True,
+                local_files_only=True,
+                **({"device_map": {"": device}} if device else {}),
+            )
+
         root = _flux2_config_dir(arch, file, config)
         kwargs: dict[str, Any] = {}
         if _is_gguf(file):
@@ -1203,6 +1216,76 @@ def _flux2_vae_state(
     return converted
 
 
+def assemble_flux2_encoders(
+    *,
+    arch: str,
+    pipeline: str,
+    distilled: bool,
+    vae_file: str,
+    text_encoder_file: str,
+    dtype: Any,
+    quant: Quantization = Quantization.NONE,
+    vae_dtype: Any = None,
+    device: str | None = None,
+) -> Any:
+    """A **transformer-less** FLUX.2 pipeline: VAE + text encoder + scheduler only.
+
+    For the checkpoints where the encoder and the transformer cannot be resident together - dev is
+    18 GB of NF4 transformer against a 15 GB encoder, 33 GB on a 24 GB card - the prompt is encoded
+    through this first, the encoder is freed, and only then is the transformer loaded and attached.
+    Same trick the trainer uses to precache before the base loads.
+    """
+    from diffusers import Flux2KleinKVPipeline, Flux2KleinPipeline, Flux2Pipeline
+
+    vae = load_flux2_vae(arch, vae_file, dtype if vae_dtype is None else vae_dtype, device=device)
+    _release_transient()
+    if pipeline == "dev":
+        text_encoder, tokenizer = load_flux2_mistral_encoder(
+            arch, text_encoder_file, dtype, quant, device=device
+        )
+    else:
+        text_encoder, tokenizer = load_text_encoder(
+            arch, text_encoder_file, dtype, quant, device=device
+        )
+    _release_transient()
+    scheduler = load_scheduler(arch)
+
+    common = dict(scheduler=scheduler, vae=vae, text_encoder=text_encoder, tokenizer=tokenizer)
+    if pipeline == "dev":
+        return Flux2Pipeline(transformer=None, **common)
+    cls = Flux2KleinKVPipeline if pipeline == "klein-kv" else Flux2KleinPipeline
+    return cls(transformer=None, is_distilled=distilled, **common)
+
+
+def attach_flux2_transformer(
+    pipe: Any,
+    *,
+    arch: str,
+    diffusion_file: str,
+    config: dict[str, Any],
+    vae_file: str,
+    dtype: Any,
+    quant: Quantization = Quantization.NONE,
+    device: str | None = None,
+    loras: tuple[LoraRef, ...] = (),
+) -> Any:
+    """Free the text encoder, then load the transformer into the VRAM it was holding.
+
+    The VAE is kept: it is small and the decode still needs it. Dropped rather than moved to the
+    CPU, because the hosts that need this staging are exactly the ones whose RAM cannot take a
+    15 GB encoder either.
+    """
+    pipe.text_encoder = None
+    pipe.tokenizer = None
+    unload_components(keep_files={vae_file})
+    _release_transient()
+    pipe.transformer = load_flux2_transformer(
+        arch, diffusion_file, config, dtype, quant, device=device, loras=loras
+    )
+    _release_transient()
+    return pipe
+
+
 def assemble_flux2_pipeline(
     *,
     arch: str,
@@ -1283,9 +1366,11 @@ def load_flux2_mistral_encoder(
         from transformers import AutoProcessor, Mistral3ForConditionalGeneration
 
         root = ensure_assets(arch)
-        weights_dir = _staged_encoder_dir(arch, file)
+        # A folder is already a loadable model directory (and for the NF4 build, already quantized);
+        # a single file is staged next to the bundled config so transformers can stream it.
+        weights_dir = file if Path(file).is_dir() else str(_staged_encoder_dir(arch, file))
         text_encoder = Mistral3ForConditionalGeneration.from_pretrained(
-            str(weights_dir),
+            weights_dir,
             torch_dtype=dtype,
             low_cpu_mem_usage=True,
             device_map={"": device} if device else None,

--- a/core/src/inline_core/models/loaders.py
+++ b/core/src/inline_core/models/loaders.py
@@ -105,7 +105,85 @@ _KREA2 = ArchSpec(
     ),
 )
 
-SPECS: dict[str, ArchSpec] = {_ZIMAGE.key: _ZIMAGE, _KREA2.key: _KREA2}
+#: FLUX.2 klein 4B: BFL's own repo is Apache-2.0 and ungated, so one repo covers every small asset
+#: including ``chat_template.jinja`` - klein encodes the prompt through the Qwen3 chat template, and
+#: a wrong template silently degrades the embedding. The transformer config is NOT fetched: it is
+#: derived from the picked checkpoint (see ``flux2/variants.py``), which is what lets one node load
+#: 4B, 9B, dev and any future build without a per-variant config.
+_FLUX2_KLEIN_4B = ArchSpec(
+    key="flux2-klein-4b",
+    assets_repo="black-forest-labs/FLUX.2-klein-4B",
+    asset_files=tuple(
+        AssetFile(path)
+        for path in (
+            "vae/config.json",
+            "scheduler/scheduler_config.json",
+            "text_encoder/config.json",
+            "text_encoder/generation_config.json",
+            "tokenizer/tokenizer.json",
+            "tokenizer/tokenizer_config.json",
+            "tokenizer/chat_template.jinja",
+            "tokenizer/special_tokens_map.json",
+            "tokenizer/added_tokens.json",
+            "tokenizer/merges.txt",
+            "tokenizer/vocab.json",
+        )
+    ),
+)
+
+#: FLUX.2 klein 9B: BFL's 9B repos are gated, so the encoder config comes from the ungated Qwen3-8B
+#: repo it is built from. The VAE, scheduler and tokenizer are identical family-wide, so they still
+#: come from the 4B repo.
+_FLUX2_KLEIN_9B = ArchSpec(
+    key="flux2-klein-9b",
+    assets_repo="Qwen/Qwen3-8B",
+    asset_files=(
+        AssetFile("config.json", local="text_encoder/config.json"),
+        AssetFile("vae/config.json", repo="black-forest-labs/FLUX.2-klein-4B"),
+        AssetFile("scheduler/scheduler_config.json", repo="black-forest-labs/FLUX.2-klein-4B"),
+        *(
+            AssetFile(path, repo="black-forest-labs/FLUX.2-klein-4B")
+            for path in (
+                "tokenizer/tokenizer.json",
+                "tokenizer/tokenizer_config.json",
+                "tokenizer/chat_template.jinja",
+                "tokenizer/special_tokens_map.json",
+                "tokenizer/added_tokens.json",
+                "tokenizer/merges.txt",
+                "tokenizer/vocab.json",
+            )
+        ),
+    ),
+)
+
+#: FLUX.2 dev: its assets come from BFL's own repo, not from Mistral's. The upstream Mistral repo
+#: ships `tekken.json` (Mistral's own tokenizer format) and has no diffusers-style processor config
+#: at all, so the pipeline cannot be built from it. BFL's repo is access-gated, which the fetch
+#: handles by using the ambient HF token (see ``ensure_assets``).
+_FLUX2_DEV = ArchSpec(
+    key="flux2-dev",
+    assets_repo="black-forest-labs/FLUX.2-dev",
+    asset_files=(
+        AssetFile("text_encoder/config.json"),
+        AssetFile("text_encoder/generation_config.json"),
+        AssetFile("tokenizer/tokenizer.json"),
+        AssetFile("tokenizer/tokenizer_config.json"),
+        AssetFile("tokenizer/preprocessor_config.json"),
+        AssetFile("tokenizer/processor_config.json"),
+        AssetFile("tokenizer/special_tokens_map.json"),
+        AssetFile("tokenizer/chat_template.jinja"),
+        AssetFile("vae/config.json", repo="black-forest-labs/FLUX.2-klein-4B"),
+        AssetFile("scheduler/scheduler_config.json", repo="black-forest-labs/FLUX.2-klein-4B"),
+    ),
+)
+
+SPECS: dict[str, ArchSpec] = {
+    _ZIMAGE.key: _ZIMAGE,
+    _KREA2.key: _KREA2,
+    _FLUX2_KLEIN_4B.key: _FLUX2_KLEIN_4B,
+    _FLUX2_KLEIN_9B.key: _FLUX2_KLEIN_9B,
+    _FLUX2_DEV.key: _FLUX2_DEV,
+}
 
 
 def _spec(arch: str) -> ArchSpec:
@@ -144,17 +222,24 @@ def ensure_assets(arch: str) -> Path:
         try:
             import shutil
 
-            from huggingface_hub import hf_hub_download
 
             for asset in spec.asset_files:
                 repo, local = asset.target(spec)
-                # token=False: these repos are public, and a stale ambient token 401s even on those.
-                fetched = hf_hub_download(repo, asset.path, local_dir=str(root), token=False)
+                fetched = _fetch_asset(repo, asset.path, root)
                 if local != asset.path:
                     destination = root / local
                     destination.parent.mkdir(parents=True, exist_ok=True)
                     shutil.move(fetched, destination)
         except Exception as error:  # noqa: BLE001 - re-raised as a clear component error
+            # A gated repo is an access problem, not a config problem, and the fix is a click on
+            # the model page rather than anything in the app - so say that instead.
+            if type(error).__name__ == "GatedRepoError":
+                raise ComponentError(
+                    f"{spec.assets_repo} is a gated repository and this Hugging Face account has "
+                    f"not been granted access. Open https://huggingface.co/{spec.assets_repo} , "
+                    "accept the licence, then run this again. (Log in with `hf auth login` or set "
+                    "HF_TOKEN if you have not already.)"
+                ) from error
             raise ComponentError(
                 f"Could not fetch the one-time {arch} config/tokenizer assets from "
                 f"{spec.assets_repo} ({error}). This ~15 MB download happens once; after it, "
@@ -162,6 +247,26 @@ def ensure_assets(arch: str) -> Path:
             ) from error
         marker.write_text("ok")
     return root
+
+
+
+def _fetch_asset(repo: str, path: str, root: Path) -> str:
+    """One small asset, trying the ambient HF token first and anonymously second.
+
+    Both directions matter: an access-gated repo (FLUX.2 dev) needs the user's token, while a
+    stale or invalid cached token 401s even on a public repo - so neither order alone works. This
+    mirrors what the model downloader does for weights (``studio/models.py``).
+    """
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.utils import HfHubHTTPError
+
+    try:
+        return hf_hub_download(repo, path, local_dir=str(root))
+    except HfHubHTTPError as error:
+        status = getattr(getattr(error, "response", None), "status_code", None)
+        if status not in (401, 403):
+            raise
+        return hf_hub_download(repo, path, local_dir=str(root), token=False)
 
 
 def _link_or_copy(src: Path, dst: Path) -> None:
@@ -920,4 +1025,276 @@ def assemble_zimage_pipeline(
         text_encoder=text_encoder,
         tokenizer=tokenizer,
         transformer=transformer,
+    )
+
+
+# --- FLUX.2 --------------------------------------------------------------------------------------
+
+
+def _flux2_config_dir(arch: str, file: str, config: dict[str, Any]) -> Path:
+    """A tiny staging dir holding the transformer config derived from ``file``, so diffusers'
+    ``from_single_file`` has a local config to read.
+
+    The config is derived from the checkpoint's own tensor shapes rather than fetched, which is what
+    lets one node load klein 4B, klein 9B, dev and any later build. Keyed by the weights path, so a
+    different checkpoint stages its own."""
+    digest = hashlib.sha1(f"{file}:{sorted(config.items())!r}".encode()).hexdigest()[:16]
+    stage = assets_root(arch) / "transformer_config" / digest
+    marker = stage / "config.json"
+    if marker.is_file():
+        return stage
+    with _ASSETS_LOCK:
+        if marker.is_file():
+            return stage
+        import json
+
+        stage.mkdir(parents=True, exist_ok=True)
+        payload = {"_class_name": "Flux2Transformer2DModel", **config}
+        marker.write_text(json.dumps(payload, indent=2))
+    return stage
+
+
+def _is_gguf(file: str) -> bool:
+    return Path(file).suffix.lower() == ".gguf"
+
+
+def _gguf_config(dtype: Any) -> Any:
+    """diffusers' GGUF quantization config, or a clear error when the optional backend is absent.
+
+    Unlike int8/NF4 this is not a fallback-to-full-precision case: a ``.gguf`` file cannot be read
+    at all without it, so failing with an install hint beats a raw parser traceback."""
+    try:
+        from diffusers import GGUFQuantizationConfig
+
+        return GGUFQuantizationConfig(compute_dtype=dtype)
+    except Exception as error:  # noqa: BLE001 - surfaced as a node error with an install hint
+        raise ComponentError(
+            "Reading a .gguf checkpoint needs the 'gguf' package. Install it (pip install gguf) or "
+            "pick a .safetensors model in the Diffusion file dropdown."
+        ) from error
+
+
+def load_flux2_transformer(
+    arch: str,
+    file: str,
+    config: dict[str, Any],
+    dtype: Any,
+    quant: Quantization = Quantization.NONE,
+    device: str | None = None,
+    loras: tuple[LoraRef, ...] = (),
+) -> Any:
+    """The FLUX.2 transformer from a single ``.safetensors`` or ``.gguf``.
+
+    ``config`` is the geometry derived from the checkpoint. GGUF carries its own quantization, so
+    the fit plan's quant is ignored for those files - the file already is the smaller weights."""
+
+    def build() -> Any:
+        from diffusers import Flux2Transformer2DModel
+
+        root = _flux2_config_dir(arch, file, config)
+        kwargs: dict[str, Any] = {}
+        if _is_gguf(file):
+            kwargs["quantization_config"] = _gguf_config(dtype)
+        model = Flux2Transformer2DModel.from_single_file(
+            file,
+            config=str(root),
+            torch_dtype=dtype,
+            low_cpu_mem_usage=True,
+            device=device,
+            local_files_only=True,
+            **kwargs,
+        )
+        if _is_gguf(file):
+            if loras:
+                raise ComponentError(
+                    "LoRAs cannot be fused into a .gguf checkpoint. Use a .safetensors model, or "
+                    "remove the LoRA."
+                )
+            return model
+        # Fuse before quantizing: the fuse adds a full-precision delta into each weight, which a
+        # quantized weight is not a plain tensor to accept. Same ordering as the Z-Image path.
+        if loras:
+            from .lora import fuse_loras
+
+            fuse_loras(model, loras)
+        if quant is Quantization.NF4:
+            _swap_to_4bit(model)
+            if device:
+                model.to(device)  # bitsandbytes quantizes each weight during this move
+        else:
+            # from_single_file ignores quantization_config, so int8 is applied after the load.
+            _quantize_in_place(model, quant)
+        return model
+
+    key = (
+        arch, "diffusion", file, _dtype_key(dtype), quant.value, _device_key(device),
+        *lora_cache_key(loras),
+    )
+    return _cached(key, build)
+
+
+def load_flux2_vae(arch: str, file: str, dtype: Any, device: str | None = None) -> Any:
+    """The FLUX.2 VAE from a single ``.safetensors`` plus the bundled config.
+
+    ``AutoencoderKLFlux2`` has no single-file converter in diffusers, so the config-driven
+    ``from_config`` + ``assign=`` load is used instead (the same shape as the Z-Image ControlNet
+    loader). Never quantized: the config sets ``force_upcast`` and it is only a few hundred MB.
+    Note this VAE carries running batch-norm buffers instead of FLUX.1's latent scale/shift scalars,
+    so a strict load is what guarantees they arrived."""
+
+    def build() -> Any:
+        import torch
+        from diffusers import AutoencoderKLFlux2
+        from safetensors.torch import load_file
+
+        root = ensure_assets(arch)
+        config = AutoencoderKLFlux2.load_config(str(root), subfolder="vae")
+        with torch.device("meta"):
+            model = AutoencoderKLFlux2.from_config(config)
+        expected = set(model.state_dict())
+        state = _flux2_vae_state(load_file(file, device=device or "cpu"), config, expected)
+        missing = expected - set(state)
+        if missing:
+            raise ComponentError(
+                f"'{Path(file).name}' is not a FLUX.2 VAE ({len(missing)} tensors missing, e.g. "
+                f"{sorted(missing)[0]}). Download the FLUX.2 VAE from the node's model popup."
+            )
+        model = model.to_empty(device=device or "cpu")
+        model.load_state_dict({k: v.to(dtype) for k, v in state.items()}, strict=True, assign=True)
+        state.clear()
+        _release_transient()
+        return model.eval()
+
+    return _cached(
+        (arch, "vae", file, _dtype_key(dtype), Quantization.NONE.value, _device_key(device)), build
+    )
+
+
+def _flux2_vae_state(
+    state: dict[str, Any], config: dict[str, Any], expected: set[str]
+) -> dict[str, Any]:
+    """The shipped VAE in diffusers key order.
+
+    The distributed file (BFL's, and ComfyUI's repack of it) uses the original LDM layout -
+    ``decoder.mid.attn_1.k`` where diffusers has ``decoder.mid_block.attentions.0.to_k`` - and
+    diffusers has no single-file loader for ``AutoencoderKLFlux2``. Its LDM converter does the bulk
+    of the rename; two things it does not know about are handled here:
+
+    - ``bn.*``, the running batch-norm statistics FLUX.2 uses in place of FLUX.1's latent
+      scale/shift scalars. Losing these silently produces washed-out output rather than an error.
+    - ``quant_conv`` / ``post_quant_conv``, which the file nests under encoder/decoder.
+
+    A file that is already diffusers-keyed is passed through untouched.
+    """
+    if expected.issubset(state):
+        return state
+    from diffusers.loaders.single_file_utils import convert_ldm_vae_checkpoint
+
+    converted: dict[str, Any] = dict(convert_ldm_vae_checkpoint(dict(state), config))
+    for source, target in (
+        ("encoder.quant_conv", "quant_conv"),
+        ("decoder.post_quant_conv", "post_quant_conv"),
+    ):
+        for suffix in ("weight", "bias"):
+            value = state.get(f"{source}.{suffix}")
+            if value is not None:
+                converted[f"{target}.{suffix}"] = value
+    converted.update({k: v for k, v in state.items() if k.startswith("bn.")})
+    return converted
+
+
+def assemble_flux2_pipeline(
+    *,
+    arch: str,
+    pipeline: str,
+    distilled: bool,
+    diffusion_file: str,
+    config: dict[str, Any],
+    vae_file: str,
+    text_encoder_file: str,
+    dtype: Any,
+    quant: Quantization = Quantization.NONE,
+    vae_dtype: Any = None,
+    device: str | None = None,
+    loras: tuple[LoraRef, ...] = (),
+    cancel_check: Callable[[], None] | None = None,
+) -> Any:
+    """Build a FLUX.2 pipeline from three local single files.
+
+    ``pipeline`` selects the class family: ``"klein"``/``"klein-kv"`` (Qwen3 encoder) or ``"dev"``
+    (Mistral-3). Components are cached individually, so swapping one file reuses the others, and
+    buffers are released between the big loads so peak memory tracks one component rather than their
+    sum. The returned pipeline is unplaced - the runner owns placement."""
+    from diffusers import Flux2KleinKVPipeline, Flux2KleinPipeline, Flux2Pipeline
+
+    transformer = load_flux2_transformer(
+        arch, diffusion_file, config, dtype, quant, device=device, loras=loras
+    )
+    _release_transient()
+    if cancel_check is not None:
+        cancel_check()
+    vae = load_flux2_vae(arch, vae_file, dtype if vae_dtype is None else vae_dtype, device=device)
+    _release_transient()
+    if cancel_check is not None:
+        cancel_check()
+    if pipeline == "dev":
+        text_encoder, tokenizer = load_flux2_mistral_encoder(
+            arch, text_encoder_file, dtype, quant, device=device
+        )
+    else:
+        # klein's encoder is a stock Qwen3 - the same loader (and the same on-disk file) Z-Image
+        # uses, so a user who already ran Z-Image has it.
+        text_encoder, tokenizer = load_text_encoder(
+            arch, text_encoder_file, dtype, quant, device=device
+        )
+    _release_transient()
+    scheduler = load_scheduler(arch)
+
+    if pipeline == "dev":
+        return Flux2Pipeline(
+            scheduler=scheduler,
+            vae=vae,
+            text_encoder=text_encoder,
+            tokenizer=tokenizer,
+            transformer=transformer,
+        )
+    cls = Flux2KleinKVPipeline if pipeline == "klein-kv" else Flux2KleinPipeline
+    return cls(
+        scheduler=scheduler,
+        vae=vae,
+        text_encoder=text_encoder,
+        tokenizer=tokenizer,
+        transformer=transformer,
+        is_distilled=distilled,
+    )
+
+
+def load_flux2_mistral_encoder(
+    arch: str,
+    file: str,
+    dtype: Any,
+    quant: Quantization = Quantization.NONE,
+    device: str | None = None,
+) -> tuple[Any, Any]:
+    """FLUX.2 dev's Mistral-3 text encoder + processor, staged like the Qwen3 one so transformers
+    streams tensors to the GPU instead of materializing all ~35 GB in host RAM."""
+
+    def build() -> tuple[Any, Any]:
+        from transformers import AutoProcessor, Mistral3ForConditionalGeneration
+
+        root = ensure_assets(arch)
+        weights_dir = _staged_encoder_dir(arch, file)
+        text_encoder = Mistral3ForConditionalGeneration.from_pretrained(
+            str(weights_dir),
+            torch_dtype=dtype,
+            low_cpu_mem_usage=True,
+            device_map={"": device} if device else None,
+            local_files_only=True,
+            quantization_config=_quant_config(quant, framework="transformers"),
+        )
+        processor = AutoProcessor.from_pretrained(str(root / "tokenizer"), local_files_only=True)
+        return text_encoder, processor
+
+    return _cached(
+        (arch, "text_encoder", file, _dtype_key(dtype), quant.value, _device_key(device)), build
     )

--- a/core/src/inline_core/models/requirements.py
+++ b/core/src/inline_core/models/requirements.py
@@ -54,6 +54,23 @@ class RequirementsProvider(Protocol):
         the hidden Hugging Face cache."""
         ...
 
+    def resolved(self) -> dict[str, str]:
+        """param key -> the file this node would load right now, for its own dropdowns.
+
+        Optional. Without it a node's file pickers sit on "auto", which tells a user nothing about
+        what actually ran; with it the node opens showing the real selection, which is also the
+        thing they need in order to change it.
+        """
+        ...
+
+    def catalog_options(self, category: str) -> list[str] | None:
+        """The files in a category this node can actually load, or None to accept the whole catalog.
+
+        Optional. Categories are shared across architectures, so an unfiltered list offers a FLUX.2
+        node a Z-Image checkpoint that would fail on load.
+        """
+        ...
+
     def estimate(self, policy: Any) -> dict[str, Any] | None:
         """Whether the model will fit this machine, or None when it can't be sized.
 
@@ -85,6 +102,33 @@ class RequirementsRegistry:
 
     def has(self, node_type: str) -> bool:
         return node_type in self._providers
+
+    def resolved(self, node_type: str) -> dict[str, str]:
+        """A node's resolved file picks, or empty when it does not implement the optional hook."""
+        return _optional(self._providers.get(node_type), "resolved", {}) or {}
+
+    def catalog_options(self, node_type: str, category: str) -> list[str] | None:
+        """A node's allowed files in a category, or None to accept the whole catalog."""
+        provider = self._providers.get(node_type)
+        hook = getattr(provider, "catalog_options", None)
+        if hook is None:
+            return None
+        try:
+            return hook(category)
+        except Exception:  # noqa: BLE001 - a provider must never break the model list
+            return None
+
+
+def _optional(provider: object | None, name: str, fallback: Any) -> Any:
+    """Call an optional provider hook, tolerating both absence and failure: the node list is served
+    on every catalog change and must not depend on a provider behaving."""
+    hook = getattr(provider, name, None)
+    if hook is None:
+        return fallback
+    try:
+        return hook()
+    except Exception:  # noqa: BLE001 - a provider must never break the model list
+        return fallback
 
     def node_types(self) -> list[str]:
         return sorted(self._providers)

--- a/core/src/inline_core/models/zimage/provider.py
+++ b/core/src/inline_core/models/zimage/provider.py
@@ -30,6 +30,18 @@ class ZImageProvider:
     def download_target(self, component: ModelComponent) -> Path:
         return models_dir() / component.category
 
+    def resolved(self) -> dict[str, str]:
+        """What this node would load right now, so the pickers show real files instead of "auto"."""
+        from pathlib import Path as _Path
+
+        diffusion = resolve_diffusion(None)
+        picks: dict[str, Any] = {
+            "model": diffusion[1] if diffusion and diffusion[0] == "single_file" else None,
+            "vae": resolve_vae(None),
+            "text_encoder": resolve_text_encoder(None),
+        }
+        return {k: _Path(str(v)).name for k, v in picks.items() if v}
+
     def estimate(self, policy: Any) -> dict[str, Any] | None:
         """Whether the model will fit this machine, and how (resident / int8 / offload / won't
         fit), so the popup warns BEFORE a load. Pure ``stat`` + a live VRAM/RAM probe; ``None``

--- a/core/src/inline_core/models/zimage/runner.py
+++ b/core/src/inline_core/models/zimage/runner.py
@@ -90,15 +90,15 @@ ZIMAGE = NodeDescriptor(
         ParamField("seed", "Seed (-1 = random)", Widget.SEED, -1),
         # Advanced: pick a specific file per component. "" = auto (the single file in that folder).
         ParamField(
-            "model", "Diffusion file (auto)", Widget.SELECT, "",
+            "model", "Diffusion model", Widget.SELECT, "",
             options_from="diffusion_models", advanced=True,
         ),
         ParamField(
-            "text_encoder", "Text-encoder file (auto)", Widget.SELECT, "",
+            "text_encoder", "Text encoder", Widget.SELECT, "",
             options_from="text_encoders", advanced=True,
         ),
         ParamField(
-            "vae", "VAE file (auto)", Widget.SELECT, "",
+            "vae", "VAE", Widget.SELECT, "",
             options_from="vae", advanced=True,
         ),
     ),

--- a/core/src/inline_core/server/app.py
+++ b/core/src/inline_core/server/app.py
@@ -321,7 +321,7 @@ def create_app(
             studio_store,
             core_models=core_models,
             core_status=core_status,
-            generation=CoreGeneration(studio_store, manager, events),
+            generation=CoreGeneration(studio_store, manager, events, registry),
             fal_generation=FalGeneration(studio_store, events),
             timeline=Timeline(studio_store, events),
             training=Training(studio_store, events, on_output=catalog.rescan),

--- a/core/src/inline_core/server/app.py
+++ b/core/src/inline_core/server/app.py
@@ -182,14 +182,14 @@ def create_app(
             return Response(status_code=304)
         body = {
             "registryVersion": version,
-            "models": [descriptor_json(d, catalog) for d in registry.descriptors()],
+            "models": [descriptor_json(d, catalog, reqs) for d in registry.descriptors()],
         }
         return JSONResponse(body, headers={"ETag": etag})
 
     @app.get("/v1/models/{model_type:path}")
     async def get_model(model_type: str) -> Response:
         try:
-            return JSONResponse(descriptor_json(registry.get(model_type), catalog))
+            return JSONResponse(descriptor_json(registry.get(model_type), catalog, reqs))
         except UnknownNodeType as error:
             return _error("not_found", str(error), 404)
 
@@ -310,7 +310,9 @@ def create_app(
         def core_models() -> dict[str, Any]:
             return {
                 "registryVersion": _version(registry, catalog),
-                "models": [descriptor_json(d, catalog) for d in registry.descriptors()],
+                "models": [
+                    descriptor_json(d, catalog, reqs) for d in registry.descriptors()
+                ],
             }
 
         def core_status() -> dict[str, Any]:

--- a/core/src/inline_core/server/bootstrap.py
+++ b/core/src/inline_core/server/bootstrap.py
@@ -74,6 +74,15 @@ def _register_builtins(
     except ImportError:
         pass
     try:
+        from ..models.flux2.provider import Flux2Provider
+        from ..models.flux2.runner import FLUX2, register_flux2
+
+        register_flux2(registry, store, policy)
+        requirements.register(FLUX2.type, Flux2Provider())
+        registered.append(FLUX2.type)
+    except ImportError:
+        pass
+    try:
         from ..models.zimage.primitives import register_zimage_primitives
 
         register_zimage_primitives(registry, store, policy)

--- a/core/src/inline_core/server/serialize.py
+++ b/core/src/inline_core/server/serialize.py
@@ -21,7 +21,12 @@ def port_json(port: Port) -> dict[str, Any]:
     return {"id": port.id, "label": port.label, "kind": port.kind.value, "required": port.required}
 
 
-def param_json(field: ParamField, catalog: ModelCatalog | None = None) -> dict[str, Any]:
+def param_json(
+    field: ParamField,
+    catalog: ModelCatalog | None = None,
+    resolved: dict[str, str] | None = None,
+    options_for: Any = None,
+) -> dict[str, Any]:
     out: dict[str, Any] = {
         "key": field.key,
         "label": field.label,
@@ -37,8 +42,17 @@ def param_json(field: ParamField, catalog: ModelCatalog | None = None) -> dict[s
     options = [{"value": o.value, "label": o.label} for o in field.options]
     if field.options_from is not None:
         out["optionsFrom"] = field.options_from
-        if catalog is not None:
+        # A node's own provider narrows the shared category to the files it can actually load;
+        # without that a FLUX.2 node lists Z-Image checkpoints that fail on load.
+        allowed = options_for(field.options_from) if options_for else None
+        if allowed is not None:
+            options += [{"value": f, "label": f} for f in allowed]
+        elif catalog is not None:
             options += [{"value": f, "label": f} for f in catalog.list(field.options_from)]
+    # Show the file the node would actually use rather than an opaque "auto", so what a user sees
+    # is what ran, and so they have something concrete to change.
+    if resolved and field.key in resolved:
+        out["default"] = resolved[field.key]
     if options:
         out["options"] = options
     if field.advanced:
@@ -47,8 +61,16 @@ def param_json(field: ParamField, catalog: ModelCatalog | None = None) -> dict[s
 
 
 def descriptor_json(
-    descriptor: NodeDescriptor, catalog: ModelCatalog | None = None
+    descriptor: NodeDescriptor,
+    catalog: ModelCatalog | None = None,
+    requirements: Any = None,
 ) -> dict[str, Any]:
+    resolved = requirements.resolved(descriptor.type) if requirements else {}
+    options_for = (
+        (lambda category: requirements.catalog_options(descriptor.type, category))
+        if requirements
+        else None
+    )
     out: dict[str, Any] = {
         "type": descriptor.type,
         "title": descriptor.title,
@@ -58,7 +80,9 @@ def descriptor_json(
         "outputKind": descriptor.output_kind.value if descriptor.output_kind else None,
         "inputs": [port_json(p) for p in descriptor.inputs],
         "outputs": [port_json(p) for p in descriptor.outputs],
-        "params": [param_json(p, catalog) for p in descriptor.params],
+        "params": [
+            param_json(p, catalog, resolved, options_for) for p in descriptor.params
+        ],
     }
     if descriptor.hidden:
         out["hidden"] = True

--- a/core/src/inline_core/studio/fal.py
+++ b/core/src/inline_core/studio/fal.py
@@ -51,18 +51,27 @@ def file_to_data_uri(abs_path: Path) -> str:
 
 def resolve_fal_inputs(conn: Any, folder: Path, frame_id: str) -> dict[str, Any]:
     """A frame's inputs + prompt, resolved for the browser to build the fal request: media inputs as
-    base64 data URIs grouped by kind, and the prompt text from a connected Prompt node."""
+    base64 data URIs grouped by kind, and the prompt text from a connected Prompt node.
+
+    ``byHandle`` additionally groups the same URIs by the input port each was wired to, so a model
+    with two ports of one kind (a start and an end keyframe) can tell them apart. Untagged inputs
+    (drag-drop, and anything predating the handle column) appear only in the kind buckets."""
     images: list[str] = []
     videos: list[str] = []
     audios: list[str] = []
+    by_handle: dict[str, list[str]] = {}
     for media in fr.frame_input_media(conn, frame_id):
         uri = file_to_data_uri(folder / media["filePath"])
         kind = media["kind"]
         (videos if kind == "video" else audios if kind == "audio" else images).append(uri)
+        handle = media.get("handle")
+        if handle:
+            by_handle.setdefault(handle, []).append(uri)
     return {
         "images": images,
         "videos": videos,
         "audios": audios,
+        "byHandle": by_handle,
         "prompt": mb.prompt_text_for_frame(conn, frame_id),
     }
 

--- a/core/src/inline_core/studio/frames.py
+++ b/core/src/inline_core/studio/frames.py
@@ -81,6 +81,7 @@ def _row_to_input(row: sqlite3.Row) -> dict[str, Any]:
         "assetId": row["asset_id"],
         "sourceFrameId": row["source_frame_id"],
         "position": row["position"],
+        "handle": row["handle"],
     }
 
 
@@ -358,27 +359,40 @@ def resolve_frame_file(
     return None
 
 
-def frame_input_media(conn: sqlite3.Connection, frame_id: str) -> list[dict[str, str]]:
-    """A frame's inputs resolved to {filePath, kind}, in order (skipping unresolvable ones)."""
-    out: list[dict[str, str]] = []
+def frame_input_media(conn: sqlite3.Connection, frame_id: str) -> list[dict[str, Any]]:
+    """A frame's inputs resolved to {filePath, kind, handle}, in order (skipping unresolvable ones).
+    ``handle`` is the input port it was wired to, or None when untagged."""
+    out: list[dict[str, Any]] = []
     for inp in _input_rows(conn, frame_id):
         if inp["asset_id"]:
             asset = conn.execute(
                 "SELECT file_path, kind FROM assets WHERE id = ?", (inp["asset_id"],)
             ).fetchone()
             if asset is not None:
-                out.append({"filePath": asset["file_path"], "kind": asset["kind"]})
+                out.append(
+                    {
+                        "filePath": asset["file_path"],
+                        "kind": asset["kind"],
+                        "handle": inp["handle"],
+                    }
+                )
         elif inp["source_frame_id"]:
             up = resolve_frame_file(conn, inp["source_frame_id"])
             if up is not None:
-                out.append(up)
+                out.append({**up, "handle": inp["handle"]})
     return out
 
 
-def add_input(conn: sqlite3.Connection, frame_id: str, asset_id: str) -> dict[str, Any]:
+def add_input(
+    conn: sqlite3.Connection, frame_id: str, asset_id: str, handle: str | None = None
+) -> dict[str, Any]:
     get_frame(conn, frame_id)
     existing = _input_rows(conn, frame_id)
-    dup = next((r for r in existing if r["asset_id"] == asset_id), None)
+    # Dedup per (asset, handle): the same image legitimately feeds two ports (a start and an end
+    # keyframe), so an asset already wired elsewhere must not block this port.
+    dup = next(
+        (r for r in existing if r["asset_id"] == asset_id and r["handle"] == handle), None
+    )
     if dup is not None:
         return _row_to_input(dup)
     row = {
@@ -387,20 +401,22 @@ def add_input(conn: sqlite3.Connection, frame_id: str, asset_id: str) -> dict[st
         "assetId": asset_id,
         "sourceFrameId": None,
         "position": len(existing),
+        "handle": handle,
     }
     conn.execute(
-        "INSERT INTO frame_inputs (id, frame_id, asset_id, position) VALUES (?, ?, ?, ?)",
-        (row["id"], frame_id, asset_id, row["position"]),
+        "INSERT INTO frame_inputs (id, frame_id, asset_id, position, handle) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (row["id"], frame_id, asset_id, row["position"], handle),
     )
     return row
 
 
 def add_inputs(
-    conn: sqlite3.Connection, frame_id: str, asset_ids: list[str]
+    conn: sqlite3.Connection, frame_id: str, asset_ids: list[str], handle: str | None = None
 ) -> list[dict[str, Any]]:
     get_frame(conn, frame_id)
     existing = _input_rows(conn, frame_id)
-    have = {r["asset_id"] for r in existing if r["asset_id"]}
+    have = {r["asset_id"] for r in existing if r["asset_id"] and r["handle"] == handle}
     added: list[dict[str, Any]] = []
     pos = len(existing)
     for asset_id in asset_ids:
@@ -413,10 +429,12 @@ def add_inputs(
             "assetId": asset_id,
             "sourceFrameId": None,
             "position": pos,
+            "handle": handle,
         }
         conn.execute(
-            "INSERT INTO frame_inputs (id, frame_id, asset_id, position) VALUES (?, ?, ?, ?)",
-            (row["id"], frame_id, asset_id, pos),
+            "INSERT INTO frame_inputs (id, frame_id, asset_id, position, handle) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (row["id"], frame_id, asset_id, pos, handle),
         )
         added.append(row)
         pos += 1
@@ -424,14 +442,21 @@ def add_inputs(
 
 
 def add_source_input(
-    conn: sqlite3.Connection, frame_id: str, source_frame_id: str
+    conn: sqlite3.Connection, frame_id: str, source_frame_id: str, handle: str | None = None
 ) -> dict[str, Any]:
     get_frame(conn, frame_id)
     get_frame(conn, source_frame_id)
     if frame_id == source_frame_id:
         raise ValueError("A frame cannot use its own output as input.")
     existing = _input_rows(conn, frame_id)
-    dup = next((r for r in existing if r["source_frame_id"] == source_frame_id), None)
+    dup = next(
+        (
+            r
+            for r in existing
+            if r["source_frame_id"] == source_frame_id and r["handle"] == handle
+        ),
+        None,
+    )
     if dup is not None:
         return _row_to_input(dup)
     row = {
@@ -440,11 +465,12 @@ def add_source_input(
         "assetId": None,
         "sourceFrameId": source_frame_id,
         "position": len(existing),
+        "handle": handle,
     }
     conn.execute(
-        "INSERT INTO frame_inputs (id, frame_id, asset_id, source_frame_id, position) "
-        "VALUES (?, ?, NULL, ?, ?)",
-        (row["id"], frame_id, source_frame_id, row["position"]),
+        "INSERT INTO frame_inputs (id, frame_id, asset_id, source_frame_id, position, handle) "
+        "VALUES (?, ?, NULL, ?, ?, ?)",
+        (row["id"], frame_id, source_frame_id, row["position"], handle),
     )
     return row
 

--- a/core/src/inline_core/studio/generation.py
+++ b/core/src/inline_core/studio/generation.py
@@ -19,7 +19,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from ..graph.schema import parse_graph
+from ..graph.schema import PortKind, parse_graph
 from ..runtime.progress import (
     CancelledEvent,
     ErrorEvent,
@@ -44,11 +44,20 @@ def _kind_str(kind: Any) -> str:
 class CoreGeneration:
     """Drives core-node runs and streams their progress as Studio generation events."""
 
-    def __init__(self, store: Any, manager: Any, events: Any) -> None:
+    def __init__(self, store: Any, manager: Any, events: Any, registry: Any = None) -> None:
         self._store = store
         self._manager = manager
         self._events = events
+        self._registry = registry
         self._active: dict[str, str] = {}  # canvas item id -> run id
+
+    def _is_list_port(self, node_type: str, port_id: str) -> bool:
+        """Whether a port accepts several wires. Only the registry knows, and the canvas needs it to
+        decide whether a second wire into a handle adds a reference or replaces the first."""
+        if self._registry is None or not self._registry.has(node_type):
+            return False
+        port = self._registry.get(node_type).input(port_id)
+        return port is not None and port.kind is PortKind.IMAGE_LIST
 
     def run_workflow(self, item_id: str) -> None:
         # If this item still has a run in flight - e.g. the user hit Run again without waiting for a
@@ -60,7 +69,7 @@ class CoreGeneration:
         if previous is not None:
             self._manager.cancel(previous)
         graph_dict, target = build_workflow_graph(
-            self._store.conn(), self._store.folder(), item_id
+            self._store.conn(), self._store.folder(), item_id, self._is_list_port
         )
         self._progress(item_id, 0.02, "Submitting")
         record, _created = self._manager.submit(parse_graph(graph_dict), target)

--- a/core/src/inline_core/studio/graph_build.py
+++ b/core/src/inline_core/studio/graph_build.py
@@ -33,19 +33,63 @@ def _source_output_port(source: dict[str, Any] | None, source_handle: str | None
     return source_handle or "out"  # a 'core' item's handles already are Core port ids
 
 
+def _loader_assets(item: dict[str, Any] | None) -> list[str]:
+    """The asset ids a Load Assets node holds, in the order the user arranged them."""
+    if item is None or item.get("type") != "loader":
+        return []
+    return list((item.get("data") or {}).get("assetIds") or [])
+
+
+def ref_node_id(loader_id: str, index: int) -> str:
+    """The derived source-node id for one asset of a fanned-out Load Assets node."""
+    return f"{loader_id}::ref{index}"
+
+
 def _edges_for(
-    item_id: str, connectors: list[dict[str, Any]], by_id: dict[str, dict[str, Any]]
-) -> dict[str, dict[str, str]]:
-    inputs: dict[str, dict[str, str]] = {}
+    item_id: str,
+    connectors: list[dict[str, Any]],
+    by_id: dict[str, dict[str, Any]],
+    is_list_port: Callable[[str, str], bool],
+    fanned_out: dict[str, int],
+) -> dict[str, list[dict[str, str]]]:
+    """This node's input edges, keyed by target port.
+
+    A **list** port keeps every wire, in connector order, because that order is user-visible: FLUX.2
+    addresses reference images by position. Any other port keeps only the last wire, which is the
+    long-standing behaviour - the canvas allows a second wire and treats it as a replacement, and
+    turning that into a validation error would break existing boards.
+
+    A Load Assets node wired into a list port contributes **all** of its assets rather than just the
+    first, so one loader holding three references composes from three. ``fanned_out`` records which
+    loaders were expanded so the node pass emits matching source nodes.
+    """
+    target = by_id.get(item_id)
+    target_type = ((target or {}).get("data") or {}).get("core", {}).get("type") or ""
+    inputs: dict[str, list[dict[str, str]]] = {}
     for c in connectors:
         if c["toItemId"] != item_id:
             continue
         data = c.get("data") or {}
-        target_handle = data.get("targetHandle") or "in"
-        inputs[target_handle] = {
-            "from": c["fromItemId"],
-            "output": _source_output_port(by_id.get(c["fromItemId"]), data.get("sourceHandle")),
-        }
+        handle = data.get("targetHandle") or "in"
+        source_id = c["fromItemId"]
+        source = by_id.get(source_id)
+        output = _source_output_port(source, data.get("sourceHandle"))
+        listed = bool(target_type) and is_list_port(target_type, handle)
+
+        assets = _loader_assets(source) if listed else []
+        if len(assets) > 1:
+            fanned_out[source_id] = len(assets)
+            edges = [
+                {"from": ref_node_id(source_id, i), "output": "image"}
+                for i in range(len(assets))
+            ]
+        else:
+            edges = [{"from": source_id, "output": output}]
+
+        if listed:
+            inputs.setdefault(handle, []).extend(edges)
+        else:
+            inputs[handle] = edges[:1]
     return inputs
 
 
@@ -55,6 +99,8 @@ def _item_to_node(
     by_id: dict[str, dict[str, Any]],
     resolve_asset_path: Callable[[str], str | None],
     resolve_frame_path: Callable[[str], str | None],
+    is_list_port: Callable[[str, str], bool],
+    fanned_out: dict[str, int],
 ) -> dict[str, Any] | None:
     data = item.get("data") or {}
     if item["type"] == "core" and data.get("core"):
@@ -62,7 +108,7 @@ def _item_to_node(
             "id": item["id"],
             "type": data["core"]["type"],
             "params": data["core"].get("params") or {},
-            "inputs": _edges_for(item["id"], connectors, by_id),
+            "inputs": _edges_for(item["id"], connectors, by_id, is_list_port, fanned_out),
         }
     if item["type"] == "prompt":
         text = data.get("promptText") or ""
@@ -76,9 +122,12 @@ def _item_to_node(
             "type": "input/image",
             "params": {"asset": {"ref": "path", "path": path}},
         }
-    # A Load Assets loader feeds its hero (first) asset as a frozen image source.
+    # A Load Assets loader feeds its hero (first) asset as a frozen image source. Wired into a list
+    # port it instead contributes every asset it holds, one source node each (see _edges_for).
     if item["type"] == "loader":
         asset_ids = data.get("assetIds") or []
+        if item["id"] in fanned_out:
+            return None  # replaced by the derived per-asset sources
         path = resolve_asset_path(asset_ids[0]) if asset_ids else None
         if not path:
             return None
@@ -140,18 +189,21 @@ def _apply_facing_hints(nodes: list[dict[str, Any]], by_id: dict[str, dict[str, 
         item = by_id.get(node["id"])
         if item is None or item.get("type") != "core":
             continue
-        inputs: dict[str, dict[str, str]] = node.get("inputs") or {}
+        inputs: dict[str, list[dict[str, str]]] = node.get("inputs") or {}
         hint: dict[str, str] | None = None
-        for edge in inputs.values():
-            source_item = by_id.get(edge["from"])
-            # Only when the control map itself made it into the graph - an unresolvable map means no
-            # ControlNet runs, and a lone "from behind" in the prompt would be a lie.
-            if edge["from"] not in by_node:
-                continue
-            if source_item is not None and source_item.get("type") == "controlSpace":
-                hint = _facing_hint(source_item)
-                if hint is not None:
-                    break
+        for edges in inputs.values():
+            for edge in edges:
+                source_item = by_id.get(edge["from"])
+                # Only when the control map itself made it into the graph - an unresolvable map
+                # means no ControlNet runs, and a lone "from behind" in the prompt would be a lie.
+                if edge["from"] not in by_node:
+                    continue
+                if source_item is not None and source_item.get("type") == "controlSpace":
+                    hint = _facing_hint(source_item)
+                    if hint is not None:
+                        break
+            if hint is not None:
+                break
         if hint is None:
             continue
         # Idempotent: a take's recipe records the params the run actually used, so restoring a take
@@ -163,8 +215,8 @@ def _apply_facing_hints(nodes: list[dict[str, Any]], by_id: dict[str, dict[str, 
                 params["negative_prompt"] = (
                     f"{existing}, {hint['negative']}" if existing else hint["negative"]
                 )
-        prompt_edge = inputs.get("prompt")
-        source = by_node.get(prompt_edge["from"]) if prompt_edge else None
+        prompt_edges = inputs.get("prompt") or []
+        source = by_node.get(prompt_edges[0]["from"]) if prompt_edges else None
         # Only a plain text source can be extended; a node-produced prompt is left alone.
         if not hint["positive"] or source is None or source["type"] != "input/text":
             continue
@@ -179,7 +231,7 @@ def _apply_facing_hints(nodes: list[dict[str, Any]], by_id: dict[str, dict[str, 
                 "params": {"text": f"{text}, {hint['positive']}" if text else hint["positive"]},
             }
         )
-        inputs["prompt"] = {"from": derived_id, "output": "text"}
+        inputs["prompt"] = [{"from": derived_id, "output": "text"}]
 
 
 def _upstream_closure(target: str, connectors: list[dict[str, Any]]) -> set[str]:
@@ -197,9 +249,17 @@ def _upstream_closure(target: str, connectors: list[dict[str, Any]]) -> set[str]
 
 
 def build_workflow_graph(
-    conn: sqlite3.Connection, folder: Path, target_item_id: str
+    conn: sqlite3.Connection,
+    folder: Path,
+    target_item_id: str,
+    is_list_port: Callable[[str, str], bool] | None = None,
 ) -> tuple[dict[str, Any], str]:
-    """Build the Core graph for a canvas node from the open project's board."""
+    """Build the Core graph for a canvas node from the open project's board.
+
+    ``is_list_port(node_type, port_id)`` reports whether a port accepts several wires; the registry
+    supplies it (see ``studio/generation.py``). Without it every port is treated as single-valued,
+    which is the pre-multi-reference behaviour and keeps this callable from a plain test.
+    """
     board = mb.list_board(conn)
     items, connectors = board["items"], board["connectors"]
     by_id = {i["id"]: i for i in items}
@@ -212,13 +272,55 @@ def build_workflow_graph(
         out = fr.resolve_frame_file(conn, frame_id)
         return str(folder / out["filePath"]) if out else None
 
+    listed = is_list_port or (lambda _type, _port: False)
+    closure = sorted(_upstream_closure(target_item_id, connectors))
+    # Two passes: the edges decide which loaders fan out, so they must be resolved before the node
+    # pass can know whether to emit one source per loader or one per asset.
+    fanned_out: dict[str, int] = {}
+    edges_by_node = {
+        node_id: _edges_for(node_id, connectors, by_id, listed, fanned_out)
+        for node_id in closure
+        if (by_id.get(node_id) or {}).get("type") == "core"
+    }
+
     nodes: list[dict[str, Any]] = []
-    for node_id in _upstream_closure(target_item_id, connectors):
+    for node_id in closure:
         item = by_id.get(node_id)
         if item is None:
             continue
-        node = _item_to_node(item, connectors, by_id, resolve_asset_path, resolve_frame_path)
+        node = _item_to_node(
+            item, connectors, by_id, resolve_asset_path, resolve_frame_path, listed, fanned_out
+        )
         if node is not None:
+            if node_id in edges_by_node:
+                node["inputs"] = edges_by_node[node_id]
             nodes.append(node)
+        nodes.extend(_fanned_out_sources(item, fanned_out, resolve_asset_path))
     _apply_facing_hints(nodes, by_id)
     return {"schemaVersion": 1, "nodes": nodes}, target_item_id
+
+
+def _fanned_out_sources(
+    item: dict[str, Any],
+    fanned_out: dict[str, int],
+    resolve_asset_path: Callable[[str], str | None],
+) -> list[dict[str, Any]]:
+    """One frozen image source per asset of a Load Assets node feeding a list port. An unresolvable
+    asset is skipped rather than failing the run, matching the single-asset path."""
+    count = fanned_out.get(item.get("id") or "")
+    if not count:
+        return []
+    asset_ids = _loader_assets(item)[:count]
+    sources: list[dict[str, Any]] = []
+    for index, asset_id in enumerate(asset_ids):
+        path = resolve_asset_path(asset_id)
+        if not path:
+            continue
+        sources.append(
+            {
+                "id": ref_node_id(item["id"], index),
+                "type": "input/image",
+                "params": {"asset": {"ref": "path", "path": path}},
+            }
+        )
+    return sources

--- a/core/src/inline_core/studio/handlers.py
+++ b/core/src/inline_core/studio/handlers.py
@@ -140,9 +140,12 @@ def register_studio_handlers(
     reg("frames:listTakes", lambda fid: fr.list_takes(conn(), fid))
     reg("frames:heroTakes", lambda: fr.hero_takes(conn()))
     reg("frames:listInputs", lambda: fr.list_inputs(conn()))
-    reg("frames:addInput", lambda fid, aid: fr.add_input(conn(), fid, aid))
-    reg("frames:addInputs", lambda fid, aids: fr.add_inputs(conn(), fid, aids))
-    reg("frames:addSourceInput", lambda fid, src: fr.add_source_input(conn(), fid, src))
+    reg("frames:addInput", lambda fid, aid, handle=None: fr.add_input(conn(), fid, aid, handle))
+    reg("frames:addInputs", lambda fid, aids, handle=None: fr.add_inputs(conn(), fid, aids, handle))
+    reg(
+        "frames:addSourceInput",
+        lambda fid, src, handle=None: fr.add_source_input(conn(), fid, src, handle),
+    )
     reg("frames:removeInput", lambda fid, aid: fr.remove_input(conn(), fid, aid))
     reg("frames:removeInputById", lambda fid, iid: fr.remove_input_by_id(conn(), fid, iid))
     reg("frames:reorderInputs", lambda fid, aids: fr.reorder_inputs(conn(), fid, aids))

--- a/core/src/inline_core/studio/handlers.py
+++ b/core/src/inline_core/studio/handlers.py
@@ -31,6 +31,24 @@ def _unlink(folder: Path, relatives: list[str]) -> None:
             pass
 
 
+
+#: A node whose face is almost entirely an image preview. At the old 200x120 the render was a
+#: thumbnail you had to open a lightbox to read, so generation nodes open large and portrait.
+GENERATION_NODE_SIZE = (320, 480)
+#: Loaders and other plumbing have no preview, so growing them would only cost canvas space.
+COMPACT_NODE_SIZE = (200, 120)
+
+
+def core_node_size(models: list[dict[str, Any]], core_type: str) -> tuple[int, int]:
+    """How large a Core node opens. Decided here rather than in the renderer because only the
+    registry knows whether a type produces a media output. An unknown type is assumed compact:
+    guessing large would leave a big empty card on the canvas."""
+    descriptor = next((m for m in models if m.get("type") == core_type), None)
+    if descriptor and descriptor.get("outputKind"):
+        return GENERATION_NODE_SIZE
+    return COMPACT_NODE_SIZE
+
+
 def register_studio_handlers(
     rpc: Any,
     store: StudioStore,
@@ -173,7 +191,13 @@ def register_studio_handlers(
     reg("moodboard:addLoader", lambda x, y: mb.add_loader(conn(), x, y))
     reg("moodboard:addControlSpace", lambda x, y: mb.add_control_space(conn(), x, y))
     reg("moodboard:addPrompt", lambda x, y: mb.add_prompt(conn(), x, y))
-    reg("moodboard:addCoreNode", lambda t, x, y: mb.add_core_node(conn(), t, x, y))
+    def _size(core_type: str) -> tuple[int, int]:
+        try:
+            return core_node_size(core_models().get("models", []), core_type)
+        except Exception:  # noqa: BLE001 - a sizing hint must never block adding a node
+            return COMPACT_NODE_SIZE
+
+    reg("moodboard:addCoreNode", lambda t, x, y: mb.add_core_node(conn(), t, x, y, *_size(t)))
     reg(
         "moodboard:addGenNode",
         lambda mid, x, y: mb.add_gen_node(conn(), mid, x, y, kind="image", params={}, title=mid),

--- a/core/src/inline_core/studio/moodboard.py
+++ b/core/src/inline_core/studio/moodboard.py
@@ -117,10 +117,13 @@ def list_board(conn: sqlite3.Connection, surface: str = STUDIO_SURFACE) -> dict[
             "SELECT * FROM moodboard_items WHERE surface = ?", (surface,)
         ).fetchall()
     ]
+    # Ordered explicitly: wiring order is user-visible semantics for a list input (FLUX.2 addresses
+    # reference images by position, "the jacket from image 2"), so it must not depend on row order.
     connectors = [
         _row_to_connector(r)
         for r in conn.execute(
-            "SELECT * FROM moodboard_connectors WHERE surface = ?", (surface,)
+            "SELECT * FROM moodboard_connectors WHERE surface = ? ORDER BY created_at, id",
+            (surface,),
         ).fetchall()
     ]
     return {"items": items, "connectors": connectors}

--- a/core/src/inline_core/studio/moodboard.py
+++ b/core/src/inline_core/studio/moodboard.py
@@ -192,9 +192,18 @@ def add_text(conn: sqlite3.Connection, x: float, y: float) -> dict[str, Any]:
     )
 
 
-def add_core_node(conn: sqlite3.Connection, core_type: str, x: float, y: float) -> dict[str, Any]:
+def add_core_node(
+    conn: sqlite3.Connection,
+    core_type: str,
+    x: float,
+    y: float,
+    width: float = 200,
+    height: float = 120,
+) -> dict[str, Any]:
+    """A Core node on the canvas. The caller sizes it, because only the registry knows whether this
+    type renders an image preview (a generation node) or is compact plumbing (a loader)."""
     return _insert_item(
-        conn, item_type="core", x=x, y=y, width=200, height=120,
+        conn, item_type="core", x=x, y=y, width=width, height=height,
         data={"core": {"type": core_type, "params": {}}},
     )
 

--- a/core/src/inline_core/studio/schema.py
+++ b/core/src/inline_core/studio/schema.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import sqlite3
 
-SCHEMA_VERSION = 16
+SCHEMA_VERSION = 17
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS project (
@@ -62,7 +62,8 @@ CREATE TABLE IF NOT EXISTS frame_inputs (
   frame_id        TEXT NOT NULL,
   asset_id       TEXT,
   source_frame_id TEXT,
-  position       INTEGER NOT NULL
+  position       INTEGER NOT NULL,
+  handle         TEXT
 );
 
 CREATE TABLE IF NOT EXISTS asset_folders (
@@ -246,6 +247,11 @@ def _migrate_columns(conn: sqlite3.Connection) -> None:
     _add_column_if_missing(conn, "frame_inputs", "source_frame_id", "TEXT")
 
     _relax_frame_inputs_asset_id(conn)  # v8 -> v9: asset_id must be nullable
+
+    # v16 -> v17: which input port an input was wired to. NULL = untagged (drag-drop, and every
+    # input made before this column existed) - those still resolve by media kind. Must come AFTER
+    # the rebuild above, whose fixed column list would drop it.
+    _add_column_if_missing(conn, "frame_inputs", "handle", "TEXT")
 
     _add_column_if_missing(conn, "assets", "preview_path", "TEXT")
     _add_column_if_missing(conn, "frames", "comfy_workflow_ready", "INTEGER NOT NULL DEFAULT 0")

--- a/core/src/inline_core/training/arch.py
+++ b/core/src/inline_core/training/arch.py
@@ -18,6 +18,7 @@ from typing import Any
 
 Z_IMAGE = "z-image"
 KREA2 = "krea2"
+FLUX2 = "flux2"
 
 #: Z-Image: every ZImageTransformerBlock's attention + SwiGLU feed-forward Linears, confirmed
 #: against ZImageTransformer2DModel.named_modules() (34 blocks, 238 Linears).
@@ -45,10 +46,53 @@ _KREA2_TARGETS = [
 ]
 
 
-#: The attention projections shared by both architectures. Narrowing to these is the Krea 2
-#: authors' advice for long runs: adapting the feed-forward and projection layers too is stronger
-#: on short style runs but costs prompt adherence as the run goes on.
-_ATTENTION = ("to_q", "to_k", "to_v", "to_out.0", "to_gate")
+#: FLUX.2: every Linear in the MMDiT stack, confirmed against Flux2Transformer2DModel's own
+#: named_parameters (5 double + 20 single blocks on klein 4B, 169 tensors, no biases anywhere).
+#: Double blocks carry separate image/text streams (``add_*`` is the text side); single blocks fuse
+#: QKV and the MLP into one ``to_qkv_mlp_proj``, which is why they cannot be adapted attention-only.
+#:
+#: The single blocks' output projection is deliberately absent. PEFT matches targets by module-name
+#: suffix, and a single block's is ``attn.to_out`` (a Linear) while a double block's is also
+#: ``attn.to_out`` (a ModuleList of Linear + Dropout, which PEFT refuses) - no suffix separates
+#: them. The single blocks still learn through ``to_qkv_mlp_proj``, their dominant projection.
+_FLUX2_TARGETS = [
+    "to_q",
+    "to_k",
+    "to_v",
+    "to_out.0",
+    "add_q_proj",
+    "add_k_proj",
+    "add_v_proj",
+    "to_add_out",
+    "ff.linear_in",
+    "ff.linear_out",
+    "ff_context.linear_in",
+    "ff_context.linear_out",
+    "to_qkv_mlp_proj",
+    "x_embedder",
+    "context_embedder",
+    "proj_out",
+]
+
+
+#: The attention projections, across architectures. Narrowing to these is the Krea 2 authors' advice
+#: for long runs: adapting the feed-forward and projection layers too is stronger on short style
+#: runs but costs prompt adherence as the run goes on.
+#:
+#: ``to_qkv_mlp_proj`` is deliberately absent: FLUX.2's single blocks fuse attention and MLP into
+#: that one projection, so including it would silently make "attention" mean "everything". On
+#: FLUX.2 this scope therefore adapts the double blocks only - the text/image fusion stage.
+_ATTENTION = (
+    "to_q",
+    "to_k",
+    "to_v",
+    "to_out.0",
+    "to_gate",
+    "add_q_proj",
+    "add_k_proj",
+    "add_v_proj",
+    "to_add_out",
+)
 
 
 @dataclass(frozen=True)
@@ -141,6 +185,55 @@ def _krea2_forward(transformer: Any, noisy: Any, timestep: Any, item: dict[str, 
     )
 
 
+
+# --- FLUX.2 ---------------------------------------------------------------------------------------
+
+
+def _flux2_sigma(device: Any, shift: float) -> Any:
+    import torch
+
+    # Logit-normal, matching the reference trainers. FLUX.2's shift is resolution dependent and
+    # computed at inference (``compute_empirical_mu``), so it is not baked into the training
+    # distribution - the same reasoning as Krea 2.
+    del shift
+    return torch.sigmoid(torch.randn((), device=device))
+
+
+def _flux2_forward(transformer: Any, noisy: Any, timestep: Any, item: dict[str, Any]) -> Any:
+    """One prediction from Flux2Transformer2DModel, mirroring Flux2KleinPipeline's denoise call.
+
+    The latent arrives already patchified and batch-norm normalized by the precache (see
+    ``dataset._flux2_latent``), so it is (128, H/16, W/16) and packing is the pipeline's plain
+    flatten to (1, tokens, 128). ``timestep`` is the raw sigma: the pipeline passes
+    ``timestep / 1000`` where its own timesteps are ``sigma * 1000``.
+
+    The packing and position-id helpers come from the pipeline itself rather than a local copy, so
+    training cannot drift from inference.
+    """
+    from diffusers import Flux2KleinPipeline as P
+
+    latents = noisy.unsqueeze(0)  # (C, h, w) -> (1, C, h, w)
+    packed = P._pack_latents(latents)
+    img_ids = P._prepare_latent_ids(latents).to(packed.device)
+    embed = item["embed"]
+    embed = embed.unsqueeze(0) if embed.dim() == 2 else embed
+    txt_ids = P._prepare_text_ids(embed).to(packed.device)
+
+    out = transformer(
+        hidden_states=packed,
+        encoder_hidden_states=embed,
+        timestep=timestep.reshape(1),
+        img_ids=img_ids,
+        txt_ids=txt_ids,
+        guidance=None,
+        return_dict=False,
+    )[0]
+    channels, height, width = noisy.shape
+    # Unpack: (1, tokens, C) -> (C, h, w), the inverse of the flatten above.
+    return out[:, : height * width].permute(0, 2, 1).reshape(channels, height, width)
+
+
+
 ARCHS: dict[str, TrainingArch] = {
     Z_IMAGE: TrainingArch(
         key=Z_IMAGE,
@@ -159,6 +252,16 @@ ARCHS: dict[str, TrainingArch] = {
         timestep=lambda sigma: sigma,
         target=lambda clean, noise: noise - clean,
         forward=_krea2_forward,
+    ),
+    FLUX2: TrainingArch(
+        key=FLUX2,
+        target_modules=_FLUX2_TARGETS,
+        sigma=_flux2_sigma,
+        # Rectified flow with Krea 2's convention: x_t = (1 - sigma) * clean + sigma * noise, so
+        # d x_t / d sigma is noise - clean, and the model is called at the sigma itself.
+        timestep=lambda sigma: sigma,
+        target=lambda clean, noise: noise - clean,
+        forward=_flux2_forward,
     ),
 }
 

--- a/core/src/inline_core/training/dataset.py
+++ b/core/src/inline_core/training/dataset.py
@@ -69,8 +69,7 @@ def precache(
     if not pairs:
         raise RuntimeError("The exported dataset is empty.")
 
-    encode_latent = _krea2_latent if arch == archs.KREA2 else _zimage_latent
-    encode_caption = _krea2_caption if arch == archs.KREA2 else _zimage_caption
+    encode_latent, encode_caption = _encoders_for(arch)
     cached: list[dict[str, Any]] = []
     for img_path, caption in pairs:
         for mirrored in (False, True) if flip else (False,):
@@ -94,7 +93,7 @@ def precache_empty(components: Any, arch: str, device: str) -> dict[str, Any]:
     still loaded - by training time the encoder has been freed to make room for the transformer."""
     import torch
 
-    encode_caption = _krea2_caption if arch == archs.KREA2 else _zimage_caption
+    _latent, encode_caption = _encoders_for(arch)
     with torch.no_grad():
         item = encode_caption(components, "", device)
     return {k: v.cpu() for k, v in item.items()}
@@ -156,3 +155,55 @@ def _krea2_caption(components: Any, caption: str, device: str) -> dict[str, Any]
         prompt=caption or "", device=torch.device(device)
     )
     return {"embed": embeds[0], "mask": mask[0]}
+
+
+# --- FLUX.2 -------------------------------------------------------------------------------------
+
+
+def _flux2_latent(vae: Any, pixels: Any) -> Any:
+    """Pixels -> the latent FLUX.2 actually denoises, matching ``_encode_vae_image``.
+
+    Two steps beyond a plain encode, and both are load-bearing. The VAE patchifies 2x2 on top of its
+    8x downscale, so the trained latent is 128 channels at H/16, not 32 at H/8. And FLUX.2 replaced
+    FLUX.1's scale/shift scalars with **running batch-norm statistics carried in the checkpoint** -
+    normalizing with a scalar (or not at all) trains against off-manifold latents that still look
+    plausible, so this must come from ``vae.bn``.
+    """
+    import torch
+    from diffusers import Flux2KleinPipeline as P
+
+    latent = vae.encode(pixels).latent_dist.mode()
+    latent = P._patchify_latents(latent)
+    mean = vae.bn.running_mean.view(1, -1, 1, 1).to(latent.device, latent.dtype)
+    std = torch.sqrt(vae.bn.running_var.view(1, -1, 1, 1) + vae.config.batch_norm_eps).to(
+        latent.device, latent.dtype
+    )
+    return (latent - mean) / std
+
+
+def _flux2_caption(components: Any, caption: str, device: str) -> dict[str, Any]:
+    """Caption -> conditioning, straight from ``Flux2KleinPipeline.encode_prompt``.
+
+    Routed through the pipeline rather than reimplemented because the details are easy to get
+    subtly wrong and impossible to notice: the Qwen3 chat template with thinking **off** (a thinking
+    preamble corrupts the embedding), and three intermediate layers stacked rather than the last.
+    """
+    import torch
+
+    with torch.no_grad():
+        embeds, _ids = components.pipeline.encode_prompt(
+            prompt=caption or "", device=torch.device(device), max_sequence_length=512
+        )
+    return {"embed": embeds[0]}  # (seq, 3 * hidden); FLUX.2 pads to a fixed length, no mask needed
+
+
+#: arch -> (latent encoder, caption encoder). Each arch reuses its own pipeline's encoding path, so
+#: a training latent is byte-for-byte what generation would produce from the same image.
+_ENCODERS = {
+    archs.KREA2: (_krea2_latent, _krea2_caption),
+    archs.FLUX2: (_flux2_latent, _flux2_caption),
+}
+
+
+def _encoders_for(arch: str) -> tuple[Any, Any]:
+    return _ENCODERS.get(arch, (_zimage_latent, _zimage_caption))

--- a/core/src/inline_core/training/models.py
+++ b/core/src/inline_core/training/models.py
@@ -32,6 +32,12 @@ _ENV = {
         "text_encoders": "INLINE_KREA2_TEXT_ENCODER",
         "adapter": "INLINE_KREA2_TRAIN_ADAPTER",
     },
+    archs.FLUX2: {
+        "diffusion_models": "INLINE_FLUX2_MODEL",
+        "vae": "INLINE_FLUX2_VAE",
+        "text_encoders": "INLINE_FLUX2_TEXT_ENCODER",
+        "adapter": "INLINE_FLUX2_TRAIN_ADAPTER",
+    },
 }
 
 
@@ -69,6 +75,15 @@ def _require(root: Path, arch: str, category: str) -> str:
 
 def _resolve(arch: str, category: str) -> Any:
     """The arch's own answer for a component, so training and generation pick the same file."""
+    if arch == archs.FLUX2:
+        from ..models.flux2 import requirements as flux2_reqs
+
+        if category == "vae":
+            return flux2_reqs.resolve_vae(None)
+        if category == "text_encoders":
+            return flux2_reqs.resolve_text_encoder(None)
+        return flux2_reqs.resolve_diffusion(None)
+
     if arch == archs.KREA2:
         from ..models.krea2 import requirements as krea2_reqs
 
@@ -89,10 +104,31 @@ def _resolve(arch: str, category: str) -> Any:
     return resolved[1] if resolved and resolved[0] == "single_file" else None
 
 
+
+def loader_arch(arch: str, models_dir: str | None = None) -> str:
+    """The ``models/loaders.py`` arch key for a training arch.
+
+    They are not the same namespace: training says ``flux2`` while the loaders key their config and
+    tokenizer bundles per variant (``flux2-klein-4b``, ``flux2-dev``), because a 4B and a 9B need
+    different encoder configs. Resolved from whichever checkpoint is installed.
+    """
+    if arch != archs.FLUX2:
+        return arch
+    from ..models.flux2 import requirements as flux2_reqs
+
+    variant = flux2_reqs.resolved_variant(None)
+    return variant.arch if variant is not None else "flux2-klein-4b"
+
+
 def _adapter_path(root: Path, arch: str, base_mode: str) -> str | None:
     """The de-distillation adapter for a turbo base mode, or None when the base is undistilled."""
     if base_mode not in ("turbo_adapter",):
         return None
+    if arch == archs.FLUX2:
+        raise RuntimeError(
+            "FLUX.2 has no de-distillation adapter. Train against a -base- checkpoint instead; "
+            "the adapter it produces still loads on the distilled build afterwards."
+        )
     picked = os.environ.get(_ENV[arch]["adapter"])
     if not picked:
         loras = root / "loras"
@@ -156,6 +192,23 @@ def load_encoders(models_dir: str, arch: str, device: str, dtype: Any) -> Encode
         )
         return Encoders(vae, text_encoder, tokenizer, scheduler, pipeline)
 
+    if arch == archs.FLUX2:
+        from diffusers import Flux2KleinPipeline
+
+        larch = loader_arch(arch, models_dir)
+        vae = loaders.load_flux2_vae(larch, vae_file, dtype, device=device)
+        text_encoder, tokenizer = loaders.load_text_encoder(
+            larch, encoder_file, dtype, device=device
+        )
+        scheduler = loaders.load_scheduler(larch)
+        # Transformer-less, so caption encoding goes through diffusers' own Qwen3 chat template and
+        # three-layer tap rather than a copy here that could drift from inference.
+        pipeline = Flux2KleinPipeline(
+            scheduler=scheduler, vae=None, text_encoder=text_encoder, tokenizer=tokenizer,
+            transformer=None,
+        )
+        return Encoders(vae, text_encoder, tokenizer, scheduler, pipeline)
+
     vae = loaders.load_vae(arch, vae_file, dtype, device=device)
     text_encoder, tokenizer = loaders.load_text_encoder(arch, encoder_file, dtype, device=device)
     return Encoders(vae, text_encoder, tokenizer, loaders.load_scheduler(arch))
@@ -184,12 +237,12 @@ def free_encoders(encoders: Encoders) -> None:
 
 #: Architectures whose loader can build a 4-bit base. Z-Image is not here because it does not need
 #: to be: it trains in ~15GB at 1024, so bf16 already fits the cards people have.
-_QUANTIZABLE = {archs.KREA2}
+_QUANTIZABLE = {archs.KREA2, archs.FLUX2}
 
 #: Peak activation cost per image token, measured at rank 16, batch 1, gradient checkpointing on.
 #: Krea 2's wider blocks cost roughly 7x Z-Image's per token, and activations - not weights - are
 #: what decides whether 1024 fits.
-_ACTIVATION_MB_PER_TOKEN = {archs.KREA2: 5.2, archs.Z_IMAGE: 0.8}
+_ACTIVATION_MB_PER_TOKEN = {archs.KREA2: 5.2, archs.Z_IMAGE: 0.8, archs.FLUX2: 1.6}
 
 #: Room left for the adapter, its 8-bit optimizer state and allocator slack.
 _MARGIN_BYTES = 2 * 1024**3
@@ -294,6 +347,17 @@ def load_transformer(
     loras: tuple[LoraRef, ...] = (LoraRef(file=adapter, strength=1.0),) if adapter else ()
 
     diffusion = _base_file(root, arch, base_mode)
+    if arch == archs.FLUX2:
+        from ..models.checkpoint import CheckpointReader
+        from ..models.flux2 import variants as flux2_variants
+
+        config = flux2_variants.derive_transformer_config(CheckpointReader(diffusion).shapes())
+        if config is None:
+            raise RuntimeError(f"{Path(diffusion).name} is not a FLUX.2 checkpoint.")
+        return loaders.load_flux2_transformer(
+            loader_arch(arch, models_dir), diffusion, config, dtype, quant,
+            device=device, loras=loras,
+        )
     if arch == archs.KREA2:
         return loaders.load_krea2_transformer(
             diffusion, dtype, quant, device=device, loras=loras
@@ -303,6 +367,8 @@ def load_transformer(
 
 def _base_file(root: Path, arch: str, base_mode: str) -> str:
     """The base checkpoint this run trains against."""
+    if arch == archs.FLUX2:
+        return _flux2_base_file(root)
     if arch != archs.KREA2:
         return _require(root, arch, "diffusion_models")
 
@@ -317,3 +383,36 @@ def _base_file(root: Path, arch: str, base_mode: str) -> str:
             f"Add {reqs.DIFFUSION_FILES[variant]} there."
         )
     return str(diffusion)
+
+
+def _flux2_base_file(root: Path) -> str:
+    """The **undistilled** FLUX.2 checkpoint to train against.
+
+    Training on a step-distilled build is the documented cause of the collapse reports: BFL and
+    musubi-tuner both say to train on ``-base-`` and load the adapter onto the distilled model
+    afterwards, which is also faster and usually better. So a distilled checkpoint is refused here
+    rather than silently producing a bad LoRA hours later.
+    """
+    from ..models.flux2 import variants as flux2_variants
+
+    override = os.environ.get(_ENV[archs.FLUX2]["diffusion_models"])
+    if override:
+        return override
+    folder = root / "diffusion_models"
+    candidates = sorted(folder.iterdir()) if folder.is_dir() else []
+    detected = [(p, flux2_variants.detect(p)) for p in candidates if p.is_file()]
+    base = [p for p, v in detected if v is not None and not v.distilled]
+    if base:
+        return str(base[0])
+    distilled = [(p, v) for p, v in detected if v is not None]
+    if distilled:
+        name, variant = distilled[0][0].name, distilled[0][1]
+        raise RuntimeError(
+            f"{name} is the step-distilled FLUX.2 {variant.label} build, which trains badly. "
+            "Download the matching Base checkpoint from the FLUX.2 node's model popup and train "
+            "on that - the LoRA still loads on the distilled build for generation."
+        )
+    raise RuntimeError(
+        f"No FLUX.2 checkpoint found under {folder}. Download one from the node's model popup "
+        f"(or set {_ENV[archs.FLUX2]['diffusion_models']})."
+    )

--- a/core/tests/test_flux2_controlnet.py
+++ b/core/tests/test_flux2_controlnet.py
@@ -1,0 +1,159 @@
+"""The ported Fun ControlNet Union: a VACE-style side branch hooked onto a stock transformer.
+
+The port has to match the checkpoint exactly - there is no partial credit, a mismapped tensor just
+produces a subtly wrong image. These pin the structure, the zero-init no-op property that proves the
+wiring is sound, and that the hooks come off again (a leaked hook would silently steer every later
+render on the cached pipeline).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+diffusers = pytest.importorskip("diffusers")
+
+from inline_core.models.flux2 import controlnet as cn  # noqa: E402
+
+#: A miniature dev: 8 double blocks (so layers 0/2/4/6 exist) and the same block topology.
+TINY = {
+    "attention_head_dim": 32,
+    "axes_dims_rope": [8, 8, 8, 8],
+    "eps": 1e-06,
+    "guidance_embeds": False,
+    "in_channels": 128,
+    "joint_attention_dim": 192,
+    "mlp_ratio": 3.0,
+    "num_attention_heads": 4,
+    "num_layers": 8,
+    "num_single_layers": 2,
+    "out_channels": None,
+    "patch_size": 1,
+    "rope_theta": 2000,
+    "timestep_guidance_channels": 256,
+}
+INNER = TINY["num_attention_heads"] * TINY["attention_head_dim"]
+
+
+def _model():
+    return diffusers.Flux2Transformer2DModel(**TINY).eval()
+
+
+def _branch():
+    return cn.Flux2ControlBranch(
+        inner_dim=INNER,
+        num_attention_heads=TINY["num_attention_heads"],
+        attention_head_dim=TINY["attention_head_dim"],
+    )
+
+
+def _call(model_inputs: int = 16):
+    from diffusers import Flux2KleinPipeline as P
+
+    lat = torch.randn(1, 128, model_inputs, model_inputs)
+    packed = P._pack_latents(lat)
+    emb = torch.randn(1, 32, 192)
+    return packed, dict(
+        hidden_states=packed,
+        encoder_hidden_states=emb,
+        timestep=torch.tensor([0.5]),
+        img_ids=P._prepare_latent_ids(lat),
+        txt_ids=P._prepare_text_ids(emb),
+        guidance=None,
+        return_dict=False,
+    )
+
+
+def test_the_branch_matches_the_published_checkpoint_layout() -> None:
+    """The union ships 4 control blocks plus one input projection; before_proj is block 0 only."""
+    branch = _branch()
+    keys = set(branch.state_dict())
+    assert len(branch.control_transformer_blocks) == 4 == len(cn.CONTROL_LAYERS)
+    assert cn.CONTROL_IN_DIM == 260, "control latent (128) + mask (4) + inpaint latent (128)"
+    assert any(k.startswith("control_img_in.") for k in keys)
+    assert any(k.startswith("before_proj.") for k in keys)
+    assert sum(1 for k in keys if k.startswith("after_proj.") and k.endswith(".weight")) == 4
+
+
+def test_checkpoint_keys_remap_onto_the_branch() -> None:
+    """Upstream nests the projections inside each control block; we keep the blocks stock."""
+    remapped = cn._remap(
+        {
+            "control_img_in.weight": 1,
+            "control_transformer_blocks.0.before_proj.weight": 2,
+            "control_transformer_blocks.2.after_proj.bias": 3,
+            "control_transformer_blocks.1.attn.to_q.weight": 4,
+        }
+    )
+    assert remapped == {
+        "control_img_in.weight": 1,
+        "before_proj.weight": 2,
+        "after_proj.2.bias": 3,
+        "control_transformer_blocks.1.attn.to_q.weight": 4,
+    }
+
+
+def test_a_zero_init_branch_changes_nothing() -> None:
+    """The correctness invariant: before_proj and after_proj are zero-init, so an unloaded branch
+    is exactly the base model. If this drifts, the injection is wired wrong."""
+    model, branch = _model(), _branch()
+    packed, call = _call()
+    context = torch.randn(1, packed.shape[1], cn.CONTROL_IN_DIM)
+    with torch.no_grad():
+        base = model(**call)[0]
+        handles = cn.attach(model, branch, context, scale=0.75)
+        try:
+            hooked = model(**call)[0]
+        finally:
+            for handle in handles:
+                handle.remove()
+    assert torch.allclose(base, hooked, atol=1e-5)
+
+
+def test_hooks_detach_completely() -> None:
+    """A leaked hook would steer every later render on the cached pipeline."""
+    model, branch = _model(), _branch()
+    for tap in branch.after_proj:
+        torch.nn.init.normal_(tap.weight, std=0.02)
+    packed, call = _call()
+    context = torch.randn(1, packed.shape[1], cn.CONTROL_IN_DIM)
+    with torch.no_grad():
+        base = model(**call)[0]
+        handles = cn.attach(model, branch, context, scale=1.0)
+        steered = model(**call)[0]
+        for handle in handles:
+            handle.remove()
+        restored = model(**call)[0]
+    assert not torch.allclose(base, steered, atol=1e-4), "a trained branch must steer"
+    assert torch.allclose(base, restored, atol=1e-6), "removal must restore the base exactly"
+
+
+def test_strength_scales_the_residual() -> None:
+    model, branch = _model(), _branch()
+    for tap in branch.after_proj:
+        torch.nn.init.normal_(tap.weight, std=0.02)
+    packed, call = _call()
+    context = torch.randn(1, packed.shape[1], cn.CONTROL_IN_DIM)
+
+    def run(scale: float):
+        handles = cn.attach(model, branch, context, scale=scale)
+        try:
+            with torch.no_grad():
+                return model(**call)[0]
+        finally:
+            for handle in handles:
+                handle.remove()
+
+    base, half, full = run(0.0), run(0.5), run(1.0)
+    assert torch.allclose(base, run(0.0), atol=1e-6)
+    # Monotonic: more strength moves further from the unsteered result.
+    assert (half - base).abs().mean() < (full - base).abs().mean()
+
+
+def test_a_model_without_enough_blocks_is_refused() -> None:
+    """The union is built for dev's 8 double blocks; klein has 5 and must not load it."""
+    small = diffusers.Flux2Transformer2DModel(**{**TINY, "num_layers": 5}).eval()
+    from inline_core.errors import ComponentError
+
+    with pytest.raises(ComponentError, match="built for FLUX.2 dev"):
+        cn.attach(small, _branch(), torch.zeros(1, 4, cn.CONTROL_IN_DIM))

--- a/core/tests/test_flux2_folder.py
+++ b/core/tests/test_flux2_folder.py
@@ -151,3 +151,29 @@ def test_staging_engages_only_when_encoder_and_transformer_cannot_coexist() -> N
         assert _needs_staged_encode("d", "v", "t", Policy(None)) is False
     finally:
         runner_mod.reqs.footprint_bytes = original
+
+
+def test_a_stale_model_pick_is_reported_missing_not_run(models: Path) -> None:
+    """A dropdown pick whose file is gone must fail the pre-flight, not reach the loader.
+
+    ``variant`` defaults to a concrete build and ``resolved_variant`` honours that param without
+    opening anything, so keying the diffusion component's presence off it reported a checkpoint
+    present when none resolved. The run then got as far as ``str(None)``, and the user saw
+    "'None' is not a FLUX.2 diffusion model" - which reads like a corrupt file rather than a pick
+    pointing at something that is no longer there.
+    """
+    _folder(models / "diffusion_models" / "flux2-dev-nf4", DEV_CONFIG)
+    stale = {"model": "deleted.safetensors", "variant": "klein-4b"}
+
+    assert reqs.resolve_diffusion(stale) is None
+    # The forced variant still resolves, which is what made this look installed.
+    assert reqs.resolved_variant(stale) is V.get("klein-4b")
+
+    diffusion = next(c for c in reqs.flux2_requirements(stale) if c.id == "diffusion")
+    assert not diffusion.present
+
+    # An installed pick, and the folder that is actually there, both still report present.
+    assert next(
+        c for c in reqs.flux2_requirements({"model": "flux2-dev-nf4"}) if c.id == "diffusion"
+    ).present
+    assert next(c for c in reqs.flux2_requirements(None) if c.id == "diffusion").present

--- a/core/tests/test_flux2_folder.py
+++ b/core/tests/test_flux2_folder.py
@@ -1,0 +1,153 @@
+"""Diffusers-format checkpoint folders: the only practical way to put dev on a 24 GB card.
+
+A prequantized dev build ships as a folder of NF4 shards plus a config, rather than one
+consolidated file. Three things follow, and all three are load-bearing:
+
+- geometry comes from ``config.json`` instead of a derived tensor header;
+- the weights must **not** be quantized again (their on-disk size already is their resident size);
+- the encoder and the transformer cannot be co-resident, so the prompt is encoded first.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from inline_core.models.flux2 import requirements as reqs
+from inline_core.models.flux2 import variants as V
+
+DEV_CONFIG = {
+    "_class_name": "Flux2Transformer2DModel",
+    "_diffusers_version": "0.36.0.dev0",
+    "attention_head_dim": 128,
+    "axes_dims_rope": [32, 32, 32, 32],
+    "eps": 1e-06,
+    "in_channels": 128,
+    "joint_attention_dim": 15360,
+    "mlp_ratio": 3.0,
+    "num_attention_heads": 48,
+    "num_layers": 8,
+    "num_single_layers": 48,
+    "out_channels": None,
+    "patch_size": 1,
+    "rope_theta": 2000,
+    "timestep_guidance_channels": 256,
+}
+#: Verbatim from diffusers/FLUX.2-dev-bnb-4bit.
+NF4 = {"quant_method": "bitsandbytes", "load_in_4bit": True, "bnb_4bit_quant_type": "nf4"}
+
+
+def _folder(path: Path, config: dict[str, Any]) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(json.dumps(config))
+    (path / "diffusion_pytorch_model.safetensors").write_bytes(b"0" * 2048)
+    return path
+
+
+@pytest.fixture
+def models(tmp_path: Path, monkeypatch: Any) -> Path:
+    root = tmp_path / "models"
+    monkeypatch.setenv("INLINE_MODELS_DIR", str(root))
+    for category in ("diffusion_models", "vae", "text_encoders"):
+        (root / category).mkdir(parents=True)
+    reqs._IDENTIFIED.clear()
+    return root
+
+
+def test_a_folder_states_its_geometry_instead_of_deriving_it(models: Path) -> None:
+    folder = _folder(models / "diffusion_models" / "flux2-dev-nf4", DEV_CONFIG)
+    config = V.config_for(folder)
+    assert config is not None
+    assert config["num_layers"] == 8 and config["num_single_layers"] == 48
+    assert config["joint_attention_dim"] == 15360
+    assert not any(k.startswith("_") for k in config), "diffusers bookkeeping is stripped"
+    assert V.detect(folder) is V.get("dev")
+
+
+def test_a_folder_from_another_architecture_is_left_alone(models: Path) -> None:
+    other = _folder(models / "diffusion_models" / "something-else", {"_class_name": "UNet2DModel"})
+    assert V.config_for(other) is None
+    assert V.detect(other) is None
+    assert reqs.resolve_diffusion() is None
+
+
+def test_a_prequantized_folder_is_flagged_so_it_is_not_quantized_again(models: Path) -> None:
+    plain = _folder(models / "diffusion_models" / "a-plain", DEV_CONFIG)
+    quantized = _folder(
+        models / "diffusion_models" / "b-nf4", {**DEV_CONFIG, "quantization_config": NF4}
+    )
+    assert V.is_prequantized(plain) is False
+    assert V.is_prequantized(quantized) is True
+    # A single file never carries its own quantization config.
+    assert V.is_prequantized(models / "diffusion_models" / "nope.safetensors") is False
+
+
+def test_folders_are_resolvable_and_pickable(models: Path) -> None:
+    folder = _folder(models / "diffusion_models" / "flux2-dev-nf4", DEV_CONFIG)
+    assert reqs.resolve_diffusion() == folder
+    # An explicit dropdown pick names the folder; this used to fail an is_file() check.
+    assert reqs.resolve_diffusion({"model": "flux2-dev-nf4"}) == folder
+    assert reqs.resolved_variant({"model": "flux2-dev-nf4"}) is V.get("dev")
+
+
+def test_a_folder_encoder_is_matched_by_its_text_width(models: Path) -> None:
+    # Mistral-3 is legitimately multimodal, so unlike the single-file check a vision tower must not
+    # disqualify it - the text stack's width is what has to line up (5120 * 3 == 15360).
+    encoder = models / "text_encoders" / "flux2-dev-mistral-nf4"
+    encoder.mkdir(parents=True)
+    (encoder / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Mistral3ForConditionalGeneration"],
+                "model_type": "mistral3",
+                "text_config": {"hidden_size": 5120, "num_hidden_layers": 40},
+                "quantization_config": NF4,
+            }
+        )
+    )
+    _folder(models / "diffusion_models" / "flux2-dev-nf4", DEV_CONFIG)
+    assert reqs._encoder_width(encoder) == 5120
+    assert reqs.resolve_text_encoder() == encoder
+
+
+def test_a_folders_footprint_is_the_sum_of_its_files(models: Path) -> None:
+    folder = _folder(models / "diffusion_models" / "flux2-dev-nf4", DEV_CONFIG)
+    sizes = reqs.footprint_bytes(folder, None, None)
+    assert sizes["diffusion_bytes"] > 2048, "config plus shards, not just one file"
+
+
+def test_staging_engages_only_when_encoder_and_transformer_cannot_coexist() -> None:
+    """The decision that keeps dev from OOMing during the load, before anything can be freed."""
+    from inline_core.models.flux2.runner import _needs_staged_encode
+
+    class Policy:
+        def __init__(self, mb: int | None) -> None:
+            self._mb = mb
+
+        def vram_budget_mb(self) -> int | None:
+            return self._mb
+
+    sizes = {"diffusion_bytes": 18_100_000_000, "vae_bytes": 336_000_000,
+             "text_encoder_bytes": 15_400_000_000}
+
+    def fake(diffusion=None, vae=None, text_encoder=None, controlnet=None):
+        return sizes
+
+    import inline_core.models.flux2.runner as runner_mod
+
+    original = runner_mod.reqs.footprint_bytes
+    runner_mod.reqs.footprint_bytes = fake
+    try:
+        # 24 GB: 33.8 GB together will not fit, 18.4 GB without the encoder will.
+        assert _needs_staged_encode("d", "v", "t", Policy(24229)) is True
+        # 80 GB: everything is resident, so there is nothing to stage around.
+        assert _needs_staged_encode("d", "v", "t", Policy(80 * 1024)) is False
+        # 8 GB: even without the encoder it does not fit, so staging would not rescue it.
+        assert _needs_staged_encode("d", "v", "t", Policy(8 * 1024)) is False
+        # A CPU device reports no budget and takes the normal path.
+        assert _needs_staged_encode("d", "v", "t", Policy(None)) is False
+    finally:
+        runner_mod.reqs.footprint_bytes = original

--- a/core/tests/test_flux2_resolve.py
+++ b/core/tests/test_flux2_resolve.py
@@ -1,0 +1,176 @@
+"""Which files the FLUX.2 node picks off disk, and what the popup reports.
+
+The node shares ``diffusion_models/``, ``vae/`` and ``text_encoders/`` with Z-Image and Krea 2, so
+"pick the first file" is not good enough: these pin that resolution identifies files by content and
+matches an encoder to the transformer that needs it.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from inline_core.models.flux2 import requirements as reqs
+from inline_core.models.flux2 import variants as V
+from tests.test_flux2_variants import DEV, KLEIN_4B, KLEIN_9B, _shapes
+
+
+def _write_header_only(path: Path, shapes: dict[str, list[int]]) -> Path:
+    """A safetensors file with a real header but no tensor bytes - enough to identify, cheap."""
+    header = {
+        name: {"dtype": "BF16", "shape": shape, "data_offsets": [0, 0]}
+        for name, shape in shapes.items()
+    }
+    blob = json.dumps(header).encode()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(struct.pack("<Q", len(blob)) + blob)
+    return path
+
+
+def _encoder(path: Path, hidden: int) -> Path:
+    """A stand-in text encoder, identified by its embedding width like the real ones are."""
+    return _write_header_only(path, {"model.embed_tokens.weight": [151936, hidden]})
+
+
+@pytest.fixture
+def models(tmp_path: Path, monkeypatch: Any) -> Path:
+    root = tmp_path / "models"
+    monkeypatch.setenv("INLINE_MODELS_DIR", str(root))
+    for category in ("diffusion_models", "vae", "text_encoders"):
+        (root / category).mkdir(parents=True)
+    reqs._IDENTIFIED.clear()  # the identify cache is keyed by path, and tmp_path is reused
+    return root
+
+
+def test_resolve_skips_checkpoints_from_other_architectures(models: Path) -> None:
+    # A Z-Image checkpoint sitting in the same folder must never be loaded as FLUX.2.
+    _write_header_only(models / "diffusion_models" / "z_image_bf16.safetensors", {"foo": [4, 4]})
+    assert reqs.resolve_diffusion() is None
+
+    flux = _write_header_only(
+        models / "diffusion_models" / "flux-2-klein-4b.safetensors", _shapes(KLEIN_4B)
+    )
+    assert reqs.resolve_diffusion() == flux
+    assert reqs.resolved_variant() is V.get("klein-4b")
+
+
+def test_an_explicit_dropdown_pick_wins(models: Path) -> None:
+    _write_header_only(models / "diffusion_models" / "a.safetensors", _shapes(KLEIN_4B))
+    picked = _write_header_only(
+        models / "diffusion_models" / "flux-2-klein-base-4b.safetensors", _shapes(KLEIN_4B)
+    )
+    resolved = reqs.resolve_diffusion({"model": "flux-2-klein-base-4b.safetensors"})
+    assert resolved == picked
+
+
+def test_text_encoder_is_matched_to_the_transformer_by_width(models: Path) -> None:
+    # Qwen3-4B (2560) and Qwen3-8B (4096) both present: the 9B checkpoint must take the 8B encoder,
+    # since the transformer's joint width is exactly three encoder layers concatenated.
+    _encoder(models / "text_encoders" / "qwen_3_4b.safetensors", 2560)
+    big = _encoder(models / "text_encoders" / "qwen_3_8b.safetensors", 4096)
+    _write_header_only(
+        models / "diffusion_models" / "flux-2-klein-9b.safetensors", _shapes(KLEIN_9B)
+    )
+    assert reqs.resolved_variant() is V.get("klein-9b")
+    assert reqs.resolve_text_encoder() == big
+
+
+def test_a_vision_language_encoder_is_never_picked(models: Path) -> None:
+    """The bug this guards: Qwen3-4B and Qwen3-VL-4B share an embedding matrix of exactly
+    151936 x 2560, so matching on width alone chose Krea 2's vision-language encoder for FLUX.2 and
+    rendered structured noise - a wrong image, not an error. A multimodal checkpoint carries a
+    vision tower and nests its text stack under ``language_model``; both disqualify it."""
+    # Named to sort first, so a width-only match would pick it.
+    vl = models / "text_encoders" / "aaa_qwen3vl_4b.safetensors"
+    _write_header_only(
+        vl,
+        {
+            "model.language_model.embed_tokens.weight": [151936, 2560],
+            "model.visual.blocks.0.attn.qkv.weight": [3840, 1280],
+        },
+    )
+    assert reqs._encoder_width(vl) is None
+
+    _write_header_only(
+        models / "diffusion_models" / "flux-2-klein-4b.safetensors", _shapes(KLEIN_4B)
+    )
+    assert reqs.resolve_text_encoder() is None, "no text-only encoder present means none is picked"
+
+    good = _encoder(models / "text_encoders" / "qwen_3_4b.safetensors", 2560)
+    assert reqs.resolve_text_encoder() == good
+
+
+def test_klein_4b_reuses_the_z_image_encoder_file(models: Path) -> None:
+    # klein 4B's encoder is stock Qwen3-4B - the same file Z-Image downloads - so a user who has
+    # run Z-Image already has it and must not be asked to fetch it again.
+    shared = _encoder(models / "text_encoders" / "qwen_3_4b.safetensors", 2560)
+    _write_header_only(
+        models / "diffusion_models" / "flux-2-klein-4b.safetensors", _shapes(KLEIN_4B)
+    )
+    assert reqs.resolve_text_encoder() == shared
+    encoder = next(c for c in reqs.flux2_requirements() if c.id == "text_encoder")
+    assert encoder.present is True
+
+
+def test_dev_falls_back_to_a_named_encoder(models: Path) -> None:
+    # Mistral's shards are not sized by a single embedding matrix, so dev matches on the name.
+    mistral = _write_header_only(
+        models / "text_encoders" / "mistral_3_small_flux2_fp8.safetensors", {"lm.weight": [8, 8]}
+    )
+    _write_header_only(models / "diffusion_models" / "flux2_dev.safetensors", _shapes(DEV))
+    assert reqs.resolved_variant() is V.get("dev")
+    assert reqs.resolve_text_encoder() == mistral
+
+
+def test_vae_prefers_the_flux2_file_over_a_shared_folder(models: Path) -> None:
+    # vae/ also holds Z-Image's ae.safetensors and Krea 2's; the exact name is matched first.
+    (models / "vae" / "ae.safetensors").write_bytes(b"x")
+    flux_vae = models / "vae" / "flux2-vae.safetensors"
+    flux_vae.write_bytes(b"x")
+    assert reqs.resolve_vae() == flux_vae
+
+
+def test_popup_blocks_on_the_required_three_then_lists_the_family(models: Path) -> None:
+    components = reqs.flux2_requirements()
+    required = [c for c in components if not c.optional]
+    assert [c.id for c in required] == ["diffusion", "text_encoder", "vae"]
+    assert not any(c.present for c in required), "an empty models dir has nothing"
+    # The rest of the family is offered but never blocks a run.
+    assert {c.id for c in components if c.optional} == {
+        "diffusion_klein_4b_base",
+        "diffusion_klein_9b",
+        "text_encoder_qwen3_8b",
+        "diffusion_dev",
+        "text_encoder_mistral",
+    }
+
+    _write_header_only(
+        models / "diffusion_models" / "flux-2-klein-4b.safetensors", _shapes(KLEIN_4B)
+    )
+    _encoder(models / "text_encoders" / "qwen_3_4b.safetensors", 2560)
+    (models / "vae" / "flux2-vae.safetensors").write_bytes(b"x")
+    reqs._IDENTIFIED.clear()
+    assert all(c.present for c in reqs.flux2_requirements() if not c.optional)
+
+
+def test_required_labels_follow_the_installed_checkpoint(models: Path) -> None:
+    _write_header_only(models / "diffusion_models" / "flux2_dev.safetensors", _shapes(DEV))
+    labels = {c.id: c.label for c in reqs.flux2_requirements()}
+    assert "dev" in labels["diffusion"]
+    assert "Mistral-3" in labels["text_encoder"]
+
+
+def test_footprint_is_a_stat_and_tolerates_absent_files(models: Path) -> None:
+    file = models / "vae" / "flux2-vae.safetensors"
+    file.write_bytes(b"0123456789")
+    sizes = reqs.footprint_bytes(None, file, "", None)
+    assert sizes == {
+        "diffusion_bytes": 0,
+        "text_encoder_bytes": 0,
+        "vae_bytes": 10,
+        "controlnet_bytes": 0,
+    }

--- a/core/tests/test_flux2_runner.py
+++ b/core/tests/test_flux2_runner.py
@@ -1,0 +1,104 @@
+"""The FLUX.2 node's descriptor and the decisions it makes before any weights load.
+
+Import-guarded and GPU-free: everything here is the logic that turns a picked checkpoint plus the
+user's params into a pipeline call.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from inline_core.models.flux2 import variants as V
+
+runner = pytest.importorskip("inline_core.models.flux2.runner")
+
+
+def test_one_node_covers_the_whole_family() -> None:
+    assert runner.FLUX2.type == "black-forest-labs/flux-2"
+    assert runner.FLUX2.output_kind is not None, "it produces a Frame with take history"
+    # Every variant is reachable from the one node's dropdown, plus the auto entry.
+    variant = next(p for p in runner.FLUX2.params if p.key == "variant")
+    assert [o.value for o in variant.options] == ["", *(v.key for v in V.VARIANTS)]
+
+
+def test_references_are_a_list_port_and_there_is_no_img2img_strength() -> None:
+    from inline_core.graph.schema import PortKind
+
+    image = runner.FLUX2.input("image")
+    assert image is not None and image.kind is PortKind.IMAGE_LIST
+    # FLUX.2 conditions on references through the whole denoise, so there is nothing to partially
+    # denoise from - a stray strength param would be a lie.
+    assert not any(p.key == "strength" for p in runner.FLUX2.params)
+
+
+def test_a_structure_map_can_be_wired() -> None:
+    from inline_core.graph.schema import PortKind, port_satisfies
+
+    control = runner.FLUX2.input("control_image")
+    assert control is not None and control.kind is PortKind.CONTROL
+    # Apply ControlNet and Control Space both emit an image-kind output.
+    assert port_satisfies(PortKind.IMAGE, PortKind.CONTROL)
+
+
+@pytest.mark.parametrize(
+    ("variant_key", "steps", "guidance"),
+    [("klein-4b", 4, 1.0), ("klein-4b-base", 50, 4.0), ("dev", 28, 4.0)],
+)
+def test_auto_sampler_defaults_come_from_the_checkpoint(
+    variant_key: str, steps: int, guidance: float
+) -> None:
+    # The descriptor ships sentinels, so switching checkpoints moves the schedule without the user
+    # touching the settings panel.
+    defaults = runner.FLUX2.defaults()
+    assert defaults["steps"] == 0 and defaults["guidance"] == -1.0
+    variant = V.get(variant_key)
+    assert runner._resolve_steps(defaults, variant) == steps
+    assert runner._resolve_guidance(defaults, variant) == guidance
+
+
+def test_an_explicit_setting_always_wins() -> None:
+    variant = V.get("klein-4b")
+    assert runner._resolve_steps({"steps": 12}, variant) == 12
+    assert runner._resolve_guidance({"guidance": 0.0}, variant) == 0.0
+
+
+def test_negative_prompt_is_dropped_where_it_does_nothing() -> None:
+    params = {"negative_prompt": "blurry"}
+    # Only an undistilled klein runs real CFG.
+    assert runner._resolve_negative(params, V.get("klein-4b-base")) == "blurry"
+    assert runner._resolve_negative(params, V.get("klein-4b")) is None
+    assert runner._resolve_negative(params, V.get("dev")) is None
+    assert runner._resolve_negative({"negative_prompt": "  "}, V.get("klein-4b-base")) is None
+
+
+def test_dimensions_snap_to_the_latent_grid() -> None:
+    # 2x2 latent packing on top of an 8x VAE means both sides must be multiples of 16.
+    assert runner._snap(1024) == 1024
+    assert runner._snap(1020) == 1008
+    assert runner._snap(10) == 64, "never below the model's 64px floor"
+
+
+def test_the_kv_variant_takes_no_guidance_argument() -> None:
+    # Flux2KleinKVPipeline.__call__ has no guidance_scale at all, so passing one would TypeError.
+    import inspect
+
+    diffusers = pytest.importorskip("diffusers")
+    signature = inspect.signature(diffusers.Flux2KleinKVPipeline.__call__)
+    assert "guidance_scale" not in signature.parameters
+    assert V.get("klein-9b-kv").pipeline == "klein-kv"
+
+
+def test_the_descriptor_matches_the_pipelines_it_drives() -> None:
+    """A drifting diffusers signature should fail here, not mid-denoise."""
+    import inspect
+
+    diffusers = pytest.importorskip("diffusers")
+    for cls in (diffusers.Flux2KleinPipeline, diffusers.Flux2Pipeline):
+        params = inspect.signature(cls.__call__).parameters
+        for name in ("image", "prompt_embeds", "max_sequence_length", "text_encoder_out_layers"):
+            assert name in params, f"{cls.__name__} lost {name}"
+    # Only the klein pipeline has a negative path, which is what supports_negative_prompt encodes.
+    klein = inspect.signature(diffusers.Flux2KleinPipeline.__call__).parameters
+    dev = inspect.signature(diffusers.Flux2Pipeline.__call__).parameters
+    assert "negative_prompt_embeds" in klein
+    assert "negative_prompt_embeds" not in dev

--- a/core/tests/test_flux2_runner.py
+++ b/core/tests/test_flux2_runner.py
@@ -16,9 +16,11 @@ runner = pytest.importorskip("inline_core.models.flux2.runner")
 def test_one_node_covers_the_whole_family() -> None:
     assert runner.FLUX2.type == "black-forest-labs/flux-2"
     assert runner.FLUX2.output_kind is not None, "it produces a Frame with take history"
-    # Every variant is reachable from the one node's dropdown, plus the auto entry.
+    # Every variant is reachable from the one node's dropdown, and only real ones are listed: the
+    # variant is normally identified from the checkpoint and served as the default, so an "auto"
+    # entry would only hide which build actually ran.
     variant = next(p for p in runner.FLUX2.params if p.key == "variant")
-    assert [o.value for o in variant.options] == ["", *(v.key for v in V.VARIANTS)]
+    assert [o.value for o in variant.options] == [v.key for v in V.VARIANTS]
 
 
 def test_references_are_a_list_port_and_there_is_no_img2img_strength() -> None:
@@ -102,3 +104,23 @@ def test_the_descriptor_matches_the_pipelines_it_drives() -> None:
     dev = inspect.signature(diffusers.Flux2Pipeline.__call__).parameters
     assert "negative_prompt_embeds" in klein
     assert "negative_prompt_embeds" not in dev
+
+
+def test_a_variant_override_that_contradicts_the_checkpoint_is_ignored(tmp_path) -> None:
+    """The dropdown defaults to a concrete variant and the settings panel persists the whole draft,
+    so a node can end up carrying a variant that no longer matches its file. Honouring it would
+    build the wrong pipeline and produce noise; the file wins."""
+    from tests.test_flux2_resolve import _write_header_only
+    from tests.test_flux2_variants import DEV, KLEIN_4B, _shapes
+
+    dev_file = _write_header_only(tmp_path / "flux2_dev.safetensors", _shapes(DEV))
+    # A stale pick from when this node pointed at a klein checkpoint.
+    variant, config = runner._identify(str(dev_file), {"variant": "klein-4b"})
+    assert variant is V.get("dev"), "the checkpoint decides, not the stale override"
+    assert config["joint_attention_dim"] == 15360
+
+    # A pick that agrees with the file is still honoured: it is the only way to say "this is a Base
+    # build" for a file whose name does not say so, which shapes cannot reveal.
+    klein_file = _write_header_only(tmp_path / "anon.safetensors", _shapes(KLEIN_4B))
+    forced, _ = runner._identify(str(klein_file), {"variant": "klein-4b-base"})
+    assert forced is V.get("klein-4b-base")

--- a/core/tests/test_flux2_training.py
+++ b/core/tests/test_flux2_training.py
@@ -1,0 +1,199 @@
+"""The FLUX.2 LoRA training arch: what it adapts, what it predicts, and which base it demands.
+
+The rule these pin is the one that decides whether a run is worth anything: FLUX.2 LoRAs are trained
+on an **undistilled** checkpoint and then loaded onto the distilled build for generation. Training
+against a step-distilled base is the documented cause of collapse, and it fails silently - hours
+later, as a bad adapter - so it is refused up front.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from inline_core.training import arch as archs
+from tests.test_flux2_resolve import _write_header_only
+from tests.test_flux2_variants import KLEIN_4B, _shapes
+
+models = pytest.importorskip("inline_core.training.models")
+
+
+def test_flux2_is_a_registered_training_arch() -> None:
+    a = archs.get("flux2")
+    assert a.key == archs.FLUX2
+    # Rectified flow, Krea 2's convention: x_t = (1-s)*clean + s*noise, so d/ds is noise - clean.
+    assert a.target(clean=2.0, noise=5.0) == 3.0
+    assert a.timestep(0.25) == 0.25
+
+
+def test_targets_cover_both_block_types_and_match_the_real_model() -> None:
+    torch = pytest.importorskip("torch")
+    diffusers = pytest.importorskip("diffusers")
+    with torch.device("meta"):
+        model = diffusers.Flux2Transformer2DModel(**KLEIN_4B)
+    linears = {
+        name
+        for name, module in model.named_modules()
+        if isinstance(module, torch.nn.Linear)
+    }
+    targets = archs.get("flux2").target_modules
+    for target in targets:
+        assert any(name.endswith(target) for name in linears), f"{target} matches nothing"
+    # The single blocks hold most of the parameters; adapting only double blocks would waste them.
+    assert any("to_qkv_mlp_proj" in t for t in targets)
+
+
+def test_attention_scope_excludes_the_fused_single_block_projection() -> None:
+    # to_qkv_mlp_proj fuses attention and MLP, so admitting it would make "attention" mean
+    # "everything" on FLUX.2. The scope narrows to the double blocks instead.
+    narrowed = archs.target_modules(archs.get("flux2"), "attention")
+    assert "to_qkv_mlp_proj" not in narrowed
+    assert {"to_q", "to_k", "to_v", "to_out.0"}.issubset(set(narrowed))
+    assert set(narrowed) < set(archs.get("flux2").target_modules)
+
+
+def test_the_loader_arch_is_resolved_per_variant(tmp_path: Path, monkeypatch) -> None:
+    # Training says "flux2"; the loaders key their config bundles per variant, because a 4B and a
+    # 9B need different encoder configs.
+    root = tmp_path / "models"
+    (root / "diffusion_models").mkdir(parents=True)
+    monkeypatch.setenv("INLINE_MODELS_DIR", str(root))
+    from inline_core.models.flux2 import requirements as reqs
+
+    reqs._IDENTIFIED.clear()
+    _write_header_only(
+        root / "diffusion_models" / "flux-2-klein-base-4b.safetensors", _shapes(KLEIN_4B)
+    )
+    assert models.loader_arch("flux2") == "flux2-klein-4b"
+    assert models.loader_arch("z-image") == "z-image"
+
+
+def test_a_distilled_checkpoint_is_refused_with_a_pointer_to_the_base(
+    tmp_path: Path, monkeypatch
+) -> None:
+    root = tmp_path / "models"
+    (root / "diffusion_models").mkdir(parents=True)
+    monkeypatch.setenv("INLINE_MODELS_DIR", str(root))
+    monkeypatch.delenv("INLINE_FLUX2_MODEL", raising=False)
+    from inline_core.models.flux2 import requirements as reqs
+
+    reqs._IDENTIFIED.clear()
+    _write_header_only(
+        root / "diffusion_models" / "flux-2-klein-4b.safetensors", _shapes(KLEIN_4B)
+    )
+    with pytest.raises(RuntimeError, match="step-distilled"):
+        models._base_file(root, archs.FLUX2, "raw")
+
+    # Add the base build and it is chosen, even though the distilled one sorts first.
+    base = _write_header_only(
+        root / "diffusion_models" / "flux-2-klein-base-4b.safetensors", _shapes(KLEIN_4B)
+    )
+    assert models._base_file(root, archs.FLUX2, "raw") == str(base)
+
+
+def test_an_empty_models_dir_says_where_to_get_a_checkpoint(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path / "models"
+    (root / "diffusion_models").mkdir(parents=True)
+    monkeypatch.setenv("INLINE_MODELS_DIR", str(root))
+    monkeypatch.delenv("INLINE_FLUX2_MODEL", raising=False)
+    with pytest.raises(RuntimeError, match="model popup"):
+        models._base_file(root, archs.FLUX2, "raw")
+
+
+def test_flux2_has_no_de_distillation_adapter(tmp_path: Path) -> None:
+    # Z-Image and Krea 2 offer a turbo+adapter path; FLUX.2's answer is a Base checkpoint.
+    with pytest.raises(RuntimeError, match="no de-distillation adapter"):
+        models._adapter_path(tmp_path, archs.FLUX2, "turbo_adapter")
+    assert models._adapter_path(tmp_path, archs.FLUX2, "raw") is None
+
+
+def test_flux2_can_train_in_4bit() -> None:
+    from inline_core.device.policy import Quantization
+
+    assert archs.FLUX2 in models._QUANTIZABLE
+    assert models.resolve_quant("nf4", "/nonexistent", archs.FLUX2, "raw", 512) is Quantization.NF4
+
+
+#: A miniature FLUX.2 with the real topology - both block types, the fused single-block projection -
+#: so shapes and adapter attachment are exercised without loading a 4B checkpoint.
+_TINY = {
+    "attention_head_dim": 32,
+    "axes_dims_rope": [8, 8, 8, 8],
+    "eps": 1e-06,
+    "guidance_embeds": False,
+    "in_channels": 128,
+    "joint_attention_dim": 192,
+    "mlp_ratio": 3.0,
+    "num_attention_heads": 4,
+    "num_layers": 2,
+    "num_single_layers": 2,
+    "out_channels": None,
+    "patch_size": 1,
+    "rope_theta": 2000,
+    "timestep_guidance_channels": 256,
+}
+
+
+def _tiny_model():
+    torch = pytest.importorskip("torch")
+    diffusers = pytest.importorskip("diffusers")
+    return diffusers.Flux2Transformer2DModel(**_TINY).to(torch.float32).eval()
+
+
+def test_one_training_step_produces_a_prediction_shaped_like_its_target() -> None:
+    """The whole loop in miniature: precached latent -> noise -> forward -> loss.
+
+    This is what catches a packing mistake. FLUX.2's VAE patchifies 2x2 on top of its 8x downscale,
+    so a 512px image trains as 128 channels at 32x32, and the transformer's packing is a plain
+    flatten - not the 2x2 permute other architectures in this repo use.
+    """
+    torch = pytest.importorskip("torch")
+    from diffusers import Flux2KleinPipeline
+
+    model = _tiny_model()
+    a = archs.get("flux2")
+
+    raw = torch.randn(1, 32, 64, 64)  # what the VAE emits for 512px
+    clean = Flux2KleinPipeline._patchify_latents(raw).squeeze(0)
+    assert tuple(clean.shape) == (128, 32, 32), "patchify is part of the trained representation"
+
+    noise = torch.randn_like(clean)
+    sigma = a.sigma("cpu", 3.0)
+    noisy = (1 - sigma) * clean + sigma * noise
+    item = {"embed": torch.randn(64, 192)}
+
+    with torch.no_grad():
+        pred = a.forward(model, noisy, a.timestep(sigma), item)
+    assert pred.shape == a.target(clean, noise).shape
+    assert torch.isfinite(pred).all()
+
+
+def test_a_lora_adapter_attaches_to_every_target_and_receives_gradient() -> None:
+    """Targets that match nothing train nothing, and PEFT does not complain loudly about it."""
+    torch = pytest.importorskip("torch")
+    peft = pytest.importorskip("peft")
+    from diffusers import Flux2KleinPipeline
+
+    model = _tiny_model()
+    a = archs.get("flux2")
+    model.add_adapter(
+        peft.LoraConfig(r=4, lora_alpha=4, target_modules=a.target_modules, init_lora_weights=False)
+    )
+    trainable = [(n, p) for n, p in model.named_parameters() if p.requires_grad]
+    assert trainable, "the adapter attached to nothing"
+    assert all("lora" in n for n, _ in trainable), "only the adapter should train"
+
+    raw = torch.randn(1, 32, 32, 32)
+    clean = Flux2KleinPipeline._patchify_latents(raw).squeeze(0)
+    noise = torch.randn_like(clean)
+    sigma = a.sigma("cpu", 3.0)
+    noisy = (1 - sigma) * clean + sigma * noise
+    pred = a.forward(model, noisy, a.timestep(sigma), {"embed": torch.randn(32, 192)})
+    torch.nn.functional.mse_loss(pred.float(), a.target(clean, noise).float()).backward()
+
+    got_grad = [n for n, p in trainable if p.grad is not None and p.grad.abs().sum() > 0]
+    assert got_grad, "no adapter parameter received gradient"
+    # Both block types must learn: the single blocks hold most of FLUX.2's parameters.
+    assert any("transformer_blocks." in n and "single" not in n for n in got_grad)
+    assert any("single_transformer_blocks." in n for n in got_grad)

--- a/core/tests/test_flux2_variants.py
+++ b/core/tests/test_flux2_variants.py
@@ -1,0 +1,129 @@
+"""Identifying a FLUX.2 checkpoint from its tensor shapes alone.
+
+These are the tests that let one node serve the whole family: if the derivation drifts, a checkpoint
+loads with the wrong geometry and produces noise rather than an error, so the round-trip is pinned
+against real ``Flux2Transformer2DModel`` shapes for every width in the family.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+
+from inline_core.models.flux2 import variants as V
+
+#: The verified klein 4B geometry, from black-forest-labs/FLUX.2-klein-4B transformer/config.json.
+KLEIN_4B = {
+    "attention_head_dim": 128,
+    "axes_dims_rope": [32, 32, 32, 32],
+    "eps": 1e-06,
+    "guidance_embeds": False,
+    "in_channels": 128,
+    "joint_attention_dim": 7680,
+    "mlp_ratio": 3.0,
+    "num_attention_heads": 24,
+    "num_layers": 5,
+    "num_single_layers": 20,
+    "out_channels": None,
+    "patch_size": 1,
+    "rope_theta": 2000,
+    "timestep_guidance_channels": 256,
+}
+KLEIN_9B = {**KLEIN_4B, "joint_attention_dim": 12288, "num_attention_heads": 32, "num_layers": 6,
+            "num_single_layers": 30}
+DEV = {**KLEIN_4B, "joint_attention_dim": 15360, "num_attention_heads": 48, "num_layers": 8,
+       "num_single_layers": 48, "guidance_embeds": True}
+
+
+def _shapes(config: dict[str, object]) -> dict[str, list[int]]:
+    """Real parameter shapes for a config, straight from diffusers on the meta device."""
+    torch = pytest.importorskip("torch")
+    diffusers = pytest.importorskip("diffusers")
+    with torch.device("meta"):
+        model = diffusers.Flux2Transformer2DModel(**config)
+    shapes = {name: list(p.shape) for name, p in model.named_parameters()}
+    shapes.update({name: list(b.shape) for name, b in model.named_buffers()})
+    return shapes
+
+
+@pytest.mark.parametrize(("label", "config"), [("4b", KLEIN_4B), ("9b", KLEIN_9B), ("dev", DEV)])
+def test_config_round_trips_from_tensor_shapes(label: str, config: dict[str, object]) -> None:
+    assert V.derive_transformer_config(_shapes(config)) == config
+
+
+def test_comfy_style_key_prefixes_are_stripped() -> None:
+    shapes = {f"model.diffusion_model.{k}": v for k, v in _shapes(KLEIN_4B).items()}
+    assert V.derive_transformer_config(shapes) == KLEIN_4B
+
+
+def test_a_non_flux2_checkpoint_is_not_claimed() -> None:
+    assert V.derive_transformer_config({"some.other.weight": [16, 16]}) is None
+    assert V.derive_transformer_config({}) is None
+
+
+@pytest.mark.parametrize(
+    ("filename", "config", "expected"),
+    [
+        ("flux-2-klein-4b.safetensors", KLEIN_4B, "klein-4b"),
+        ("flux-2-klein-base-4b.safetensors", KLEIN_4B, "klein-4b-base"),
+        ("flux-2-klein-9b.safetensors", KLEIN_9B, "klein-9b"),
+        ("flux-2-klein-base-9b.safetensors", KLEIN_9B, "klein-9b-base"),
+        ("flux-2-klein-9b-kv.safetensors", KLEIN_9B, "klein-9b-kv"),
+        ("flux2_dev_fp8mixed.safetensors", DEV, "dev"),
+        # dev has no base or KV split, so those name markers must not steer it elsewhere.
+        ("flux2-dev-base-kv.safetensors", DEV, "dev"),
+    ],
+)
+def test_detect_combines_shape_and_name(filename: str, config: dict, expected: str) -> None:
+    assert V.detect(filename, _shapes(config)) is V.get(expected)
+
+
+def test_distilled_and_base_differ_only_by_name() -> None:
+    # Architecturally identical, so a mislabeled file is the one case detection cannot save us from
+    # and the reason the variant dropdown offers explicit choices.
+    shapes = _shapes(KLEIN_4B)
+    assert V.detect("a.safetensors", shapes) is V.get("klein-4b")
+    assert V.detect("a-base.safetensors", shapes) is V.get("klein-4b-base")
+
+
+def test_sampler_defaults_follow_distillation() -> None:
+    distilled, base = V.get("klein-4b"), V.get("klein-4b-base")
+    assert (distilled.steps, distilled.guidance) == (4, 1.0)
+    assert (base.steps, base.guidance) == (50, 4.0)
+    # Only an undistilled klein runs real CFG; dev is guidance-distilled with no negative path.
+    assert base.supports_negative_prompt is True
+    assert distilled.supports_negative_prompt is False
+    assert V.get("dev").supports_negative_prompt is False
+
+
+def test_every_variant_maps_to_a_loader_arch_and_pipeline() -> None:
+    from inline_core.models import loaders
+
+    for variant in V.VARIANTS:
+        assert variant.arch in loaders.SPECS, variant.key
+        assert variant.pipeline in ("klein", "klein-kv", "dev"), variant.key
+        # The joint width is exactly three encoder layers concatenated, which is what the text
+        # encoder is matched on when resolving files.
+        assert variant.joint_attention_dim % 3 == 0, variant.key
+
+
+def test_detect_reads_a_real_safetensors_header(tmp_path: Path) -> None:
+    """The on-disk path: a header-only file (no tensor data) is enough to identify a checkpoint."""
+    header = {
+        name: {"dtype": "BF16", "shape": shape, "data_offsets": [0, 0]}
+        for name, shape in _shapes(KLEIN_4B).items()
+    }
+    blob = json.dumps(header).encode()
+    file = tmp_path / "flux-2-klein-base-4b.safetensors"
+    file.write_bytes(struct.pack("<Q", len(blob)) + blob)
+    assert V.detect(file) is V.get("klein-4b-base")
+
+
+def test_an_unreadable_file_is_simply_not_flux2(tmp_path: Path) -> None:
+    junk = tmp_path / "notamodel.safetensors"
+    junk.write_bytes(b"\x00" * 64)
+    assert V.detect(junk) is None
+    assert V.detect(tmp_path / "missing.safetensors") is None

--- a/core/tests/test_memory_policy.py
+++ b/core/tests/test_memory_policy.py
@@ -200,6 +200,45 @@ def test_fit_wont_fit_when_bigger_than_vram_and_ram() -> None:
     assert fit is not None and fit.plan == "wont-fit" and fit.fits is False
 
 
+#: A FLUX.2 dev-scale footprint: the 32B transformer plus the Mistral-3 encoder. Far past what int8
+#: can squeeze onto a 24 GB card, which is the rung NF4 exists for.
+_FLUX2_DEV_FOOTPRINT = ModelFootprint(
+    diffusion_bytes=35_455_599_592,
+    text_encoder_bytes=18_034_640_095,
+    vae_bytes=336_213_556,
+)
+
+
+def test_fit_nf4_when_int8_exceeds_vram() -> None:
+    # A 24 GB card cannot hold FLUX.2 dev at int8 (~27 GB of weights) but does hold it at NF4
+    # (~15 GB), so the ladder takes the 4-bit rung instead of falling all the way to streaming.
+    policy = MemoryPolicy(_CUDA, vram_gb=24, ram_gb=64)
+    policy.set_footprint(_FLUX2_DEV_FOOTPRINT)
+    fit = policy.fit_estimate()
+    assert fit is not None and fit.plan == "nf4" and fit.fits is True
+    assert policy.quantization() is Quantization.NF4
+    # NF4 keeps weights resident, like int8: bitsandbytes and accelerate's offload hooks do not mix.
+    assert policy.placement("denoiser").offload_mode is OffloadMode.NONE
+
+
+def test_nf4_does_not_force_bf16_on_a_card_without_it() -> None:
+    # Only torchao int8 needs a bf16 compute dtype. NF4 carries its own compute dtype, so a Turing
+    # card keeps fp16 and its tensor cores, with the VAE still upcast against overflow.
+    policy = MemoryPolicy(_CUDA, vram_gb=24, ram_gb=64, supports_bf16=False)
+    policy.set_footprint(_FLUX2_DEV_FOOTPRINT)
+    assert policy.quantization() is Quantization.NF4
+    assert policy.placement("denoiser").dtype is DType.FP16
+    assert policy.placement("vae").dtype is DType.FP32
+
+
+def test_fit_prefers_int8_over_nf4_when_int8_fits() -> None:
+    # The ladder is ordered by quality, not by size: NF4 is only reached when int8 cannot fit.
+    policy = MemoryPolicy(_CUDA, vram_gb=15.6, ram_gb=64)
+    policy.set_footprint(_ZIMAGE_FOOTPRINT)
+    fit = policy.fit_estimate()
+    assert fit is not None and fit.plan == "int8"
+
+
 def test_fit_offload_when_int8_exceeds_vram_but_model_fits_ram() -> None:
     # Small GPU, ample RAM: int8 won't fit VRAM, but the model fits RAM -> stream (sequential),
     # unquantized (int8 + offload deadlock).

--- a/core/tests/test_studio_fal.py
+++ b/core/tests/test_studio_fal.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from inline_core.studio import fal
+from inline_core.studio import frames as fr
 from inline_core.studio import moodboard as mb
 from inline_core.studio.store import StudioStore
 
@@ -188,3 +189,48 @@ def test_resolve_fal_inputs_media_and_prompt(tmp_path) -> None:
     assert len(resolved["images"]) == 1
     assert resolved["images"][0].startswith("data:image/png;base64,")
     assert resolved["videos"] == [] and resolved["audios"] == []
+    # Untagged inputs stay out of byHandle so they fall back to positional kind resolution.
+    assert resolved["byHandle"] == {}
+
+
+def test_resolve_fal_inputs_groups_by_handle(tmp_path) -> None:
+    """Two images on different ports (a start and an end keyframe) stay distinguishable."""
+    store = StudioStore(tmp_path / "app", tmp_path / "ws")
+    project = store.create_project("Fal")
+    conn, folder = store.conn(), store.folder()
+    (folder / "assets").mkdir(exist_ok=True)
+    for name in ("start", "end"):
+        (folder / "assets" / f"{name}.png").write_bytes(name.encode())
+        conn.execute(
+            "INSERT INTO assets (id, project_id, name, file_path, kind, created_at) "
+            f"VALUES ('{name}', ?, '{name}', 'assets/{name}.png', 'image', 0)",
+            (project["id"],),
+        )
+    gen = mb.add_gen_node(conn, "minimax/h3/image-to-video", 0, 0, kind="video", params={},
+                          title="H3")
+    fr.add_input(conn, gen["frameId"], "start", "image")
+    fr.add_input(conn, gen["frameId"], "end", "end_image")
+
+    resolved = fal.resolve_fal_inputs(conn, folder, gen["frameId"])
+    assert len(resolved["images"]) == 2
+    assert resolved["byHandle"]["image"] == [resolved["images"][0]]
+    assert resolved["byHandle"]["end_image"] == [resolved["images"][1]]
+
+
+def test_the_same_asset_can_feed_two_ports(tmp_path) -> None:
+    """Dedup is per (asset, handle): one image wired to both keyframes must not collapse to one."""
+    store = StudioStore(tmp_path / "app", tmp_path / "ws")
+    project = store.create_project("Fal")
+    conn = store.conn()
+    conn.execute(
+        "INSERT INTO assets (id, project_id, name, file_path, kind, created_at) "
+        "VALUES ('a1', ?, 'in', 'assets/in.png', 'image', 0)",
+        (project["id"],),
+    )
+    gen = mb.add_gen_node(conn, "minimax/h3/image-to-video", 0, 0, kind="video", params={},
+                          title="H3")
+    first = fr.add_input(conn, gen["frameId"], "a1", "image")
+    second = fr.add_input(conn, gen["frameId"], "a1", "end_image")
+    assert first["id"] != second["id"]
+    # Re-adding the same (asset, handle) pair still dedups.
+    assert fr.add_input(conn, gen["frameId"], "a1", "image")["id"] == first["id"]

--- a/core/tests/test_studio_generation.py
+++ b/core/tests/test_studio_generation.py
@@ -30,7 +30,7 @@ def test_build_workflow_graph_prompt_into_zimage(tmp_path) -> None:
     by_type = {n["type"]: n for n in graph["nodes"]}
     assert by_type["input/text"]["params"] == {"text": "a neon city"}
     zi = by_type["alibaba/z-image-turbo"]
-    assert zi["inputs"]["prompt"] == {"from": prompt["id"], "output": "text"}
+    assert zi["inputs"]["prompt"] == [{"from": prompt["id"], "output": "text"}]
 
 
 def test_build_workflow_graph_frame_output_into_zimage_image(tmp_path) -> None:
@@ -51,7 +51,7 @@ def test_build_workflow_graph_frame_output_into_zimage_image(tmp_path) -> None:
     assert frame_node["params"]["asset"]["path"] == str(store.folder() / "takes/hero.png")
     # Z-Image's image input references the frame node's "image" output - no dangling edge.
     zi = by_id[z["id"]]
-    assert zi["inputs"]["image"] == {"from": frame_item["id"], "output": "image"}
+    assert zi["inputs"]["image"] == [{"from": frame_item["id"], "output": "image"}]
     assert take["id"]  # hero take exists
 
 
@@ -76,7 +76,7 @@ def test_build_workflow_graph_loader_into_zimage_image(tmp_path) -> None:
     loader_node = by_id[loader["id"]]
     assert loader_node["type"] == "input/image"
     assert loader_node["params"]["asset"]["path"] == str(store.folder() / "assets/a.png")
-    assert by_id[z["id"]]["inputs"]["image"] == {"from": loader["id"], "output": "image"}
+    assert by_id[z["id"]]["inputs"]["image"] == [{"from": loader["id"], "output": "image"}]
 
 
 def test_build_workflow_graph_control_space_into_zimage_control(tmp_path) -> None:
@@ -101,7 +101,7 @@ def test_build_workflow_graph_control_space_into_zimage_control(tmp_path) -> Non
     assert cs_node["type"] == "input/image"
     assert cs_node["params"]["asset"]["path"] == str(store.folder() / "assets/pose.png")
     # The map lands on the control_image input, not the plain image input.
-    assert by_id[z["id"]]["inputs"]["control_image"] == {"from": cs["id"], "output": "image"}
+    assert by_id[z["id"]]["inputs"]["control_image"] == [{"from": cs["id"], "output": "image"}]
 
 
 def test_build_workflow_graph_control_space_without_render_is_dropped(tmp_path) -> None:

--- a/core/tests/test_studio_graph_build.py
+++ b/core/tests/test_studio_graph_build.py
@@ -55,7 +55,7 @@ def test_back_facing_control_space_states_the_facing_in_the_prompt(conn) -> None
     nodes = _nodes(conn, gen_id)
 
     # The prompt is rewired to a derived text node; the shared prompt node is left untouched.
-    source = nodes[gen_id]["inputs"]["prompt"]["from"]
+    source = nodes[gen_id]["inputs"]["prompt"][0]["from"]
     assert source != prompt_id
     assert nodes[source]["params"]["text"] == f"a woman standing, {BACK_HINT['positive']}"
     assert nodes[prompt_id]["params"]["text"] == "a woman standing"
@@ -82,7 +82,7 @@ def test_the_hint_never_stacks_when_a_restored_take_already_carries_it(conn) -> 
     )
     nodes = _nodes(conn, gen_id)
     assert nodes[gen_id]["params"]["negative_prompt"] == BACK_HINT["negative"]
-    assert nodes[gen_id]["inputs"]["prompt"]["from"] == prompt_id  # no second derived node
+    assert nodes[gen_id]["inputs"]["prompt"][0]["from"] == prompt_id  # no second derived node
 
 
 @pytest.mark.parametrize(
@@ -97,7 +97,7 @@ def test_the_hint_never_stacks_when_a_restored_take_already_carries_it(conn) -> 
 def test_no_hint_leaves_the_prompt_alone(conn, scene) -> None:
     gen_id, prompt_id = _board(conn, scene)
     nodes = _nodes(conn, gen_id)
-    assert nodes[gen_id]["inputs"]["prompt"]["from"] == prompt_id
+    assert nodes[gen_id]["inputs"]["prompt"][0]["from"] == prompt_id
     assert not nodes[gen_id]["params"].get("negative_prompt")
 
 
@@ -107,5 +107,5 @@ def test_an_unresolvable_control_map_adds_nothing(conn) -> None:
     control_id = next(i["id"] for i in mb.list_items(conn) if i["type"] == "controlSpace")
     mb.update_item(conn, control_id, {"data": {"controlScene": {"promptHint": BACK_HINT}}})
     nodes = _nodes(conn, gen_id)
-    assert nodes[gen_id]["inputs"]["prompt"]["from"] == prompt_id
+    assert nodes[gen_id]["inputs"]["prompt"][0]["from"] == prompt_id
     assert not nodes[gen_id]["params"].get("negative_prompt")

--- a/core/tests/test_studio_multi_reference.py
+++ b/core/tests/test_studio_multi_reference.py
@@ -1,0 +1,163 @@
+"""Several images wired into one list port, in the order the user wired them.
+
+FLUX.2 addresses reference images by position ("the jacket from image 2"), so this ordering is
+user-visible semantics rather than an implementation detail. Before this, ``_edges_for`` keyed edges
+by target handle and a second wire silently replaced the first.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+import pytest
+
+from inline_core.graph.schema import PortKind
+from inline_core.studio import moodboard as mb
+from inline_core.studio.graph_build import build_workflow_graph, ref_node_id
+from inline_core.studio.store import StudioStore
+
+_FLUX2 = "black-forest-labs/flux-2"
+
+
+def _list_ports(node_type: str, port_id: str) -> bool:
+    """Stands in for the registry: FLUX.2's reference port is the one list port."""
+    return node_type == _FLUX2 and port_id == "image"
+
+
+@pytest.fixture
+def store(tmp_path) -> StudioStore:
+    store = StudioStore(tmp_path / "app", tmp_path / "ws")
+    store.create_project("Refs")
+    return store
+
+
+def _asset(conn: sqlite3.Connection, asset_id: str) -> str:
+    conn.execute(
+        "INSERT INTO assets (id, project_id, name, file_path, kind, created_at) "
+        "VALUES (?, ?, ?, ?, 'image', 0)",
+        (asset_id, mb._project_id(conn), asset_id, f"assets/{asset_id}.png"),
+    )
+    return asset_id
+
+
+def _nodes(store: StudioStore, target: str) -> dict[str, dict[str, Any]]:
+    graph, _ = build_workflow_graph(store.conn(), store.folder(), target, _list_ports)
+    return {n["id"]: n for n in graph["nodes"]}
+
+
+def test_several_assets_into_one_list_port_keep_wiring_order(store: StudioStore) -> None:
+    conn = store.conn()
+    flux = mb.add_core_node(conn, _FLUX2, 400, 200)
+    items = []
+    for name in ("a", "b", "c"):
+        _asset(conn, name)
+        item = mb.add_asset(conn, name, 0, 0)
+        mb.create_connector(conn, item["id"], flux["id"], "out", "image")
+        items.append(item["id"])
+
+    edges = _nodes(store, flux["id"])[flux["id"]]["inputs"]["image"]
+    assert [e["from"] for e in edges] == items, "all three survive, in wiring order"
+
+
+def test_a_second_wire_into_a_single_port_still_replaces(store: StudioStore) -> None:
+    # Long-standing behaviour on non-list ports: the canvas treats a second wire as a replacement.
+    # Turning that into a validation error would break existing boards.
+    conn = store.conn()
+    flux = mb.add_core_node(conn, _FLUX2, 400, 200)
+    first = mb.add_prompt(conn, 0, 0)
+    second = mb.add_prompt(conn, 0, 100)
+    mb.create_connector(conn, first["id"], flux["id"], "out", "prompt")
+    mb.create_connector(conn, second["id"], flux["id"], "out", "prompt")
+
+    edges = _nodes(store, flux["id"])[flux["id"]]["inputs"]["prompt"]
+    assert [e["from"] for e in edges] == [second["id"]]
+
+
+def test_a_load_assets_node_contributes_every_asset_to_a_list_port(store: StudioStore) -> None:
+    conn = store.conn()
+    for name in ("a", "b", "c"):
+        _asset(conn, name)
+    flux = mb.add_core_node(conn, _FLUX2, 400, 200)
+    loader = mb.add_loader(conn, 80, 200)
+    mb.update_item(conn, loader["id"], {"data": {"assetIds": ["a", "b", "c"]}})
+    mb.create_connector(conn, loader["id"], flux["id"], "out", "image")
+
+    nodes = _nodes(store, flux["id"])
+    edges = nodes[flux["id"]]["inputs"]["image"]
+    assert [e["from"] for e in edges] == [ref_node_id(loader["id"], i) for i in range(3)]
+    # One frozen image source per asset, and the un-fanned loader node is gone (no dangling edge).
+    assert loader["id"] not in nodes
+    paths = [nodes[e["from"]]["params"]["asset"]["path"] for e in edges]
+    assert paths == [str(store.folder() / f"assets/{n}.png") for n in ("a", "b", "c")]
+
+
+def test_a_load_assets_node_still_feeds_its_hero_asset_to_a_single_port(store: StudioStore) -> None:
+    # Z-Image's image port is not a list, so the loader keeps its hero-asset behaviour exactly.
+    conn = store.conn()
+    for name in ("a", "b"):
+        _asset(conn, name)
+    z = mb.add_core_node(conn, "alibaba/z-image-turbo", 400, 200)
+    loader = mb.add_loader(conn, 80, 200)
+    mb.update_item(conn, loader["id"], {"data": {"assetIds": ["a", "b"]}})
+    mb.create_connector(conn, loader["id"], z["id"], "out", "image")
+
+    nodes = _nodes(store, z["id"])
+    assert nodes[z["id"]]["inputs"]["image"] == [{"from": loader["id"], "output": "image"}]
+    assert nodes[loader["id"]]["params"]["asset"]["path"] == str(store.folder() / "assets/a.png")
+
+
+def test_a_single_asset_loader_is_not_fanned_out(store: StudioStore) -> None:
+    conn = store.conn()
+    _asset(conn, "a")
+    flux = mb.add_core_node(conn, _FLUX2, 400, 200)
+    loader = mb.add_loader(conn, 80, 200)
+    mb.update_item(conn, loader["id"], {"data": {"assetIds": ["a"]}})
+    mb.create_connector(conn, loader["id"], flux["id"], "out", "image")
+
+    nodes = _nodes(store, flux["id"])
+    assert nodes[flux["id"]]["inputs"]["image"] == [{"from": loader["id"], "output": "image"}]
+    assert loader["id"] in nodes
+
+
+def test_a_structure_map_rides_its_own_port_alongside_references(store: StudioStore) -> None:
+    conn = store.conn()
+    _asset(conn, "ref")
+    _asset(conn, "pose")
+    flux = mb.add_core_node(conn, _FLUX2, 400, 200)
+    ref = mb.add_asset(conn, "ref", 0, 0)
+    control = mb.add_control_space(conn, 0, 100)
+    mb.update_item(conn, control["id"], {"data": {"controlAssetId": "pose"}})
+    mb.create_connector(conn, ref["id"], flux["id"], "out", "image")
+    mb.create_connector(conn, control["id"], flux["id"], "out", "control_image")
+
+    inputs = _nodes(store, flux["id"])[flux["id"]]["inputs"]
+    assert [e["from"] for e in inputs["image"]] == [ref["id"]]
+    assert [e["from"] for e in inputs["control_image"]] == [control["id"]]
+
+
+def test_without_a_resolver_every_port_stays_single_valued(store: StudioStore) -> None:
+    # The pre-multi-reference behaviour, which is what a caller with no registry gets.
+    conn = store.conn()
+    flux = mb.add_core_node(conn, _FLUX2, 400, 200)
+    ids = []
+    for name in ("a", "b"):
+        _asset(conn, name)
+        item = mb.add_asset(conn, name, 0, 0)
+        mb.create_connector(conn, item["id"], flux["id"], "out", "image")
+        ids.append(item["id"])
+
+    graph, _ = build_workflow_graph(conn, store.folder(), flux["id"])
+    node = next(n for n in graph["nodes"] if n["id"] == flux["id"])
+    assert [e["from"] for e in node["inputs"]["image"]] == [ids[-1]]
+
+
+def test_the_graph_validates_and_only_the_list_port_takes_many_edges() -> None:
+    """The engine's own rule: >1 edge is rejected everywhere except a list port."""
+    from inline_core.models.flux2.runner import FLUX2
+
+    image = FLUX2.input("image")
+    assert image is not None and image.kind is PortKind.IMAGE_LIST
+    for port in FLUX2.inputs:
+        if port.id != "image":
+            assert port.kind is not PortKind.IMAGE_LIST, f"{port.id} would silently accept fan-in"

--- a/core/tests/test_studio_node_size.py
+++ b/core/tests/test_studio_node_size.py
@@ -1,0 +1,58 @@
+"""Generation nodes open large and portrait; plumbing nodes stay compact.
+
+The size is decided at insert from the node's descriptor rather than by the renderer, because only
+the registry knows whether a type renders an image preview.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from inline_core.studio import moodboard as mb
+from inline_core.studio.schema import apply_schema
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    apply_schema(c)
+    c.execute("INSERT INTO project (id, name, created_at, updated_at) VALUES ('p', 'P', 0, 0)")
+    return c
+
+
+def test_a_core_node_defaults_to_the_compact_size(conn: sqlite3.Connection) -> None:
+    item = mb.add_core_node(conn, "load/vae", 0, 0)
+    assert (item["width"], item["height"]) == (200, 120)
+
+
+def test_the_caller_can_size_it(conn: sqlite3.Connection) -> None:
+    item = mb.add_core_node(conn, "alibaba/z-image-turbo", 0, 0, 320, 480)
+    assert (item["width"], item["height"]) == (320, 480)
+    assert item["height"] > item["width"], "generation nodes open portrait"
+
+
+def test_generation_types_open_large_and_portrait() -> None:
+    """The rule the handler applies: an outputKind means a preview, which means the large card."""
+    from inline_core.studio.handlers import COMPACT_NODE_SIZE, GENERATION_NODE_SIZE, core_node_size
+
+    models = [
+        {"type": "alibaba/z-image-turbo", "outputKind": "image"},
+        {"type": "black-forest-labs/flux-2", "outputKind": "image"},
+        {"type": "krea/krea-2-turbo", "outputKind": "image"},
+        {"type": "load/vae", "outputKind": None},
+    ]
+    for node_type in ("alibaba/z-image-turbo", "black-forest-labs/flux-2", "krea/krea-2-turbo"):
+        assert core_node_size(models, node_type) == GENERATION_NODE_SIZE
+
+    width, height = GENERATION_NODE_SIZE
+    assert height > width, "generation nodes open portrait"
+    assert width * height > 5 * COMPACT_NODE_SIZE[0] * COMPACT_NODE_SIZE[1]
+
+    # A loader has no preview, and an unregistered type is assumed compact rather than guessed
+    # large: a big empty card on the canvas is worse than a small one.
+    assert core_node_size(models, "load/vae") == COMPACT_NODE_SIZE
+    assert core_node_size(models, "not/registered") == COMPACT_NODE_SIZE
+    assert core_node_size([], "alibaba/z-image-turbo") == COMPACT_NODE_SIZE

--- a/core/tests/test_studio_rpc.py
+++ b/core/tests/test_studio_rpc.py
@@ -61,6 +61,7 @@ def test_full_project_and_canvas_flow(client) -> None:
     visible = {m["type"] for m in models["models"] if not m.get("hidden")}
     assert visible == {
         "alibaba/z-image-turbo",
+        "black-forest-labs/flux-2",
         "krea/krea-2-turbo",
         "krea/krea-2-raw",
         "load/diffusion-model",

--- a/core/tests/test_studio_schema.py
+++ b/core/tests/test_studio_schema.py
@@ -95,3 +95,22 @@ def test_frame_inputs_asset_id_relaxed_to_nullable() -> None:
     cols = conn.execute("PRAGMA table_info(frame_inputs)").fetchall()
     asset = next(c for c in cols if c[1] == "asset_id")
     assert asset[3] == 0  # notnull flag cleared
+    # The v9 rebuild copies a fixed column list, so `handle` must be added after it, not dropped.
+    assert "handle" in _columns(conn, "frame_inputs")
+
+
+def test_frame_inputs_gain_a_nullable_handle_keeping_existing_rows() -> None:
+    """v16 -> v17: existing inputs survive and read back untagged, so they still resolve by kind."""
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE frame_inputs (id TEXT PRIMARY KEY, frame_id TEXT NOT NULL, asset_id TEXT,
+                                   source_frame_id TEXT, position INTEGER NOT NULL);
+        INSERT INTO frame_inputs (id, frame_id, asset_id, position) VALUES ('i1', 'f1', 'a1', 0);
+        PRAGMA user_version = 16;
+        """
+    )
+    apply_schema(conn)
+    assert "handle" in _columns(conn, "frame_inputs")
+    row = conn.execute("SELECT asset_id, handle FROM frame_inputs WHERE id='i1'").fetchone()
+    assert row == ("a1", None)

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -576,7 +576,7 @@ wheels = [
 
 [[package]]
 name = "inline-core"
-version = "1.2.53"
+version = "1.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inline-studio",
-  "version": "1.2.53",
+  "version": "1.2.6",
   "description": "An experimentation layer for visual artists: a node canvas for building generative pipelines, served by the Inline Core engine.",
   "author": "Inline Studio",
   "license": "GPL-3.0-or-later",

--- a/packages/frontend/pyproject.toml
+++ b/packages/frontend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inline-studio-frontend"
-version = "1.2.53"
+version = "1.2.6"
 description = "Prebuilt Inline Studio web UI (SPA), served by Inline Core. Mirrors comfyui-frontend-package."
 requires-python = ">=3.9"
 readme = "README.md"

--- a/src/renderer/components/CoachMark.tsx
+++ b/src/renderer/components/CoachMark.tsx
@@ -1,0 +1,84 @@
+/**
+ * A numbered callout with a curved arrow pointing at a control on the canvas.
+ *
+ * Purely presentational: the caller measures the target and passes a point. Only the dismiss button
+ * takes pointer events, so the canvas stays usable behind the hint.
+ */
+export interface Point {
+  x: number
+  y: number
+}
+
+export function CoachMark({
+  target,
+  step,
+  title,
+  body,
+  side = 'left',
+  onDismiss,
+}: {
+  /** Where the arrow lands, in coordinates relative to the positioned parent. */
+  target: Point
+  step: number
+  title: string
+  body: string
+  /** Which side of the target the card sits on. */
+  side?: 'left' | 'right'
+  onDismiss?: () => void
+}): React.JSX.Element {
+  const gap = 120
+  const card = { x: side === 'left' ? target.x - gap : target.x + gap, y: target.y - 78 }
+  // A single quadratic curve reads as a gesture rather than a connector line, which matters when it
+  // is drawn over a canvas that is itself full of straight edges.
+  const from = { x: card.x, y: card.y + 46 }
+  const control = { x: (from.x + target.x) / 2, y: from.y - 26 }
+
+  return (
+    <>
+      <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible">
+        <defs>
+          <marker
+            id={`coach-arrow-${step}`}
+            viewBox="0 0 10 10"
+            refX="8"
+            refY="5"
+            markerWidth="5"
+            markerHeight="5"
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 1 L 9 5 L 0 9" fill="none" stroke="currentColor" strokeWidth="1.6" />
+          </marker>
+        </defs>
+        <path
+          d={`M ${from.x} ${from.y} Q ${control.x} ${control.y} ${target.x} ${target.y}`}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeDasharray="4 3"
+          markerEnd={`url(#coach-arrow-${step})`}
+          className="text-accent"
+        />
+      </svg>
+      <div
+        className="absolute w-52 -translate-x-1/2 rounded-lg border border-accent/50 bg-panel/95 p-2.5 shadow-xl backdrop-blur"
+        style={{ left: card.x, top: card.y }}
+      >
+        <div className="flex items-center gap-1.5">
+          <span className="flex h-4 w-4 items-center justify-center rounded-full bg-accent text-[9px] font-bold text-black">
+            {step}
+          </span>
+          <span className="text-[11px] font-medium text-zinc-100">{title}</span>
+        </div>
+        <p className="mt-1 text-[10px] leading-relaxed text-zinc-400">{body}</p>
+        {onDismiss && (
+          <button
+            onClick={onDismiss}
+            className="pointer-events-auto mt-1.5 rounded px-1.5 py-0.5 text-[10px] text-zinc-400 hover:bg-surface hover:text-zinc-200"
+          >
+            Got it
+          </button>
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/renderer/lib/starterGraph.test.ts
+++ b/src/renderer/lib/starterGraph.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { buildStarterGraph } from './starterGraph'
+import { recipeFor } from './starterRecipes'
+import { useMoodboardStore } from '../store/moodboardStore'
+import { useGenerationStore } from '../store/generationStore'
+import type { MoodboardItem } from '@shared/types'
+
+const item = (id: string, data: Record<string, unknown> = {}): MoodboardItem =>
+  ({ id, type: 'core', x: 0, y: 0, width: 200, height: 120, data }) as unknown as MoodboardItem
+
+type Store = ReturnType<typeof useMoodboardStore.getState>
+
+function stub(over: Partial<Store> = {}) {
+  const addCoreNode = vi.fn<Store['addCoreNode']>(async () => item('gen', { keepMe: 1 }))
+  const addPrompt = vi.fn<Store['addPrompt']>(async () => item('prompt', { keepMe: 2 }))
+  const updateItem = vi.fn<Store['updateItem']>(async () => undefined)
+  const connect = vi.fn<Store['connect']>(async () => undefined)
+  useMoodboardStore.setState({ addCoreNode, addPrompt, updateItem, connect, ...over })
+  return { addCoreNode, addPrompt, updateItem, connect }
+}
+
+const ZIMAGE = recipeFor('zimage')!
+
+describe('buildStarterGraph', () => {
+  beforeEach(() => {
+    useGenerationStore.setState({ error: null })
+  })
+
+  it('creates both nodes and wires them, returning [prompt, gen]', async () => {
+    const s = stub()
+    const ids = await buildStarterGraph(ZIMAGE, { x: 0, y: 0 })
+    expect(ids).toEqual(['prompt', 'gen'])
+    expect(s.addCoreNode).toHaveBeenCalledWith(
+      'alibaba/z-image-turbo',
+      expect.any(Number),
+      expect.any(Number),
+    )
+    expect(s.connect).toHaveBeenCalledWith('prompt', 'gen', 'out', 'prompt')
+  })
+
+  it('spreads the created data instead of replacing it', async () => {
+    // updateItem replaces `data` wholesale (there is no patchData), so a missing spread would
+    // silently drop whatever Core seeded onto the node.
+    const s = stub()
+    await buildStarterGraph(ZIMAGE, { x: 0, y: 0 })
+    const genData = s.updateItem.mock.calls[0]?.[1].data as Record<string, unknown>
+    const promptData = s.updateItem.mock.calls[1]?.[1].data as Record<string, unknown>
+    expect(genData).toMatchObject({ keepMe: 1 })
+    expect(genData.core).toEqual({ type: 'alibaba/z-image-turbo', params: ZIMAGE.params })
+    expect(promptData).toMatchObject({ keepMe: 2, promptText: ZIMAGE.promptText })
+  })
+
+  it('does not add an undo entry for the param writes', async () => {
+    // The adds already record; recording again would make Ctrl-Z walk through empty steps.
+    const s = stub()
+    await buildStarterGraph(ZIMAGE, { x: 0, y: 0 })
+    for (const call of s.updateItem.mock.calls) expect(call[2]).toBe(false)
+  })
+
+  it('aborts without wiring when the model node cannot be created', async () => {
+    const s = stub({ addCoreNode: vi.fn<Store['addCoreNode']>(async () => null) })
+    expect(await buildStarterGraph(ZIMAGE, { x: 0, y: 0 })).toEqual([])
+    expect(s.addPrompt).not.toHaveBeenCalled()
+    expect(s.connect).not.toHaveBeenCalled()
+    expect(useGenerationStore.getState().error).toMatch(/Inline Core/)
+  })
+
+  it('aborts without wiring when the prompt node cannot be created', async () => {
+    const s = stub({ addPrompt: vi.fn<Store['addPrompt']>(async () => null) })
+    expect(await buildStarterGraph(ZIMAGE, { x: 0, y: 0 })).toEqual([])
+    expect(s.connect).not.toHaveBeenCalled()
+  })
+
+  it('builds nothing for a card that has no graph', async () => {
+    const s = stub()
+    expect(await buildStarterGraph(recipeFor('training')!, { x: 0, y: 0 })).toEqual([])
+    expect(s.addCoreNode).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/lib/starterGraph.test.ts
+++ b/src/renderer/lib/starterGraph.test.ts
@@ -13,14 +13,19 @@ type Store = ReturnType<typeof useMoodboardStore.getState>
 
 function stub(over: Partial<Store> = {}) {
   const addCoreNode = vi.fn<Store['addCoreNode']>(async () => item('gen', { keepMe: 1 }))
+  const addGenNode = vi.fn<Store['addGenNode']>(async () => ({
+    ...item('gen', { keepMe: 1 }),
+    frameId: 'frame-1',
+  }))
   const addPrompt = vi.fn<Store['addPrompt']>(async () => item('prompt', { keepMe: 2 }))
   const updateItem = vi.fn<Store['updateItem']>(async () => undefined)
   const connect = vi.fn<Store['connect']>(async () => undefined)
-  useMoodboardStore.setState({ addCoreNode, addPrompt, updateItem, connect, ...over })
-  return { addCoreNode, addPrompt, updateItem, connect }
+  useMoodboardStore.setState({ addCoreNode, addGenNode, addPrompt, updateItem, connect, ...over })
+  return { addCoreNode, addGenNode, addPrompt, updateItem, connect }
 }
 
 const ZIMAGE = recipeFor('zimage')!
+const API = recipeFor('api')!
 
 describe('buildStarterGraph', () => {
   beforeEach(() => {
@@ -76,5 +81,26 @@ describe('buildStarterGraph', () => {
     const s = stub()
     expect(await buildStarterGraph(recipeFor('training')!, { x: 0, y: 0 })).toEqual([])
     expect(s.addCoreNode).not.toHaveBeenCalled()
+    expect(s.addGenNode).not.toHaveBeenCalled()
+  })
+
+  it('builds the API card as a fal node and wires the same prompt handle', async () => {
+    const setParams = vi.fn(async () => undefined)
+    useGenerationStore.setState({ setParams })
+    const s = stub()
+
+    const ids = await buildStarterGraph(API, { x: 0, y: 0 })
+
+    expect(ids).toEqual(['prompt', 'gen'])
+    expect(s.addGenNode).toHaveBeenCalledWith(
+      'minimax/h3/text-to-video',
+      expect.any(Number),
+      expect.any(Number),
+    )
+    expect(s.addCoreNode).not.toHaveBeenCalled()
+    // A fal node's params live on its frame, so they must not be written into the item's data.
+    expect(setParams).toHaveBeenCalledWith('frame-1', API.params)
+    expect(s.updateItem.mock.calls.map((c) => c[0])).toEqual(['prompt'])
+    expect(s.connect).toHaveBeenCalledWith('prompt', 'gen', 'out', 'prompt')
   })
 })

--- a/src/renderer/lib/starterGraph.ts
+++ b/src/renderer/lib/starterGraph.ts
@@ -1,5 +1,6 @@
 /**
- * Build a starter graph on the Studio canvas: a prompt node wired into a model node.
+ * Build a starter graph on the Studio canvas: a prompt node wired into a model node, either an
+ * Inline Core node or a hosted fal one.
  *
  * Mirrors `recipeGraph.ts` deliberately, including `recordHistory: false` on the param writes.
  * Note that `addCoreNode`, `addPrompt` and `connect` each record their own undo entry, so a starter
@@ -20,20 +21,27 @@ import {
  * A partial graph is worse than none, so a failure aborts before wiring and nothing is left dangling.
  */
 export async function buildStarterGraph(recipe: StarterRecipe, centre: Point): Promise<string[]> {
-  if (!recipe.coreType) return []
+  if (!recipe.coreType && !recipe.falModelId) return []
   const store = useMoodboardStore.getState()
   const at = starterLayout(centre)
 
-  const gen = await store.addCoreNode(recipe.coreType, at.gen.x, at.gen.y)
+  const gen = recipe.falModelId
+    ? await store.addGenNode(recipe.falModelId, at.gen.x, at.gen.y)
+    : await store.addCoreNode(recipe.coreType as string, at.gen.x, at.gen.y)
   if (!gen) {
     useGenerationStore.getState().setError('Could not add the model node. Is Inline Core running?')
     return []
   }
-  await store.updateItem(
-    gen.id,
-    { data: { ...gen.data, core: { type: recipe.coreType, params: { ...recipe.params } } } },
-    false,
-  )
+  if (recipe.coreType) {
+    await store.updateItem(
+      gen.id,
+      { data: { ...gen.data, core: { type: recipe.coreType, params: { ...recipe.params } } } },
+      false,
+    )
+  } else if (gen.frameId) {
+    // A fal node's params live on its frame, not in the item's data blob.
+    await useGenerationStore.getState().setParams(gen.frameId, { ...recipe.params })
+  }
 
   const prompt = await store.addPrompt(at.prompt.x, at.prompt.y)
   if (!prompt) {

--- a/src/renderer/lib/starterGraph.ts
+++ b/src/renderer/lib/starterGraph.ts
@@ -1,0 +1,52 @@
+/**
+ * Build a starter graph on the Studio canvas: a prompt node wired into a model node.
+ *
+ * Mirrors `recipeGraph.ts` deliberately, including `recordHistory: false` on the param writes.
+ * Note that `addCoreNode`, `addPrompt` and `connect` each record their own undo entry, so a starter
+ * graph unwinds in three steps rather than one; that matches how recipe rebuilds already behave.
+ */
+import { useGenerationStore } from '../store/generationStore'
+import { useMoodboardStore } from '../store/moodboardStore'
+import {
+  PROMPT_SOURCE_HANDLE,
+  PROMPT_TARGET_HANDLE,
+  starterLayout,
+  type Point,
+  type StarterRecipe,
+} from './starterRecipes'
+
+/**
+ * Returns the created ids as `[promptId, genId]`, or `[]` if the board rejected a node (Core down).
+ * A partial graph is worse than none, so a failure aborts before wiring and nothing is left dangling.
+ */
+export async function buildStarterGraph(recipe: StarterRecipe, centre: Point): Promise<string[]> {
+  if (!recipe.coreType) return []
+  const store = useMoodboardStore.getState()
+  const at = starterLayout(centre)
+
+  const gen = await store.addCoreNode(recipe.coreType, at.gen.x, at.gen.y)
+  if (!gen) {
+    useGenerationStore.getState().setError('Could not add the model node. Is Inline Core running?')
+    return []
+  }
+  await store.updateItem(
+    gen.id,
+    { data: { ...gen.data, core: { type: recipe.coreType, params: { ...recipe.params } } } },
+    false,
+  )
+
+  const prompt = await store.addPrompt(at.prompt.x, at.prompt.y)
+  if (!prompt) {
+    // The model node stays: it is usable on its own, and deleting it would also wipe the undo entry.
+    useGenerationStore.getState().setError('Could not add the prompt node.')
+    return []
+  }
+  await store.updateItem(
+    prompt.id,
+    { data: { ...prompt.data, promptText: recipe.promptText } },
+    false,
+  )
+
+  await store.connect(prompt.id, gen.id, PROMPT_SOURCE_HANDLE, PROMPT_TARGET_HANDLE)
+  return [prompt.id, gen.id]
+}

--- a/src/renderer/lib/starterRecipes.test.ts
+++ b/src/renderer/lib/starterRecipes.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import { getNodeDef } from '@shared/nodes/registry'
+import { defaultParams } from '@shared/nodes/types'
 import {
   PROMPT_SOURCE_HANDLE,
   PROMPT_TARGET_HANDLE,
@@ -28,11 +30,23 @@ const KNOWN_PARAM_KEYS = new Set([
 ])
 
 const gen = STARTER_RECIPES.filter((r) => r.coreType !== null)
+const withPrompt = STARTER_RECIPES.filter((r) => r.coreType !== null || r.falModelId)
 
 describe('starter recipes', () => {
-  it('covers the four cards with unique keys', () => {
-    expect(STARTER_RECIPES.map((r) => r.key)).toEqual(['zimage', 'flux2', 'krea2', 'training'])
+  it('covers the five cards with unique keys', () => {
+    expect(STARTER_RECIPES.map((r) => r.key)).toEqual([
+      'zimage',
+      'flux2',
+      'krea2',
+      'api',
+      'training',
+    ])
     expect(new Set(STARTER_RECIPES.map((r) => r.key)).size).toBe(STARTER_RECIPES.length)
+  })
+
+  it('never sets both a Core type and a fal model on one card', () => {
+    for (const recipe of STARTER_RECIPES)
+      expect(recipe.coreType != null && recipe.falModelId != null).toBe(false)
   })
 
   it('names real Core node types', () => {
@@ -69,8 +83,39 @@ describe('starter recipes', () => {
       expect(recipeFor(key)?.params).toMatchObject({ steps: 8, guidance: 0 })
   })
 
+  it('starts the API card on MiniMax H3 text to video, with the model’s own defaults', () => {
+    const api = recipeFor('api')
+    const def = getNodeDef(api?.falModelId ?? '')
+    expect(def?.id).toBe('minimax/h3/text-to-video')
+    // Writing literals that drift from the def would send the wrong body on the very first run.
+    expect(api?.params).toEqual(defaultParams(def!))
+    // Text-to-video takes no wired media, so the card is one click from a clip.
+    expect(def?.inputs).toEqual([])
+  })
+
+  it('labels each card with what it generates, which drives the colour coding', () => {
+    expect(Object.fromEntries(STARTER_RECIPES.map((r) => [r.key, r.kind]))).toEqual({
+      zimage: 'image',
+      flux2: 'image',
+      krea2: 'image',
+      api: 'video',
+      training: 'training',
+    })
+  })
+
+  it('matches the fal card’s kind to the model’s real output', () => {
+    const api = recipeFor('api')
+    expect(getNodeDef(api?.falModelId ?? '')?.outputKind).toBe(api?.kind)
+  })
+
+  it('tags only the two newest models', () => {
+    const tagged = STARTER_RECIPES.filter((r) => r.tag).map((r) => r.key)
+    expect(tagged).toEqual(['flux2', 'api'])
+    for (const key of tagged) expect(recipeFor(key)?.tag).toBe('New')
+  })
+
   it('ships a usable prompt with every generation card', () => {
-    for (const recipe of gen) {
+    for (const recipe of withPrompt) {
       expect(recipe.promptText.length).toBeGreaterThan(20)
       expect(recipe.promptText).not.toMatch(/[—–]/) // house style: no em or en dashes
     }
@@ -79,6 +124,7 @@ describe('starter recipes', () => {
   it('has no prompt or params on the training card, which builds no graph', () => {
     const training = recipeFor('training')
     expect(training?.coreType).toBeNull()
+    expect(training?.falModelId).toBeUndefined()
     expect(training?.promptText).toBe('')
     expect(training?.params).toEqual({})
   })

--- a/src/renderer/lib/starterRecipes.test.ts
+++ b/src/renderer/lib/starterRecipes.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  PROMPT_SOURCE_HANDLE,
+  PROMPT_TARGET_HANDLE,
+  STARTER_RECIPES,
+  recipeFor,
+  starterLayout,
+} from './starterRecipes'
+
+/** The param keys every generation node in the repo exposes. A recipe key outside this set is a typo. */
+const KNOWN_PARAM_KEYS = new Set([
+  'width',
+  'height',
+  'steps',
+  'guidance',
+  'seed',
+  'negative_prompt',
+  'sampler',
+  'scheduler',
+  'strength',
+  'variant',
+  'model',
+  'vae',
+  'text_encoder',
+  'controlnet',
+  'control_strength',
+])
+
+const gen = STARTER_RECIPES.filter((r) => r.coreType !== null)
+
+describe('starter recipes', () => {
+  it('covers the four cards with unique keys', () => {
+    expect(STARTER_RECIPES.map((r) => r.key)).toEqual(['zimage', 'flux2', 'krea2', 'training'])
+    expect(new Set(STARTER_RECIPES.map((r) => r.key)).size).toBe(STARTER_RECIPES.length)
+  })
+
+  it('names real Core node types', () => {
+    expect(gen.map((r) => r.coreType)).toEqual([
+      'alibaba/z-image-turbo',
+      'black-forest-labs/flux-2',
+      'krea/krea-2-turbo',
+    ])
+  })
+
+  it('only sets params the nodes actually have', () => {
+    // Catches a `cfg` vs `guidance` slip at build time rather than as a silently ignored param.
+    for (const recipe of gen)
+      for (const key of Object.keys(recipe.params))
+        expect(KNOWN_PARAM_KEYS.has(key), `${recipe.key} sets unknown param ${key}`).toBe(true)
+  })
+
+  it('leaves the file pickers alone', () => {
+    // Core resolves these from disk; pinning a filename breaks on a differently named checkpoint.
+    for (const recipe of gen)
+      for (const key of ['model', 'vae', 'text_encoder'])
+        expect(recipe.params).not.toHaveProperty(key)
+  })
+
+  it('keeps FLUX.2 on its from-the-checkpoint sentinels', () => {
+    // steps 0 / guidance -1 let the runner use the detected variant's own schedule. A literal 4
+    // would silently give anyone on the dev checkpoint the wrong number of steps.
+    const flux = recipeFor('flux2')
+    expect(flux?.params).toMatchObject({ steps: 0, guidance: -1 })
+  })
+
+  it('gives the distilled models their CFG-free schedule', () => {
+    for (const key of ['zimage', 'krea2'] as const)
+      expect(recipeFor(key)?.params).toMatchObject({ steps: 8, guidance: 0 })
+  })
+
+  it('ships a usable prompt with every generation card', () => {
+    for (const recipe of gen) {
+      expect(recipe.promptText.length).toBeGreaterThan(20)
+      expect(recipe.promptText).not.toMatch(/[—–]/) // house style: no em or en dashes
+    }
+  })
+
+  it('has no prompt or params on the training card, which builds no graph', () => {
+    const training = recipeFor('training')
+    expect(training?.coreType).toBeNull()
+    expect(training?.promptText).toBe('')
+    expect(training?.params).toEqual({})
+  })
+
+  it('lays the two nodes out without overlapping', () => {
+    const { prompt, gen: genAt } = starterLayout({ x: 0, y: 0 })
+    // Prompt nodes are 240 wide, so the model node has to start beyond that.
+    expect(genAt.x).toBeGreaterThan(prompt.x + 240)
+  })
+
+  it('wires the prompt output into the model prompt input', () => {
+    expect(PROMPT_SOURCE_HANDLE).toBe('out')
+    expect(PROMPT_TARGET_HANDLE).toBe('prompt')
+  })
+})

--- a/src/renderer/lib/starterRecipes.ts
+++ b/src/renderer/lib/starterRecipes.ts
@@ -1,0 +1,87 @@
+/**
+ * The starter graphs behind the getting-started cards: one prompt node wired into one model node,
+ * with params and a prompt already filled in so the first click ends in a render.
+ *
+ * Pure data, so the definitions can be tested against the live node descriptors without a canvas.
+ */
+import type { StarterKey } from './vramAdvice'
+
+export interface StarterRecipe {
+  key: StarterKey
+  /** Inline Core node type, or null for a card that does not build a graph (training). */
+  coreType: string | null
+  title: string
+  blurb: string
+  params: Record<string, unknown>
+  promptText: string
+}
+
+/**
+ * `model`, `vae` and `text_encoder` are deliberately absent from every recipe. Core resolves those
+ * from what is on disk and now serves the resolved filename as the param default, so writing one
+ * here would pin a filename that breaks the moment the user has a differently named checkpoint.
+ */
+export const STARTER_RECIPES: readonly StarterRecipe[] = [
+  {
+    key: 'zimage',
+    coreType: 'alibaba/z-image-turbo',
+    title: 'Z-Image Turbo',
+    blurb: 'Eight steps, no guidance. The quickest way to a first image.',
+    params: { width: 1024, height: 1024, steps: 8, guidance: 0, seed: -1 },
+    promptText:
+      'A tall white lighthouse on a cliff above a stormy sea at sunset, beam lit, dramatic clouds, cinematic',
+  },
+  {
+    key: 'flux2',
+    coreType: 'black-forest-labs/flux-2',
+    title: 'FLUX.2',
+    blurb: 'Prose prompts and multi-reference editing. Klein 4B is the light build.',
+    // steps 0 and guidance -1 mean "from the checkpoint": the runner substitutes the detected
+    // variant's own schedule (klein wants 4 steps at guidance 1.0, dev wants 28 at 4.0). Writing a
+    // literal here would silently give dev users the wrong schedule.
+    params: { width: 1024, height: 1024, steps: 0, guidance: -1, seed: -1 },
+    promptText:
+      'A retro-futuristic diner on Mars, neon signage, chrome and dust, wide establishing shot, film still',
+  },
+  {
+    key: 'krea2',
+    coreType: 'krea/krea-2-turbo',
+    title: 'Krea 2 Turbo',
+    blurb: 'Photographic look, distilled to eight steps. The heaviest of the three.',
+    params: { width: 1024, height: 1024, steps: 8, guidance: 0, seed: -1 },
+    promptText:
+      'Close-up portrait in soft window light, natural skin texture, 85mm lens, shallow depth of field',
+  },
+  {
+    key: 'training',
+    coreType: null,
+    title: 'Train a LoRA',
+    blurb: 'Teach a style or subject from your own images, then generate with it.',
+    params: {},
+    promptText: '',
+  },
+]
+
+export function recipeFor(key: StarterKey): StarterRecipe | undefined {
+  return STARTER_RECIPES.find((r) => r.key === key)
+}
+
+export interface Point {
+  x: number
+  y: number
+}
+
+/**
+ * Where the two nodes land, relative to the viewport centre. Prompt nodes default to 240x120 and
+ * core nodes to 200x120, so this clears both with room for the connector.
+ */
+export function starterLayout(centre: Point): { prompt: Point; gen: Point } {
+  return {
+    prompt: { x: centre.x - 380, y: centre.y - 20 },
+    gen: { x: centre.x + 20, y: centre.y - 60 },
+  }
+}
+
+/** Handles the connector uses: a prompt node's only output into the model's prompt input. */
+export const PROMPT_SOURCE_HANDLE = 'out'
+export const PROMPT_TARGET_HANDLE = 'prompt'

--- a/src/renderer/lib/starterRecipes.ts
+++ b/src/renderer/lib/starterRecipes.ts
@@ -8,9 +8,15 @@ import type { StarterKey } from './vramAdvice'
 
 export interface StarterRecipe {
   key: StarterKey
-  /** Inline Core node type, or null for a card that does not build a graph (training). */
+  /** Inline Core node type, or null for a card that builds no Core node (API nodes, training). */
   coreType: string | null
+  /** fal model id for a card that starts on a hosted model instead. Mutually exclusive with above. */
+  falModelId?: string
   title: string
+  /** Short chip beside the title, e.g. `New`. Absent on the settled cards. */
+  tag?: string
+  /** What this card generates. Drives the card's colour coding. */
+  kind: 'image' | 'video' | 'training'
   blurb: string
   params: Record<string, unknown>
   promptText: string
@@ -26,6 +32,7 @@ export const STARTER_RECIPES: readonly StarterRecipe[] = [
     key: 'zimage',
     coreType: 'alibaba/z-image-turbo',
     title: 'Z-Image Turbo',
+    kind: 'image',
     blurb: 'Eight steps, no guidance. The quickest way to a first image.',
     params: { width: 1024, height: 1024, steps: 8, guidance: 0, seed: -1 },
     promptText:
@@ -35,6 +42,8 @@ export const STARTER_RECIPES: readonly StarterRecipe[] = [
     key: 'flux2',
     coreType: 'black-forest-labs/flux-2',
     title: 'FLUX.2',
+    tag: 'New',
+    kind: 'image',
     blurb: 'Prose prompts and multi-reference editing. Klein 4B is the light build.',
     // steps 0 and guidance -1 mean "from the checkpoint": the runner substitutes the detected
     // variant's own schedule (klein wants 4 steps at guidance 1.0, dev wants 28 at 4.0). Writing a
@@ -47,15 +56,33 @@ export const STARTER_RECIPES: readonly StarterRecipe[] = [
     key: 'krea2',
     coreType: 'krea/krea-2-turbo',
     title: 'Krea 2 Turbo',
+    kind: 'image',
     blurb: 'Photographic look, distilled to eight steps. The heaviest of the three.',
     params: { width: 1024, height: 1024, steps: 8, guidance: 0, seed: -1 },
     promptText:
       'Close-up portrait in soft window light, natural skin texture, 85mm lens, shallow depth of field',
   },
   {
+    key: 'api',
+    coreType: null,
+    // MiniMax H3 text-to-video: nothing to wire but a prompt, so the card is one click from a clip.
+    falModelId: 'minimax/h3/text-to-video',
+    title: 'Try MiniMax H3',
+    tag: 'New',
+    kind: 'video',
+    blurb: 'Hosted text to video, no GPU. The first of the API Nodes.',
+    params: { resolution: '2K', duration: 5, aspect_ratio: '16:9' },
+    // Video prompts read as prose, not the comma-separated fragments the image cards use: the scene
+    // first, then the camera move and the light. That is how MiniMax's own examples are written.
+    // Text-to-video has no reference ports, so the look is described rather than pointed at.
+    promptText:
+      'A photoreal city street in the late afternoon, where the buildings and pedestrians are live action but every tree and parked car is a blocky voxel object built from visible cubes with low-resolution textures. The camera tracks slowly along the pavement, warm low sun, real shadows falling across the filmed and the voxel elements alike.',
+  },
+  {
     key: 'training',
     coreType: null,
     title: 'Train a LoRA',
+    kind: 'training',
     blurb: 'Teach a style or subject from your own images, then generate with it.',
     params: {},
     promptText: '',

--- a/src/renderer/lib/vramAdvice.test.ts
+++ b/src/renderer/lib/vramAdvice.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  pickRecommended,
+  readVram,
+  recommendedLabel,
+  tierFor,
+  type StarterKey,
+  type VramReading,
+} from './vramAdvice'
+import type { GpuStat, SystemStatsEvent } from '@shared/types'
+
+const GB = 1024 ** 3
+const gpu = (name: string, totalGb: number, index = 0): GpuStat => ({
+  index,
+  name,
+  utilization: 0,
+  memoryUsed: 0,
+  memoryTotal: totalGb * GB,
+  temperature: null,
+})
+const stats = (gpus: GpuStat[]): SystemStatsEvent => ({ cpu: 0, ramUsed: 0, ramTotal: 0, gpus })
+const known = (totalGb: number): VramReading => ({ state: 'known', totalGb, name: 'x' })
+
+describe('readVram', () => {
+  it('is pending until the first broadcast arrives', () => {
+    // systemStats is null for ~1.5s after mount; cards must render anyway.
+    expect(readVram(null)).toEqual({ state: 'pending' })
+  })
+
+  it('is unknown rather than "no GPU" when nothing can be read', () => {
+    // Apple Silicon, AMD, or missing pynvml all report an empty list, and those machines do run.
+    expect(readVram(stats([]))).toEqual({ state: 'unknown' })
+  })
+
+  it('tiers on the largest card, not the first', () => {
+    const reading = readVram(stats([gpu('display', 4, 0), gpu('compute', 24, 1)]))
+    expect(reading).toMatchObject({ state: 'known', name: 'compute' })
+    expect(reading.state === 'known' && Math.round(reading.totalGb)).toBe(24)
+  })
+})
+
+describe('tierFor', () => {
+  it('falls back to a static requirement when the hardware is unreadable', () => {
+    for (const state of ['pending', 'unknown'] as const) {
+      const advice = tierFor('flux2', { state })
+      expect(advice.tier).toBeNull()
+      expect(advice.note).toMatch(/VRAM/)
+    }
+  })
+
+  it.each([
+    ['zimage', 24, 'best'],
+    ['zimage', 16, 'good'],
+    ['zimage', 10, 'ok'],
+    ['zimage', 8, 'heavy'],
+    ['flux2', 24, 'best'],
+    ['flux2', 16, 'good'],
+    ['flux2', 12, 'ok'],
+    ['flux2', 8, 'heavy'],
+    ['krea2', 32, 'best'],
+    ['krea2', 24, 'good'],
+    ['krea2', 16, 'ok'],
+    ['krea2', 12, 'heavy'],
+    ['training', 24, 'best'],
+    ['training', 16, 'ok'],
+    ['training', 8, 'heavy'],
+  ] as [StarterKey, number, string][])('%s at %s GB is %s', (key, gbTotal, tier) => {
+    expect(tierFor(key, known(gbTotal)).tier).toBe(tier)
+  })
+
+  it('does not demote a card that advertises 16 GB but reports slightly under', () => {
+    // A "16 GB" card reports ~15.9 GiB. Rounding it down a tier would be visibly wrong.
+    expect(tierFor('flux2', known(15.6)).tier).toBe('good')
+    expect(tierFor('zimage', known(15.6)).tier).toBe('good')
+    // A genuinely smaller card still drops.
+    expect(tierFor('flux2', known(14)).tier).toBe('ok')
+  })
+
+  it('always tells the user it will still run, even at the lowest tier', () => {
+    for (const key of ['zimage', 'flux2', 'krea2', 'training'] as StarterKey[]) {
+      const advice = tierFor(key, known(4))
+      expect(advice.tier).toBe('heavy')
+      expect(advice.note.toLowerCase()).toMatch(/will run|try /)
+    }
+  })
+})
+
+describe('pickRecommended', () => {
+  it('returns the neutral starting point when the hardware is unreadable', () => {
+    expect(pickRecommended({ state: 'pending' })).toBe('zimage')
+    expect(pickRecommended({ state: 'unknown' })).toBe('zimage')
+    expect(recommendedLabel({ state: 'unknown' })).toBe('Best place to start')
+  })
+
+  it('breaks ties lightest-first, so it is deterministic', () => {
+    // At 24 GB, Z-Image and FLUX.2 are both `best`; the lighter one wins.
+    expect(pickRecommended(known(24))).toBe('zimage')
+    expect(recommendedLabel(known(24))).toBe('Recommended for your GPU')
+  })
+
+  it('still names exactly one card on a small GPU', () => {
+    expect(pickRecommended(known(6))).toBe('zimage')
+  })
+})

--- a/src/renderer/lib/vramAdvice.ts
+++ b/src/renderer/lib/vramAdvice.ts
@@ -12,8 +12,11 @@
  */
 import type { SystemStatsEvent } from '@shared/types'
 
-export type StarterKey = 'zimage' | 'flux2' | 'krea2' | 'training'
+export type StarterKey = 'zimage' | 'flux2' | 'krea2' | 'api' | 'training'
 export type Tier = 'best' | 'good' | 'ok' | 'heavy'
+
+/** Keys whose model runs on this machine, so VRAM has something to say about them. */
+type LocalKey = Exclude<StarterKey, 'api'>
 
 export type VramReading =
   | { state: 'pending' }
@@ -46,7 +49,7 @@ interface TierRow {
  * A card advertising 16 GB reports slightly under 16 GiB, so the rows sit a little below the round
  * number rather than exactly on it.
  */
-const TIERS: Record<StarterKey, TierRow[]> = {
+const TIERS: Record<LocalKey, TierRow[]> = {
   zimage: [
     { minGb: 23.5, tier: 'best', note: 'Runs fully resident. The fastest option here.' },
     { minGb: 15.5, tier: 'good', note: 'Fits with int8 weights.' },
@@ -77,12 +80,15 @@ const TIERS: Record<StarterKey, TierRow[]> = {
 }
 
 /** Static requirement copy, shown when the hardware cannot be read. */
-const STATIC_NOTE: Record<StarterKey, string> = {
+const STATIC_NOTE: Record<LocalKey, string> = {
   zimage: 'Around 12 GB of VRAM for a comfortable run.',
   flux2: 'Around 16 GB of VRAM for a comfortable run.',
   krea2: 'Around 24 GB of VRAM for a comfortable run.',
   training: 'Around 16 GB of VRAM to train at 512 px.',
 }
+
+/** Hosted models run on fal's hardware, so no reading of this machine applies. */
+const API_NOTE = 'No GPU needed. You bring a fal key and pay per render.'
 
 export interface Advice {
   tier: Tier | null
@@ -90,6 +96,7 @@ export interface Advice {
 }
 
 export function tierFor(key: StarterKey, reading: VramReading): Advice {
+  if (key === 'api') return { tier: null, note: API_NOTE }
   if (reading.state !== 'known') return { tier: null, note: STATIC_NOTE[key] }
   const row = TIERS[key].find((r) => reading.totalGb >= r.minGb)
   // The last row is minGb 0, so this only falls through if a table is mis-edited.
@@ -98,7 +105,8 @@ export function tierFor(key: StarterKey, reading: VramReading): Advice {
 
 const SCORE: Record<Tier, number> = { best: 3, good: 2, ok: 1, heavy: 0 }
 /** Ties break lightest-first, so a new user is pointed at the quickest thing that works. */
-const PREFERENCE: StarterKey[] = ['zimage', 'flux2', 'krea2', 'training']
+// 'api' is deliberately absent: it has no tier to score, and the ribbon is about this machine.
+const PREFERENCE: LocalKey[] = ['zimage', 'flux2', 'krea2', 'training']
 
 /**
  * The one card that gets the ribbon. Without a hardware reading this is Z-Image, labelled as a

--- a/src/renderer/lib/vramAdvice.ts
+++ b/src/renderer/lib/vramAdvice.ts
@@ -1,0 +1,119 @@
+/**
+ * How comfortably each starter model will run on this machine.
+ *
+ * Advisory, never gating. The device policy auto-quantizes and offloads to fit, so "will not run"
+ * is nearly always wrong; what a new user actually needs to know is which model will feel fast and
+ * which will crawl. Every tier's copy therefore still says it runs.
+ *
+ * Tiering deliberately does NOT use the engine's own fit estimate. That sizes models from what is
+ * on disk, so on a fresh install with nothing downloaded every model reports a zero footprint and
+ * "fits, resident" - the exact opposite of useful. Static requirements are correct before the first
+ * download, which is when this advice is read.
+ */
+import type { SystemStatsEvent } from '@shared/types'
+
+export type StarterKey = 'zimage' | 'flux2' | 'krea2' | 'training'
+export type Tier = 'best' | 'good' | 'ok' | 'heavy'
+
+export type VramReading =
+  | { state: 'pending' }
+  /** No GPU memory could be read. Ambiguous: an Apple Silicon or AMD box, or NVML missing. */
+  | { state: 'unknown' }
+  | { state: 'known'; totalGb: number; name: string }
+
+/** Total VRAM in GiB, from the largest card present. */
+export function readVram(stats: SystemStatsEvent | null): VramReading {
+  if (stats == null) return { state: 'pending' }
+  const gpus = stats.gpus ?? []
+  if (gpus.length === 0) return { state: 'unknown' }
+  // The largest card, not gpus[0]: a box with a small display GPU at index 0 would otherwise be
+  // mis-tiered. The device policy may still choose device 0, which is fine for a recommendation.
+  const largest = gpus.reduce((a, b) => (b.memoryTotal > a.memoryTotal ? b : a))
+  return { state: 'known', totalGb: largest.memoryTotal / 1024 ** 3, name: largest.name }
+}
+
+interface TierRow {
+  minGb: number
+  tier: Tier
+  note: string
+}
+
+/**
+ * Descending thresholds per model, from measured footprints: Z-Image is 12.3 GB of weights plus an
+ * 8 GB encoder that can be evicted after encoding; FLUX.2 klein 4B is 16.1 GB resident at bf16;
+ * Krea 2 is around 26 GB and drops to NF4 below roughly 24 GB.
+ *
+ * A card advertising 16 GB reports slightly under 16 GiB, so the rows sit a little below the round
+ * number rather than exactly on it.
+ */
+const TIERS: Record<StarterKey, TierRow[]> = {
+  zimage: [
+    { minGb: 23.5, tier: 'best', note: 'Runs fully resident. The fastest option here.' },
+    { minGb: 15.5, tier: 'good', note: 'Fits with int8 weights.' },
+    { minGb: 9.5, tier: 'ok', note: 'Runs with CPU offload. Slower first render.' },
+    { minGb: 0, tier: 'heavy', note: 'Will run, but expect offload and slow steps.' },
+  ],
+  flux2: [
+    { minGb: 23.5, tier: 'best', note: 'Klein 4B stays resident, and dev is within reach.' },
+    { minGb: 15.5, tier: 'good', note: 'Klein 4B fits with int8 and encoder eviction.' },
+    { minGb: 11.5, tier: 'ok', note: 'Klein 4B runs quantized with offload.' },
+    { minGb: 0, tier: 'heavy', note: 'Will run, but slowly. Try Z-Image first.' },
+  ],
+  krea2: [
+    { minGb: 31.5, tier: 'best', note: 'Full bf16 weights stay resident.' },
+    { minGb: 23.5, tier: 'good', note: 'Loads in NF4 or int8.' },
+    { minGb: 15.5, tier: 'ok', note: 'NF4 plus offload. Noticeably slower.' },
+    {
+      minGb: 0,
+      tier: 'heavy',
+      note: 'Will run, but this is the heaviest model here. Expect long renders.',
+    },
+  ],
+  training: [
+    { minGb: 23.5, tier: 'best', note: 'Comfortable for LoRA training.' },
+    { minGb: 15.5, tier: 'ok', note: 'Trainable at 512 to 768 px with a small batch.' },
+    { minGb: 0, tier: 'heavy', note: 'Will run at a small size. Training wants about 16 GB.' },
+  ],
+}
+
+/** Static requirement copy, shown when the hardware cannot be read. */
+const STATIC_NOTE: Record<StarterKey, string> = {
+  zimage: 'Around 12 GB of VRAM for a comfortable run.',
+  flux2: 'Around 16 GB of VRAM for a comfortable run.',
+  krea2: 'Around 24 GB of VRAM for a comfortable run.',
+  training: 'Around 16 GB of VRAM to train at 512 px.',
+}
+
+export interface Advice {
+  tier: Tier | null
+  note: string
+}
+
+export function tierFor(key: StarterKey, reading: VramReading): Advice {
+  if (reading.state !== 'known') return { tier: null, note: STATIC_NOTE[key] }
+  const row = TIERS[key].find((r) => reading.totalGb >= r.minGb)
+  // The last row is minGb 0, so this only falls through if a table is mis-edited.
+  return row ? { tier: row.tier, note: row.note } : { tier: null, note: STATIC_NOTE[key] }
+}
+
+const SCORE: Record<Tier, number> = { best: 3, good: 2, ok: 1, heavy: 0 }
+/** Ties break lightest-first, so a new user is pointed at the quickest thing that works. */
+const PREFERENCE: StarterKey[] = ['zimage', 'flux2', 'krea2', 'training']
+
+/**
+ * The one card that gets the ribbon. Without a hardware reading this is Z-Image, labelled as a
+ * neutral starting point rather than as a claim about a GPU we could not see.
+ */
+export function pickRecommended(reading: VramReading): StarterKey {
+  if (reading.state !== 'known') return 'zimage'
+  return PREFERENCE.reduce((best, key) => {
+    const a = SCORE[tierFor(key, reading).tier ?? 'heavy']
+    const b = SCORE[tierFor(best, reading).tier ?? 'heavy']
+    return a > b ? key : best
+  }, PREFERENCE[0])
+}
+
+/** The ribbon's wording, which must not imply hardware knowledge we do not have. */
+export function recommendedLabel(reading: VramReading): string {
+  return reading.state === 'known' ? 'Recommended for your GPU' : 'Best place to start'
+}

--- a/src/renderer/store/frameStore.ts
+++ b/src/renderer/store/frameStore.ts
@@ -23,9 +23,9 @@ interface FrameState {
   load: () => Promise<void>
   importAsFrames: () => Promise<void>
   addFromAssets: (assetIds: string[]) => Promise<void>
-  addInputs: (frameId: string, assetIds: string[]) => Promise<void>
+  addInputs: (frameId: string, assetIds: string[], handle?: string | null) => Promise<void>
   /** Link another frame's output as an input (resolves to its hero take). */
-  addSourceInput: (frameId: string, sourceFrameId: string) => Promise<void>
+  addSourceInput: (frameId: string, sourceFrameId: string, handle?: string | null) => Promise<void>
   removeInput: (frameId: string, assetId: string) => Promise<void>
   /** Remove one input by its row id (works for asset AND flow-link inputs). */
   removeInputById: (frameId: string, inputId: string) => Promise<void>
@@ -104,9 +104,9 @@ export const useFrameStore = create<FrameState>((set, get) => ({
     }
   },
 
-  addInputs: async (frameId, assetIds) => {
+  addInputs: async (frameId, assetIds, handle) => {
     try {
-      const res = await studio().frames.addInputs(frameId, assetIds)
+      const res = await studio().frames.addInputs(frameId, assetIds, handle ?? null)
       if (!res.ok) return set({ error: res.error })
       const added = res.value
       if (added.length === 0) return
@@ -121,9 +121,9 @@ export const useFrameStore = create<FrameState>((set, get) => ({
     }
   },
 
-  addSourceInput: async (frameId, sourceFrameId) => {
+  addSourceInput: async (frameId, sourceFrameId, handle) => {
     try {
-      const res = await studio().frames.addSourceInput(frameId, sourceFrameId)
+      const res = await studio().frames.addSourceInput(frameId, sourceFrameId, handle ?? null)
       if (!res.ok) return set({ error: res.error })
       set((s) => {
         const existing = s.inputsByFrame[frameId] ?? []

--- a/src/renderer/store/generationStore.ts
+++ b/src/renderer/store/generationStore.ts
@@ -5,7 +5,7 @@
  */
 import { create } from 'zustand'
 import { getNodeDef } from '@shared/nodes/registry'
-import { emptyResolvedInputs } from '@shared/nodes/types'
+import { emptyResolvedInputs, mediaFamily, portMedia } from '@shared/nodes/types'
 import type { FalRunRequest } from '@shared/ipc'
 import { ipcErrorMessage } from '../lib/ipcError'
 import { studio } from '@/lib/studio'
@@ -93,6 +93,18 @@ export const useGenerationStore = create<GenerationState>((set) => ({
           images: resolved.value.images,
           videos: resolved.value.videos,
           audios: resolved.value.audios,
+          byHandle: resolved.value.byHandle ?? {},
+        }
+        // A required media port with nothing behind it would go out as an empty URL, and fal
+        // answers that with a 422 "failed to download the file" that says nothing about the cause.
+        const starved = def.inputs.filter(
+          (p) => p.required && mediaFamily(p.kind) && portMedia(def, inputs, p.id).length === 0,
+        )
+        if (starved.length > 0) {
+          return fail(
+            `${def.title} needs ${starved.map((p) => p.label.toLowerCase()).join(' and ')}. ` +
+              'Wire it into the node, or drop the media onto the node itself.',
+          )
         }
         const runParams = { ...frame.params, prompt: resolved.value.prompt ?? '' }
         request = {

--- a/src/renderer/store/onboardingStore.test.ts
+++ b/src/renderer/store/onboardingStore.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useOnboardingStore } from './onboardingStore'
+
+const KEY = 'inline-studio.onboarding.starterHints'
+const target = { itemId: 'n1', surface: 'studio' as const }
+
+/**
+ * The suite runs in node with no DOM, which is the repo's default and worth keeping: a store that
+ * only touches localStorage behind try/catch should not drag jsdom into every other test. So the
+ * shim is local, and one case removes it entirely to prove the guards actually hold.
+ */
+function installStorage(over: Partial<Storage> = {}): Map<string, string> {
+  const map = new Map<string, string>()
+  const store: Partial<Storage> = {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => map.clear(),
+    ...over,
+  }
+  Object.defineProperty(globalThis, 'localStorage', { value: store, configurable: true })
+  return map
+}
+
+function removeStorage(): void {
+  Reflect.deleteProperty(globalThis as Record<string, unknown>, 'localStorage')
+}
+
+describe('onboardingStore', () => {
+  beforeEach(() => {
+    installStorage()
+    useOnboardingStore.setState({ starterHintsSeen: false, hintTarget: null })
+  })
+
+  it('marks seen when the hint is shown, not when it is dismissed', () => {
+    // A reload part-way through the hint should not replay it.
+    const map = installStorage()
+    useOnboardingStore.getState().armHints(target)
+    expect(map.get(KEY)).toBe('1')
+    expect(useOnboardingStore.getState().hintTarget).toEqual(target)
+
+    useOnboardingStore.getState().dismissHints()
+    expect(useOnboardingStore.getState().hintTarget).toBeNull()
+    expect(useOnboardingStore.getState().starterHintsSeen).toBe(true)
+  })
+
+  it('will not re-arm once seen', () => {
+    useOnboardingStore.getState().armHints(target)
+    useOnboardingStore.getState().dismissHints()
+    useOnboardingStore.getState().armHints({ itemId: 'n2', surface: 'studio' })
+    expect(useOnboardingStore.getState().hintTarget).toBeNull()
+  })
+
+  it('still shows the hint when localStorage throws', () => {
+    // Private browsing. Not remembering the hint is survivable; crashing the canvas is not.
+    installStorage({
+      setItem: () => {
+        throw new Error('quota exceeded')
+      },
+    })
+    expect(() => useOnboardingStore.getState().armHints(target)).not.toThrow()
+    expect(useOnboardingStore.getState().hintTarget).toEqual(target)
+  })
+
+  it('survives localStorage being absent entirely', () => {
+    removeStorage()
+    expect(() => useOnboardingStore.getState().armHints(target)).not.toThrow()
+    expect(() => useOnboardingStore.getState().resetSeen()).not.toThrow()
+    installStorage()
+  })
+
+  it('can be reset, which is the seam for a replay action', () => {
+    const map = installStorage()
+    useOnboardingStore.getState().armHints(target)
+    useOnboardingStore.getState().resetSeen()
+    expect(map.get(KEY)).toBeUndefined()
+    expect(useOnboardingStore.getState().starterHintsSeen).toBe(false)
+  })
+})

--- a/src/renderer/store/onboardingStore.ts
+++ b/src/renderer/store/onboardingStore.ts
@@ -1,0 +1,62 @@
+/**
+ * First-run coaching state: whether the Run and Edit-params hints have been shown, and which node
+ * they currently point at.
+ *
+ * The "seen" flag is per device and global, not per project: you learn where Run is once, and a
+ * second project should not teach it again. Persisted the same way as the canvas preferences, since
+ * this is a view preference rather than project data.
+ */
+import { create } from 'zustand'
+
+import type { CanvasSurface } from '@shared/types'
+
+const SEEN_KEY = 'inline-studio.onboarding.starterHints'
+
+function loadSeen(): boolean {
+  try {
+    return localStorage.getItem(SEEN_KEY) === '1'
+  } catch {
+    // Private mode or a quota error. Replaying the hints each session beats crashing the canvas.
+    return false
+  }
+}
+
+export interface HintTarget {
+  itemId: string
+  surface: CanvasSurface
+}
+
+interface OnboardingState {
+  starterHintsSeen: boolean
+  /** The node the hints point at. Transient, never persisted. */
+  hintTarget: HintTarget | null
+  /** Point the hints at a node. A no-op once they have been seen. */
+  armHints: (target: HintTarget) => void
+  dismissHints: () => void
+  /** Escape hatch for tests and a future "replay tips" action. */
+  resetSeen: () => void
+}
+
+export const useOnboardingStore = create<OnboardingState>((set, get) => ({
+  starterHintsSeen: loadSeen(),
+  hintTarget: null,
+  armHints: (hintTarget) => {
+    if (get().starterHintsSeen) return
+    // Marked seen on show rather than on dismiss, so reloading mid-hint does not replay it.
+    try {
+      localStorage.setItem(SEEN_KEY, '1')
+    } catch {
+      /* not persisting is survivable; the hint still shows this session */
+    }
+    set({ hintTarget, starterHintsSeen: true })
+  },
+  dismissHints: () => set({ hintTarget: null }),
+  resetSeen: () => {
+    try {
+      localStorage.removeItem(SEEN_KEY)
+    } catch {
+      /* nothing to undo */
+    }
+    set({ starterHintsSeen: false, hintTarget: null })
+  },
+}))

--- a/src/renderer/views/Moodboard/AddNodeMenu.tsx
+++ b/src/renderer/views/Moodboard/AddNodeMenu.tsx
@@ -12,6 +12,8 @@
 
 import { useState } from 'react'
 
+import { useMenuPlacement } from './useMenuPlacement'
+
 import { addableCoreNodes, type NodeDescriptor } from '@shared/coreNodes'
 import { isExtensionNode, extensionOf } from '@shared/extensions'
 import { listNodeDefs, groupByOwner } from '@shared/nodes/registry'
@@ -80,6 +82,7 @@ export function AddNodeMenu({
   onClose: () => void
 }): React.JSX.Element {
   const [tab, setTab] = useState<Tab>('core')
+  const place = useMenuPlacement<HTMLDivElement>(x, y, above)
 
   // Only high-level model nodes are offered; samplers/inputs are hidden plumbing.
   const all = addableCoreNodes(coreNodes)
@@ -101,10 +104,11 @@ export function AddNodeMenu({
     <>
       <div className="absolute inset-0 z-20" onClick={onClose} />
       <div
+        ref={place.ref}
         className={`absolute z-30 flex w-64 select-none flex-col overflow-hidden rounded-md border border-border bg-panel text-xs shadow-xl ${
-          above ? '-translate-x-1/2 -translate-y-full' : ''
+          above ? '-translate-x-1/2 -translate-y-full' : place.flipped ? '-translate-y-full' : ''
         }`}
-        style={{ left: x, top: y }}
+        style={place.style}
       >
         <div className="flex border-b border-border">
           <TabButton active={tab === 'core'} onClick={() => setTab('core')}>
@@ -115,8 +119,9 @@ export function AddNodeMenu({
           </TabButton>
         </div>
 
-        {/* One scroll area for the active tab, not per-section. */}
-        <div className="max-h-[70vh] overflow-y-auto">
+        {/* One scroll area for the active tab, not per-section. `nowheel` keeps React Flow from
+            swallowing the wheel and zooming the canvas instead of scrolling this list. */}
+        <div className="nowheel overflow-y-auto" style={{ maxHeight: place.maxHeight }}>
           {tab === 'core' ? (
             <>
               {sections.map(([category, rows]) => (

--- a/src/renderer/views/Moodboard/CanvasToolbar.tsx
+++ b/src/renderer/views/Moodboard/CanvasToolbar.tsx
@@ -2,6 +2,9 @@
  * Floating bottom-center widget bar: a horizontal strip of canvas tools - Select (edit), Pan
  * (view), Text, and Add (opens a node list). It sits inside the canvas area, so it tracks the
  * Assets panel as it opens/resizes.
+ *
+ * Shared by both canvases. The Trainer omits `onAddText`, since it has no text node, and the
+ * button is dropped rather than shown disabled.
  */
 export function CanvasToolbar({
   tool,
@@ -14,8 +17,8 @@ export function CanvasToolbar({
   tool: 'select' | 'pan'
   onSelectTool: () => void
   onPanTool: () => void
-  /** Add a text node (at canvas centre). */
-  onAddText: () => void
+  /** Add a text node (at canvas centre). Omitted on canvases without text nodes (the Trainer). */
+  onAddText?: () => void
   /** Open the "Add node" list, anchored to the + button. */
   onOpenAdd: (buttonRect: DOMRect) => void
 }): React.JSX.Element {
@@ -28,9 +31,11 @@ export function CanvasToolbar({
         <HandIcon />
       </ToolButton>
       <div className="mx-0.5 h-6 w-px self-center bg-border" />
-      <ToolButton label="Add text" onClick={onAddText}>
-        <span className="text-base font-bold leading-none">T</span>
-      </ToolButton>
+      {onAddText && (
+        <ToolButton label="Add text" onClick={onAddText}>
+          <span className="text-base font-bold leading-none">T</span>
+        </ToolButton>
+      )}
       <ToolButton
         label="Add node"
         onClick={(e) => onOpenAdd(e.currentTarget.getBoundingClientRect())}

--- a/src/renderer/views/Moodboard/CoreParamWidget.tsx
+++ b/src/renderer/views/Moodboard/CoreParamWidget.tsx
@@ -38,17 +38,22 @@ export function CoreParamWidget({
   }
   if (field.widget === 'select') {
     const options = field.options ?? []
-    // A file-picker whose empty value means "none"/"auto" needs an explicit empty option, or the
+    // A picker whose empty value genuinely means "none" needs an explicit empty option, or the
     // native select shows the FIRST file while the value is really "" - which reads as picked when
     // it isn't (e.g. the ControlNet dropdown looked set but control was actually off).
-    const needsEmpty =
-      !options.some((o) => o.value === '') && (field.default === '' || field.optionsFrom != null)
+    //
+    // Only when the *default* is empty, though. Core now resolves a concrete file for the model,
+    // VAE and text-encoder pickers, and offering "Auto" beside it hides which file actually ran.
+    const needsEmpty = !options.some((o) => o.value === '') && field.default === ''
     const emptyLabel = field.optionsFrom === 'controlnet' ? 'None' : 'Auto'
+    // A node saved before Core resolved these still has "" stored, which would match no option and
+    // render blank. Fall back to the resolved default so an existing node shows its real file too.
+    const selected = value == null || value === '' ? field.default : value
     return (
       <label className="flex flex-col gap-1">
         <span className={labelCls}>{field.label}</span>
         <select
-          value={String(value ?? field.default)}
+          value={String(selected)}
           onChange={(e) => onCommit(e.target.value)}
           className={inputCls}
         >

--- a/src/renderer/views/Moodboard/GenerateSettingsPanel.tsx
+++ b/src/renderer/views/Moodboard/GenerateSettingsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { getNodeDef } from '@shared/nodes/registry'
-import { defaultParams } from '@shared/nodes/types'
+import { defaultParams, type NodeDef } from '@shared/nodes/types'
 import { useFrameStore } from '../../store/frameStore'
 import { useGenerationStore } from '../../store/generationStore'
 import { useSettingsDraft } from '../../lib/useSettingsDraft'
@@ -26,7 +26,7 @@ export function GenerateSettingsPanel(): React.JSX.Element | null {
     [def, frame],
   )
   const persist = (params: Record<string, unknown>): void => {
-    if (frameId) void setParams(frameId, params)
+    if (frameId) void setParams(frameId, def ? clampNumbers(def, params) : params)
   }
   const { local, dirty, change, apply } = useSettingsDraft(
     frameId ? `${frameId}:${defId ?? ''}` : null,
@@ -75,4 +75,25 @@ export function GenerateSettingsPanel(): React.JSX.Element | null {
       </div>
     </div>
   )
+}
+
+/**
+ * Bound every number param to its declared range before it is stored.
+ *
+ * The inputs keep a live draft and only clamp on blur, but clicking outside the panel persists on
+ * `pointerdown`, which lands first. Without this an out-of-range entry stuck in the box while the
+ * request quietly used the clamped value, so the field and the render disagreed forever.
+ */
+function clampNumbers(def: NodeDef, params: Record<string, unknown>): Record<string, unknown> {
+  const out = { ...params }
+  for (const field of def.params) {
+    if (field.widget !== 'number') continue
+    const n = Number(out[field.key])
+    if (!Number.isFinite(n)) {
+      out[field.key] = field.default
+      continue
+    }
+    out[field.key] = Math.min(field.max ?? n, Math.max(field.min ?? n, n))
+  }
+  return out
 }

--- a/src/renderer/views/Moodboard/GettingStarted/FirstRunHints.tsx
+++ b/src/renderer/views/Moodboard/GettingStarted/FirstRunHints.tsx
@@ -1,0 +1,110 @@
+/**
+ * The one-time coaching that follows a starter card: two arrows, at Run graph and at Edit params.
+ *
+ * Anchoring is by measurement rather than layout, because both targets move with the canvas. The
+ * Run pill is the awkward one: it is a React Flow NodeToolbar that only mounts while the node is
+ * the selected graph's run target, so it can vanish under us if the board refreshes. When it does,
+ * we fall back to the node's own top-right corner rather than draw an arrow pointing at nothing.
+ */
+import { useEffect, useRef, useState } from 'react'
+
+import { CoachMark, type Point } from '../../../components/CoachMark'
+import { useOnboardingStore } from '../../../store/onboardingStore'
+
+/** Measured every frame while visible: two rects, and only during onboarding. */
+interface Anchors {
+  run: Point | null
+  adjust: Point | null
+}
+
+const AUTO_DISMISS_MS = 20_000
+
+export function FirstRunHints({
+  wrapperRef,
+}: {
+  wrapperRef: React.RefObject<HTMLDivElement | null>
+}): React.JSX.Element | null {
+  const target = useOnboardingStore((s) => s.hintTarget)
+  const dismiss = useOnboardingStore((s) => s.dismissHints)
+  const [anchors, setAnchors] = useState<Anchors>({ run: null, adjust: null })
+  const frame = useRef<number>(0)
+
+  // Track both controls while the hints are up. rAF rather than ResizeObserver plus onMove: those
+  // miss inertial pan and the animated fitView frames, so the arrow visibly lags right after a click.
+  useEffect(() => {
+    if (!target) return
+    const wrapper = wrapperRef.current
+    if (!wrapper) return
+
+    const toLocal = (el: Element | null): Point | null => {
+      if (!el) return null
+      const r = el.getBoundingClientRect()
+      const w = wrapper.getBoundingClientRect()
+      return { x: r.left + r.width / 2 - w.left, y: r.top + r.height / 2 - w.top }
+    }
+    const node = () => wrapper.querySelector(`.react-flow__node[data-id="${target.itemId}"]`)
+    const tick = (): void => {
+      setAnchors({
+        run: toLocal(document.querySelector('[data-run-toolbar]')) ?? nodeCorner(node(), wrapper),
+        // Not unique on its own: every node with settings renders one, so scope to this node.
+        adjust: toLocal(node()?.querySelector('[data-gen-settings-toggle]') ?? null),
+      })
+      frame.current = requestAnimationFrame(tick)
+    }
+    frame.current = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(frame.current)
+  }, [target, wrapperRef])
+
+  // Any deliberate action means the lesson landed. Escape and a timeout stop it outstaying welcome.
+  useEffect(() => {
+    if (!target) return
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') dismiss()
+    }
+    const onDown = (e: PointerEvent): void => {
+      const el = e.target as HTMLElement
+      if (el.closest('[data-run-toolbar], [data-gen-settings-toggle]')) dismiss()
+    }
+    const timer = window.setTimeout(dismiss, AUTO_DISMISS_MS)
+    window.addEventListener('keydown', onKey)
+    window.addEventListener('pointerdown', onDown, true)
+    return () => {
+      window.clearTimeout(timer)
+      window.removeEventListener('keydown', onKey)
+      window.removeEventListener('pointerdown', onDown, true)
+    }
+  }, [target, dismiss])
+
+  if (!target) return null
+  return (
+    <div className="pointer-events-none absolute inset-0 z-30">
+      {anchors.run && (
+        <CoachMark
+          target={anchors.run}
+          step={1}
+          title="Run graph"
+          body="Renders this graph. The result becomes a take, and running again adds another rather than replacing it."
+          side="left"
+          onDismiss={dismiss}
+        />
+      )}
+      {anchors.adjust && (
+        <CoachMark
+          target={anchors.adjust}
+          step={2}
+          title="Edit params"
+          body="Opens size, steps, guidance and the model files in a side panel."
+          side="right"
+        />
+      )}
+    </div>
+  )
+}
+
+/** Fallback anchor: the node's top-right, where the Run pill sits when it is mounted. */
+function nodeCorner(node: Element | null | undefined, wrapper: HTMLElement): Point | null {
+  if (!node) return null
+  const r = node.getBoundingClientRect()
+  const w = wrapper.getBoundingClientRect()
+  return { x: r.right - w.left, y: r.top - w.top - 10 }
+}

--- a/src/renderer/views/Moodboard/GettingStarted/StarterCard.tsx
+++ b/src/renderer/views/Moodboard/GettingStarted/StarterCard.tsx
@@ -1,0 +1,92 @@
+import type { Advice, Tier } from '../../../lib/vramAdvice'
+
+/** Tier colours. Amber is as loud as this gets, because every tier still runs. */
+const TIER_STYLE: Record<Tier, { chip: string; label: string }> = {
+  best: { chip: 'bg-emerald-500/15 text-emerald-300', label: 'Runs great' },
+  good: { chip: 'bg-emerald-500/10 text-emerald-400/90', label: 'Runs well' },
+  ok: { chip: 'bg-sky-500/10 text-sky-300', label: 'Runs' },
+  heavy: { chip: 'bg-amber-500/10 text-amber-300', label: 'Heavy' },
+}
+
+export interface CardStatus {
+  /** Model files still to download. 0 once everything is installed. */
+  missing: number
+  /** An extra line from the engine's own fit estimate, only trustworthy once installed. */
+  note: string | null
+}
+
+/** One getting-started card: presentational, reports clicks upward. */
+export function StarterCard({
+  icon,
+  title,
+  blurb,
+  advice,
+  recommended,
+  recommendedLabel,
+  status,
+  onPick,
+  onGetModels,
+  disabled = false,
+}: {
+  icon: React.JSX.Element
+  title: string
+  blurb: string
+  advice: Advice
+  recommended: boolean
+  recommendedLabel: string
+  /** Null while the install state is still unknown, so nothing flashes on first paint. */
+  status: CardStatus | null
+  onPick: () => void
+  onGetModels?: () => void
+  disabled?: boolean
+}): React.JSX.Element {
+  const tier = advice.tier ? TIER_STYLE[advice.tier] : null
+  return (
+    <div
+      className={`relative flex flex-col rounded-lg border bg-surface/80 p-3 text-left transition ${
+        recommended ? 'border-accent/60' : 'border-border'
+      } ${disabled ? 'opacity-50' : 'hover:border-zinc-500'}`}
+    >
+      {recommended && (
+        <span className="absolute -top-2 left-3 rounded-full bg-accent px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-black">
+          {recommendedLabel}
+        </span>
+      )}
+      <button
+        onClick={onPick}
+        disabled={disabled}
+        className="flex flex-col gap-1.5 text-left disabled:cursor-not-allowed"
+      >
+        <span className="flex items-center gap-2">
+          <span className="text-zinc-400">{icon}</span>
+          <span className="text-sm font-medium text-zinc-100">{title}</span>
+          {tier && (
+            <span className={`rounded px-1.5 py-0.5 text-[9px] font-medium ${tier.chip}`}>
+              {tier.label}
+            </span>
+          )}
+        </span>
+        <span className="text-[11px] leading-relaxed text-zinc-400">{blurb}</span>
+        <span className="text-[10px] leading-relaxed text-zinc-500">{advice.note}</span>
+      </button>
+      {status && status.missing > 0 && (
+        <div className="mt-2 flex items-center gap-2 border-t border-border pt-2">
+          <span className="flex-1 text-[10px] text-zinc-500">
+            {status.missing} model {status.missing === 1 ? 'file' : 'files'} to download
+          </span>
+          {onGetModels && (
+            <button
+              onClick={onGetModels}
+              className="rounded px-1.5 py-0.5 text-[10px] text-zinc-400 hover:bg-panel hover:text-zinc-200"
+            >
+              Get models
+            </button>
+          )}
+        </div>
+      )}
+      {status?.note && (
+        <p className="mt-2 border-t border-border pt-2 text-[10px] text-zinc-500">{status.note}</p>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/views/Moodboard/GettingStarted/StarterCard.tsx
+++ b/src/renderer/views/Moodboard/GettingStarted/StarterCard.tsx
@@ -1,11 +1,22 @@
+import type { StarterRecipe } from '../../../lib/starterRecipes'
 import type { Advice, Tier } from '../../../lib/vramAdvice'
 
 /** Tier colours. Amber is as loud as this gets, because every tier still runs. */
 const TIER_STYLE: Record<Tier, { chip: string; label: string }> = {
-  best: { chip: 'bg-emerald-500/15 text-emerald-300', label: 'Runs great' },
-  good: { chip: 'bg-emerald-500/10 text-emerald-400/90', label: 'Runs well' },
-  ok: { chip: 'bg-sky-500/10 text-sky-300', label: 'Runs' },
-  heavy: { chip: 'bg-amber-500/10 text-amber-300', label: 'Heavy' },
+  best: { chip: 'bg-emerald-500/15 text-emerald-200', label: 'Runs great' },
+  good: { chip: 'bg-emerald-500/10 text-emerald-300', label: 'Runs well' },
+  ok: { chip: 'bg-sky-500/15 text-sky-200', label: 'Runs' },
+  heavy: { chip: 'bg-amber-500/15 text-amber-200', label: 'Heavy' },
+}
+
+/**
+ * One hue per kind of generation, so the list is scannable before it is read. Deliberately clear of
+ * the emerald/sky/amber the tier chips already own, and of the yellow-green accent.
+ */
+const KIND_STYLE: Record<StarterRecipe['kind'], { tile: string; label: string; text: string }> = {
+  image: { tile: 'bg-indigo-500/15 text-indigo-300', label: 'Image', text: 'text-indigo-300' },
+  video: { tile: 'bg-fuchsia-500/15 text-fuchsia-300', label: 'Video', text: 'text-fuchsia-300' },
+  training: { tile: 'bg-teal-500/15 text-teal-300', label: 'Training', text: 'text-teal-300' },
 }
 
 export interface CardStatus {
@@ -15,77 +26,121 @@ export interface CardStatus {
   note: string | null
 }
 
-/** One getting-started card: presentational, reports clicks upward. */
+const CHIP = 'shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium leading-none'
+
+/** One getting-started card: a compact row, presentational, reports clicks upward. */
 export function StarterCard({
   icon,
   title,
+  tag,
+  kind,
   blurb,
   advice,
   recommended,
   recommendedLabel,
   status,
+  action,
   onPick,
   onGetModels,
   disabled = false,
 }: {
   icon: React.JSX.Element
   title: string
+  /** Short chip beside the title, e.g. `New`. */
+  tag?: string
+  kind: StarterRecipe['kind']
   blurb: string
   advice: Advice
   recommended: boolean
   recommendedLabel: string
   /** Null while the install state is still unknown, so nothing flashes on first paint. */
   status: CardStatus | null
+  /** A one-off setup step this card needs, shown in the same slot as the model downloads. */
+  action?: { hint: string; label: string; onClick: () => void }
   onPick: () => void
   onGetModels?: () => void
   disabled?: boolean
 }): React.JSX.Element {
   const tier = advice.tier ? TIER_STYLE[advice.tier] : null
+  const kindStyle = KIND_STYLE[kind]
   return (
     <div
-      className={`relative flex flex-col rounded-lg border bg-surface/80 p-3 text-left transition ${
-        recommended ? 'border-accent/60' : 'border-border'
-      } ${disabled ? 'opacity-50' : 'hover:border-zinc-500'}`}
+      className={`group flex items-center gap-3 rounded-lg border bg-surface/95 px-3 py-2.5 text-left shadow-sm backdrop-blur transition ${
+        recommended ? 'border-accent/50' : 'border-border'
+      } ${disabled ? 'opacity-50' : 'hover:border-zinc-500 hover:bg-surface'}`}
     >
-      {recommended && (
-        <span className="absolute -top-2 left-3 rounded-full bg-accent px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-black">
-          {recommendedLabel}
-        </span>
-      )}
       <button
         onClick={onPick}
         disabled={disabled}
-        className="flex flex-col gap-1.5 text-left disabled:cursor-not-allowed"
+        className="flex min-w-0 flex-1 items-center gap-3 text-left disabled:cursor-not-allowed"
       >
-        <span className="flex items-center gap-2">
-          <span className="text-zinc-400">{icon}</span>
-          <span className="text-sm font-medium text-zinc-100">{title}</span>
-          {tier && (
-            <span className={`rounded px-1.5 py-0.5 text-[9px] font-medium ${tier.chip}`}>
-              {tier.label}
+        <span
+          className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-md ${kindStyle.tile}`}
+        >
+          {icon}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex flex-wrap items-center gap-1.5">
+            <span className="text-sm font-semibold leading-tight text-zinc-50">{title}</span>
+            {/* Solid accent for `New`, outlined for the recommendation: on a card that is both,
+                one has to win, and `New` is the thing worth noticing. */}
+            {tag && <span className={`${CHIP} bg-accent font-semibold text-black`}>{tag}</span>}
+            {tier && <span className={`${CHIP} ${tier.chip}`}>{tier.label}</span>}
+            {/* Inline, not a floating ribbon: the cards stack tightly and an overhanging badge
+                would sit on top of the card above it. */}
+            {recommended && (
+              <span className={`${CHIP} border border-accent/40 bg-accent/10 text-accent`}>
+                {recommendedLabel}
+              </span>
+            )}
+          </span>
+          <span className="mt-1 block text-xs leading-snug text-zinc-300">{blurb}</span>
+          <span className="mt-0.5 block text-[11px] leading-snug text-zinc-400">
+            <span className={`font-semibold uppercase tracking-wide ${kindStyle.text}`}>
+              {kindStyle.label}
+            </span>
+            <span className="text-zinc-600"> · </span>
+            {advice.note}
+          </span>
+          {status?.note && (
+            <span className="mt-0.5 block text-[11px] leading-snug text-amber-200/80">
+              {status.note}
             </span>
           )}
         </span>
-        <span className="text-[11px] leading-relaxed text-zinc-400">{blurb}</span>
-        <span className="text-[10px] leading-relaxed text-zinc-500">{advice.note}</span>
       </button>
       {status && status.missing > 0 && (
-        <div className="mt-2 flex items-center gap-2 border-t border-border pt-2">
-          <span className="flex-1 text-[10px] text-zinc-500">
-            {status.missing} model {status.missing === 1 ? 'file' : 'files'} to download
-          </span>
-          {onGetModels && (
-            <button
-              onClick={onGetModels}
-              className="rounded px-1.5 py-0.5 text-[10px] text-zinc-400 hover:bg-panel hover:text-zinc-200"
-            >
-              Get models
-            </button>
-          )}
-        </div>
+        <FooterAction
+          hint={`${status.missing} ${status.missing === 1 ? 'file' : 'files'}`}
+          label="Get models"
+          onClick={onGetModels}
+        />
       )}
-      {status?.note && (
-        <p className="mt-2 border-t border-border pt-2 text-[10px] text-zinc-500">{status.note}</p>
+      {action && <FooterAction hint={action.hint} label={action.label} onClick={action.onClick} />}
+    </div>
+  )
+}
+
+/** The right-hand setup slot: what is missing, and the one button that fixes it. */
+function FooterAction({
+  hint,
+  label,
+  onClick,
+}: {
+  hint: string
+  label: string
+  onClick?: () => void
+}): React.JSX.Element {
+  return (
+    <div className="flex shrink-0 items-center gap-2 self-stretch border-l border-border pl-3">
+      <span className="text-[11px] text-zinc-400">{hint}</span>
+      {onClick && (
+        <button
+          onClick={onClick}
+          className="rounded border border-border px-2 py-1 text-[11px] font-medium text-zinc-200 transition hover:border-zinc-500 hover:bg-panel"
+        >
+          {label}
+        </button>
       )}
     </div>
   )

--- a/src/renderer/views/Moodboard/GettingStarted/StarterCards.tsx
+++ b/src/renderer/views/Moodboard/GettingStarted/StarterCards.tsx
@@ -1,0 +1,101 @@
+/**
+ * What a new project shows instead of an empty canvas: four ways to start, each saying how it will
+ * run on this machine, each one click away from a working graph.
+ *
+ * The overlay stays `pointer-events-none` so dragging an asset onto an empty canvas still reaches
+ * the ReactFlow pane underneath; only the card grid takes pointer events.
+ */
+import { useEffect, useMemo } from 'react'
+
+import { STARTER_RECIPES } from '../../../lib/starterRecipes'
+import { pickRecommended, readVram, recommendedLabel, tierFor } from '../../../lib/vramAdvice'
+import type { StarterKey } from '../../../lib/vramAdvice'
+import { useCoreNodesStore } from '../../../store/coreNodesStore'
+import { useModelRequirementsStore } from '../../../store/modelRequirementsStore'
+import { useTrainingStore } from '../../../store/trainingStore'
+import { BoxIcon, WandIcon } from '../nodes/NodeBadge'
+import { StarterCard, type CardStatus } from './StarterCard'
+
+const ICONS: Record<StarterKey, React.JSX.Element> = {
+  zimage: <WandIcon className="h-4 w-4" />,
+  flux2: <WandIcon className="h-4 w-4" />,
+  krea2: <WandIcon className="h-4 w-4" />,
+  training: <BoxIcon className="h-4 w-4" />,
+}
+
+export function StarterCards({ onPick }: { onPick: (key: StarterKey) => void }): React.JSX.Element {
+  const stats = useTrainingStore((s) => s.systemStats)
+  const byType = useModelRequirementsStore((s) => s.byType)
+  const loadReqs = useModelRequirementsStore((s) => s.load)
+  const openReqs = useModelRequirementsStore((s) => s.open)
+  const descriptors = useCoreNodesStore((s) => s.descriptors)
+  const registryVersion = useCoreNodesStore((s) => s.registryVersion)
+
+  const reading = useMemo(() => readVram(stats), [stats])
+  const recommended = useMemo(() => pickRecommended(reading), [reading])
+  const label = recommendedLabel(reading)
+
+  // Requirements are a filesystem stat in Core, so this is cheap and needs no node on the canvas.
+  // Re-run on registryVersion: a dropped-in file or a finished download bumps it.
+  useEffect(() => {
+    for (const recipe of STARTER_RECIPES) if (recipe.coreType) void loadReqs(recipe.coreType)
+  }, [loadReqs, registryVersion])
+
+  const known = useMemo(() => new Set(descriptors.map((d) => d.type)), [descriptors])
+  // Core may not have answered yet. Show the cards muted rather than letting the layout jump.
+  const engineReady = descriptors.length > 0
+
+  const statusFor = (coreType: string | null): CardStatus | null => {
+    if (!coreType) return null
+    const reqs = byType[coreType]
+    if (!reqs) return null
+    const missing = reqs.components.filter((c) => !c.present && !c.optional).length
+    // The engine's estimate sizes what is on disk, so it only means anything once installed.
+    const note = reqs.allPresent ? (reqs.estimate?.warning ?? null) : null
+    return { missing, note }
+  }
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center p-6">
+      <div className="pointer-events-auto flex w-full max-w-3xl flex-col gap-3">
+        <div className="text-center">
+          <p className="text-sm font-medium text-zinc-200">Start with a model</p>
+          <p className="mt-1 text-xs text-zinc-500">
+            {reading.state === 'pending'
+              ? 'Checking your hardware'
+              : reading.state === 'unknown'
+                ? 'Could not read GPU memory, so these show their usual requirements.'
+                : `Matched to your ${reading.name}, ${reading.totalGb.toFixed(0)} GB.`}
+          </p>
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {STARTER_RECIPES.map((recipe) => {
+            const unavailable =
+              recipe.coreType != null && engineReady && !known.has(recipe.coreType)
+            if (unavailable) return null
+            return (
+              <StarterCard
+                key={recipe.key}
+                icon={ICONS[recipe.key]}
+                title={recipe.title}
+                blurb={recipe.blurb}
+                advice={tierFor(recipe.key, reading)}
+                recommended={recipe.key === recommended}
+                recommendedLabel={label}
+                status={statusFor(recipe.coreType)}
+                onPick={() => onPick(recipe.key)}
+                onGetModels={
+                  recipe.coreType ? () => openReqs(recipe.coreType as string) : undefined
+                }
+                disabled={recipe.coreType != null && !engineReady}
+              />
+            )
+          })}
+        </div>
+        <p className="text-center text-[10px] text-zinc-600">
+          Or drag an asset from the Assets panel to start from an image.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/views/Moodboard/GettingStarted/StarterCards.tsx
+++ b/src/renderer/views/Moodboard/GettingStarted/StarterCards.tsx
@@ -11,16 +11,21 @@ import { STARTER_RECIPES } from '../../../lib/starterRecipes'
 import { pickRecommended, readVram, recommendedLabel, tierFor } from '../../../lib/vramAdvice'
 import type { StarterKey } from '../../../lib/vramAdvice'
 import { useCoreNodesStore } from '../../../store/coreNodesStore'
+import { useFalSettingsStore } from '../../../store/falSettingsStore'
 import { useModelRequirementsStore } from '../../../store/modelRequirementsStore'
 import { useTrainingStore } from '../../../store/trainingStore'
-import { BoxIcon, WandIcon } from '../nodes/NodeBadge'
+import { useUiStore } from '../../../store/uiStore'
+import { LayersIcon, VideoGlyph, WandIcon } from '../nodes/NodeBadge'
 import { StarterCard, type CardStatus } from './StarterCard'
 
+// The glyph reinforces the kind colour: a wand for image generation, a camera for video, a stack
+// for the dataset that training starts from.
 const ICONS: Record<StarterKey, React.JSX.Element> = {
   zimage: <WandIcon className="h-4 w-4" />,
   flux2: <WandIcon className="h-4 w-4" />,
   krea2: <WandIcon className="h-4 w-4" />,
-  training: <BoxIcon className="h-4 w-4" />,
+  api: <VideoGlyph className="h-4 w-4" />,
+  training: <LayersIcon className="h-4 w-4" />,
 }
 
 export function StarterCards({ onPick }: { onPick: (key: StarterKey) => void }): React.JSX.Element {
@@ -30,6 +35,11 @@ export function StarterCards({ onPick }: { onPick: (key: StarterKey) => void }):
   const openReqs = useModelRequirementsStore((s) => s.open)
   const descriptors = useCoreNodesStore((s) => s.descriptors)
   const registryVersion = useCoreNodesStore((s) => s.registryVersion)
+  const falConfigured = useFalSettingsStore((s) => s.configured)
+  const loadFalStatus = useFalSettingsStore((s) => s.load)
+  const setSettingsOpen = useUiStore((s) => s.setSettingsOpen)
+
+  useEffect(() => void loadFalStatus(), [loadFalStatus])
 
   const reading = useMemo(() => readVram(stats), [stats])
   const recommended = useMemo(() => pickRecommended(reading), [reading])
@@ -57,10 +67,10 @@ export function StarterCards({ onPick }: { onPick: (key: StarterKey) => void }):
 
   return (
     <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center p-6">
-      <div className="pointer-events-auto flex w-full max-w-3xl flex-col gap-3">
+      <div className="pointer-events-auto flex w-full max-w-2xl flex-col gap-3">
         <div className="text-center">
-          <p className="text-sm font-medium text-zinc-200">Start with a model</p>
-          <p className="mt-1 text-xs text-zinc-500">
+          <p className="text-base font-semibold text-zinc-50">Start with a model</p>
+          <p className="mt-1 text-xs text-zinc-400">
             {reading.state === 'pending'
               ? 'Checking your hardware'
               : reading.state === 'unknown'
@@ -68,7 +78,7 @@ export function StarterCards({ onPick }: { onPick: (key: StarterKey) => void }):
                 : `Matched to your ${reading.name}, ${reading.totalGb.toFixed(0)} GB.`}
           </p>
         </div>
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="flex flex-col gap-2">
           {STARTER_RECIPES.map((recipe) => {
             const unavailable =
               recipe.coreType != null && engineReady && !known.has(recipe.coreType)
@@ -78,11 +88,22 @@ export function StarterCards({ onPick }: { onPick: (key: StarterKey) => void }):
                 key={recipe.key}
                 icon={ICONS[recipe.key]}
                 title={recipe.title}
+                tag={recipe.tag}
+                kind={recipe.kind}
                 blurb={recipe.blurb}
                 advice={tierFor(recipe.key, reading)}
                 recommended={recipe.key === recommended}
                 recommendedLabel={label}
                 status={statusFor(recipe.coreType)}
+                action={
+                  recipe.falModelId && !falConfigured
+                    ? {
+                        hint: 'Needs a fal API key',
+                        label: 'Add key',
+                        onClick: () => setSettingsOpen(true),
+                      }
+                    : undefined
+                }
                 onPick={() => onPick(recipe.key)}
                 onGetModels={
                   recipe.coreType ? () => openReqs(recipe.coreType as string) : undefined
@@ -92,7 +113,7 @@ export function StarterCards({ onPick }: { onPick: (key: StarterKey) => void }):
             )
           })}
         </div>
-        <p className="text-center text-[10px] text-zinc-600">
+        <p className="text-center text-[11px] text-zinc-500">
           Or drag an asset from the Assets panel to start from an image.
         </p>
       </div>

--- a/src/renderer/views/Moodboard/GettingStarted/useStarterGraph.ts
+++ b/src/renderer/views/Moodboard/GettingStarted/useStarterGraph.ts
@@ -1,0 +1,96 @@
+/**
+ * Turns a starter-card click into a built, selected, framed graph with the hints armed.
+ *
+ * The selection step is not cosmetic. The Run pill only mounts while its node is the selected
+ * graph's run target, and `toNodes` rebuilds every node without `selected` whenever `items`
+ * changes, so selecting has to happen *after* the new items land. Hence the pending ref plus an
+ * effect keyed on items rather than a straight call.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { Node } from '@xyflow/react'
+
+import { buildStarterGraph } from '../../../lib/starterGraph'
+import { recipeFor } from '../../../lib/starterRecipes'
+import type { StarterKey } from '../../../lib/vramAdvice'
+import { useModelRequirementsStore } from '../../../store/modelRequirementsStore'
+import { useMoodboardStore } from '../../../store/moodboardStore'
+import { useOnboardingStore } from '../../../store/onboardingStore'
+import { useUiStore } from '../../../store/uiStore'
+
+interface Options {
+  setNodes: React.Dispatch<React.SetStateAction<Node[]>>
+  fitView: (opts: {
+    nodes: { id: string }[]
+    padding: number
+    maxZoom: number
+    duration: number
+  }) => void
+  centre: () => { x: number; y: number }
+}
+
+export function useStarterGraph({ setNodes, fitView, centre }: Options): {
+  onPick: (key: StarterKey) => void
+  building: boolean
+} {
+  const items = useMoodboardStore((s) => s.items)
+  const [building, setBuilding] = useState(false)
+  // Ids waiting to be selected once they appear in `items`.
+  const pending = useRef<string[] | null>(null)
+  // Node the hints should point at, held back until its models are installed.
+  const deferred = useRef<{ itemId: string; coreType: string } | null>(null)
+
+  useEffect(() => {
+    const ids = pending.current
+    if (!ids || !ids.every((id) => items.some((i) => i.id === id))) return
+    pending.current = null
+    setNodes((nodes) => nodes.map((n) => ({ ...n, selected: ids.includes(n.id) })))
+    fitView({ nodes: ids.map((id) => ({ id })), padding: 0.35, maxZoom: 1, duration: 400 })
+  }, [items, setNodes, fitView])
+
+  // Models can take a long time to download, and a Run hint is useless until Run works. So the
+  // hint waits for the requirements to report everything present.
+  const byType = useModelRequirementsStore((s) => s.byType)
+  useEffect(() => {
+    const held = deferred.current
+    if (!held) return
+    if (!byType[held.coreType]?.allPresent) return
+    deferred.current = null
+    useOnboardingStore.getState().armHints({ itemId: held.itemId, surface: 'studio' })
+  }, [byType])
+
+  const onPick = useCallback(
+    (key: StarterKey): void => {
+      if (building) return
+      const recipe = recipeFor(key)
+      if (!recipe) return
+
+      // Training lives on its own canvas, which seeds its own graph when empty.
+      if (!recipe.coreType) {
+        useUiStore.getState().setActiveTab('trainer')
+        return
+      }
+
+      setBuilding(true)
+      const coreType = recipe.coreType
+      void buildStarterGraph(recipe, centre())
+        .then((ids) => {
+          if (ids.length !== 2) return
+          pending.current = ids
+          const genId = ids[1]
+          const ready = useModelRequirementsStore.getState().byType[coreType]?.allPresent
+          if (ready) {
+            useOnboardingStore.getState().armHints({ itemId: genId, surface: 'studio' })
+          } else {
+            // The graph is the durable artifact, so it is built either way; the download popup
+            // opens on top and the hints wait behind it.
+            deferred.current = { itemId: genId, coreType }
+            useModelRequirementsStore.getState().open(coreType)
+          }
+        })
+        .finally(() => setBuilding(false))
+    },
+    [building, centre],
+  )
+
+  return { onPick, building }
+}

--- a/src/renderer/views/Moodboard/GettingStarted/useStarterGraph.ts
+++ b/src/renderer/views/Moodboard/GettingStarted/useStarterGraph.ts
@@ -12,6 +12,7 @@ import type { Node } from '@xyflow/react'
 import { buildStarterGraph } from '../../../lib/starterGraph'
 import { recipeFor } from '../../../lib/starterRecipes'
 import type { StarterKey } from '../../../lib/vramAdvice'
+import { useFalSettingsStore } from '../../../store/falSettingsStore'
 import { useModelRequirementsStore } from '../../../store/modelRequirementsStore'
 import { useMoodboardStore } from '../../../store/moodboardStore'
 import { useOnboardingStore } from '../../../store/onboardingStore'
@@ -65,7 +66,7 @@ export function useStarterGraph({ setNodes, fitView, centre }: Options): {
       if (!recipe) return
 
       // Training lives on its own canvas, which seeds its own graph when empty.
-      if (!recipe.coreType) {
+      if (!recipe.coreType && !recipe.falModelId) {
         useUiStore.getState().setActiveTab('trainer')
         return
       }
@@ -77,6 +78,15 @@ export function useStarterGraph({ setNodes, fitView, centre }: Options): {
           if (ids.length !== 2) return
           pending.current = ids
           const genId = ids[1]
+          if (!coreType) {
+            // Hosted models have nothing to download. The key is the only thing that can be
+            // missing, and Settings is where it goes, so open that instead of a model popup.
+            useOnboardingStore.getState().armHints({ itemId: genId, surface: 'studio' })
+            if (!useFalSettingsStore.getState().configured) {
+              useUiStore.getState().setSettingsOpen(true)
+            }
+            return
+          }
           const ready = useModelRequirementsStore.getState().byType[coreType]?.allPresent
           if (ready) {
             useOnboardingStore.getState().armHints({ itemId: genId, surface: 'studio' })

--- a/src/renderer/views/Moodboard/ModelInfoPanel.tsx
+++ b/src/renderer/views/Moodboard/ModelInfoPanel.tsx
@@ -8,14 +8,16 @@ const KIND_LABEL: Record<PortKind, string> = {
   image: 'Image',
   'image[]': 'Images',
   video: 'Video',
+  'video[]': 'Videos',
   audio: 'Audio',
+  'audio[]': 'Audio',
   text: 'Text',
   path: 'File',
 }
 
 function KindIcon({ kind }: { kind: PortKind }): React.JSX.Element {
-  if (kind === 'video') return <VideoGlyph className="h-4 w-4" />
-  if (kind === 'audio') return <AudioGlyph className="h-4 w-4" />
+  if (kind === 'video' || kind === 'video[]') return <VideoGlyph className="h-4 w-4" />
+  if (kind === 'audio' || kind === 'audio[]') return <AudioGlyph className="h-4 w-4" />
   if (kind === 'text') return <span className="text-sm font-bold leading-none">T</span>
   return <ImageGlyph className="h-4 w-4" />
 }

--- a/src/renderer/views/Moodboard/MoodboardPanel.tsx
+++ b/src/renderer/views/Moodboard/MoodboardPanel.tsx
@@ -69,6 +69,9 @@ import { DeletableEdge } from './edges/DeletableEdge'
 import { SideMenu } from './SideMenu'
 import { CanvasToolbar } from './CanvasToolbar'
 import { AddNodeMenu, type AddNodeKind } from './AddNodeMenu'
+import { FirstRunHints } from './GettingStarted/FirstRunHints'
+import { StarterCards } from './GettingStarted/StarterCards'
+import { useStarterGraph } from './GettingStarted/useStarterGraph'
 import { Modal } from '../../components/Modal'
 import { readRecipeFromBlob, type Recipe } from '../../lib/pngRecipe'
 import { buildGraphFromRecipe } from '../../lib/recipeGraph'
@@ -603,6 +606,9 @@ function Board(): React.JSX.Element {
     return screenToFlowPosition({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 })
   }
 
+  const loading = useMoodboardStore((s) => s.loading)
+  const { onPick: onPickStarter } = useStarterGraph({ setNodes, fitView, centre })
+
   /** The topmost layer whose rectangle contains an absolute flow point (or null). */
   const layerAt = (pos: { x: number; y: number }, exceptId?: string): MoodboardItem | null => {
     const hit = items
@@ -1080,7 +1086,10 @@ function Board(): React.JSX.Element {
           <Background gap={22} size={2.5} color="#525a66" />
         </ReactFlow>
 
-        {items.length === 0 && <EmptyCanvasHint />}
+        {/* Gate on loading too: items is briefly empty while the board loads, and the cards
+            flashing in and out reads as a glitch. */}
+        {items.length === 0 && !loading && <StarterCards onPick={onPickStarter} />}
+        <FirstRunHints wrapperRef={wrapperRef} />
 
         {genError && <GenErrorToast message={genError} onDismiss={() => setGenError(null)} />}
 
@@ -1245,34 +1254,6 @@ function GenErrorToast({
   )
 }
 
-/** Centered hint shown over an empty canvas. Non-interactive so it never blocks drops. */
-function EmptyCanvasHint(): React.JSX.Element {
-  return (
-    <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
-      <div className="flex max-w-sm flex-col items-center gap-2 text-center">
-        <svg
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="h-9 w-9 text-zinc-600"
-        >
-          <rect x="3" y="3" width="18" height="18" rx="2" />
-          <circle cx="8.5" cy="8.5" r="1.5" />
-          <path d="m21 15-4.5-4.5L7 20" />
-        </svg>
-        <p className="text-sm font-medium text-zinc-300">Your canvas is empty</p>
-        <p className="text-xs leading-relaxed text-zinc-500">
-          Drag an asset from the Assets panel onto the canvas to create your first frame.
-        </p>
-      </div>
-    </div>
-  )
-}
-
-/** Map items to React Flow nodes - layers first so they precede their children. */
 function toNodes(
   items: MoodboardItem[],
   assetsById: Map<

--- a/src/renderer/views/Moodboard/MoodboardPanel.tsx
+++ b/src/renderer/views/Moodboard/MoodboardPanel.tsx
@@ -27,6 +27,8 @@ import { importFilesToLibrary, importMediaUrlToLibrary } from '@/lib/importFiles
 import { copyText } from '@/lib/clipboard'
 import type { MoodboardItem, MoodboardConnector, TextItemData, Frame, Asset } from '@shared/types'
 import { portKindColor, portsSatisfy, type NodeDescriptor, type PortKind } from '@shared/coreNodes'
+import { getNodeDef } from '@shared/nodes/registry'
+import { portIdForHandle } from '@shared/nodes/handles'
 import { useMoodboardStore } from '../../store/moodboardStore'
 import { useProjectStore } from '../../store/projectStore'
 import { useCoreNodesStore } from '../../store/coreNodesStore'
@@ -304,6 +306,7 @@ function Board(): React.JSX.Element {
   const undo = useMoodboardStore((s) => s.undo)
   const redo = useMoodboardStore((s) => s.redo)
   const addSourceInput = useFrameStore((s) => s.addSourceInput)
+  const addInputs = useFrameStore((s) => s.addInputs)
   const setHero = useFrameStore((s) => s.setHero)
   const genError = useGenerationStore((s) => s.error)
   const setGenError = useGenerationStore((s) => s.setError)
@@ -677,14 +680,24 @@ function Board(): React.JSX.Element {
 
     void connect(c.source, c.target, c.sourceHandle ?? null, c.targetHandle ?? null)
 
-    // Output → Frame/GenNode input ('in', or a GenNode's 'audio' dot): also wire the data flow-link
-    // (the DAG edge). The target frame takes the source's frame - a frame/GenNode directly, or the
-    // frame feeding a Preview - as a live input, resolved to that frame's hero take at generate time.
-    if (
-      tgt?.type === 'frame' &&
-      (c.targetHandle === 'in' || c.targetHandle === 'audio') &&
-      tgt.frameId
-    ) {
+    // Output → Frame/GenNode media input: also wire the data flow-link (the DAG edge). The target
+    // frame takes the source's frame - a frame/GenNode directly, or the frame feeding a Preview - as
+    // a live input, resolved to that frame's hero take at generate time. Everything but the 'prompt'
+    // dot is a media input; the input records which port it landed on, so a model with two ports of
+    // one kind (start vs end keyframe) can tell them apart.
+    if (tgt?.type === 'frame' && c.targetHandle !== 'prompt' && tgt.frameId) {
+      const tgtFrame = frames.find((f) => f.id === tgt.frameId)
+      const tgtDef = tgtFrame?.modelId ? getNodeDef(tgtFrame.modelId) : undefined
+      const handle = tgtDef ? portIdForHandle(tgtDef, c.targetHandle) : null
+      // A library source contributes the assets themselves: a Load Assets node all of its own, a
+      // single asset node itself. Without this the edge drew but no input row was written, so the
+      // node looked wired and generated from nothing.
+      const assetIds =
+        src?.type === 'loader' ? (src.data?.assetIds ?? []) : src?.assetId ? [src.assetId] : []
+      if (assetIds.length > 0) {
+        void addInputs(tgt.frameId, assetIds, handle)
+        return
+      }
       let sourceFrameId: string | undefined
       if (src?.type === 'frame') {
         sourceFrameId = src.frameId ?? undefined
@@ -695,7 +708,7 @@ function Board(): React.JSX.Element {
           : undefined
       }
       if (sourceFrameId && sourceFrameId !== tgt.frameId) {
-        void addSourceInput(tgt.frameId, sourceFrameId)
+        void addSourceInput(tgt.frameId, sourceFrameId, handle)
       }
     }
     // Wiring into a Director node's input handle just persists the connector (above); the

--- a/src/renderer/views/Moodboard/ParamWidget.tsx
+++ b/src/renderer/views/Moodboard/ParamWidget.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react'
 import type { ParamField } from '@shared/nodes/types'
 
 /**
@@ -60,19 +61,14 @@ export function ParamWidget({
   }
   if (field.widget === 'number') {
     return (
-      <label className="flex flex-col gap-1">
-        <span className={labelCls}>{field.label}</span>
-        <input
-          type="number"
-          value={Number(value ?? field.default)}
-          min={field.min}
-          max={field.max}
-          step={field.step}
-          onChange={(e) => onChange(Number(e.target.value))}
-          onBlur={() => onCommit(Number(value ?? field.default))}
-          className={inputCls}
-        />
-      </label>
+      <NumberField
+        field={field}
+        value={value}
+        onChange={onChange}
+        onCommit={onCommit}
+        inputCls={inputCls}
+        labelCls={labelCls}
+      />
     )
   }
   return (
@@ -86,4 +82,83 @@ export function ParamWidget({
       />
     </label>
   )
+}
+
+/**
+ * Number input that keeps a free-form text *draft* while the user types, so the box can be cleared
+ * entirely and edited mid-value (a bare controlled `Number()` snaps an empty box to 0, trapping you
+ * into editing around it). The draft resolves on blur: empty or unparseable falls back to the
+ * field's default, anything else commits parsed and clamped to the declared range.
+ *
+ * Mirrors `CoreParamWidget`'s NumberField; the two panels stay separate because their field schemas
+ * are different types.
+ */
+function NumberField({
+  field,
+  value,
+  onChange,
+  onCommit,
+  inputCls,
+  labelCls,
+}: {
+  field: Extract<ParamField, { widget: 'number' }>
+  value: unknown
+  onChange: (v: number) => void
+  onCommit: (v: number) => void
+  inputCls: string
+  labelCls: string
+}): React.JSX.Element {
+  const external = value ?? field.default
+  const [draft, setDraft] = useState<string>(external == null ? '' : String(external))
+  // Re-seed when the committed value changes from outside (the panel switching to another node),
+  // but never while the user is mid-edit of this same value.
+  const lastExternal = useRef(external)
+  useEffect(() => {
+    if (external !== lastExternal.current) {
+      lastExternal.current = external
+      setDraft(external == null ? '' : String(external))
+    }
+  }, [external])
+
+  // Emit while typing so an outside click that persists the panel picks up the edit. Unclamped
+  // here, so typing "1" on the way to "12" is not yanked up to a minimum of 5.
+  const emit = (raw: string): void => {
+    setDraft(raw)
+    if (raw.trim() === '') return
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed)) {
+      lastExternal.current = parsed
+      onChange(parsed)
+    }
+  }
+
+  const commit = (): void => {
+    const parsed = draft.trim() === '' ? Number(field.default) : Number(draft)
+    const resolved = Number.isFinite(parsed) ? clamp(parsed, field.min, field.max) : field.default
+    lastExternal.current = resolved
+    setDraft(String(resolved))
+    onCommit(resolved)
+  }
+
+  return (
+    <label className="flex flex-col gap-1">
+      <span className={labelCls}>{field.label}</span>
+      <input
+        type="number"
+        value={draft}
+        min={field.min}
+        max={field.max}
+        step={field.step}
+        onChange={(e) => emit(e.target.value)}
+        onBlur={commit}
+        className={inputCls}
+      />
+    </label>
+  )
+}
+
+function clamp(n: number, min?: number, max?: number): number {
+  if (min != null && n < min) return min
+  if (max != null && n > max) return max
+  return n
 }

--- a/src/renderer/views/Moodboard/edges/DeletableEdge.tsx
+++ b/src/renderer/views/Moodboard/edges/DeletableEdge.tsx
@@ -12,8 +12,18 @@ import { useCanvasPrefsStore } from '../../../store/canvasPrefsStore'
  * A connector that highlights when clicked and shows a ✕ button at its midpoint to
  * remove the link between two nodes. `data.functional` distinguishes the animated
  * output→preview wire (indigo) from purely-visual frame links (gray).
+ *
+ * The Studio and Trainer canvases keep separate stores, and React Flow builds edges from a type map
+ * and cannot pass props. So the drawing lives in `DeletableEdgeBody`, which takes `disconnect`
+ * explicitly, and each canvas wraps it with its own store. One implementation, two thin wrappers.
  */
 export function DeletableEdge(props: EdgeProps): React.JSX.Element {
+  return <DeletableEdgeBody {...props} disconnect={useMoodboardStore((s) => s.disconnect)} />
+}
+
+export function DeletableEdgeBody(
+  props: EdgeProps & { disconnect: (id: string) => void | Promise<void> },
+): React.JSX.Element {
   const {
     id,
     sourceX,
@@ -25,8 +35,8 @@ export function DeletableEdge(props: EdgeProps): React.JSX.Element {
     markerEnd,
     selected,
     data,
+    disconnect,
   } = props
-  const disconnect = useMoodboardStore((s) => s.disconnect)
   // Line style is a live canvas preference - every edge subscribes, so switching it in Settings
   // restyles all connectors at once. `angled` = cornered (smooth step); `wave` = curved (bezier).
   const edgeStyle = useCanvasPrefsStore((s) => s.edgeStyle)

--- a/src/renderer/views/Moodboard/nodes/GenNode.tsx
+++ b/src/renderer/views/Moodboard/nodes/GenNode.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react'
 import { Handle, Position, type NodeProps } from '@xyflow/react'
 import { takeWaveformPath } from '@shared/media'
 import { getNodeDef } from '@shared/nodes/registry'
-import { formatPrice } from '@shared/nodes/types'
+import { dotPorts, handleIdForPort, portIdForHandle } from '@shared/nodes/handles'
+import { formatPrice, mediaFamily } from '@shared/nodes/types'
 import { useFrameStore } from '../../../store/frameStore'
 import { useAssetStore } from '../../../store/assetStore'
 import { useMoodboardStore } from '../../../store/moodboardStore'
@@ -149,30 +150,37 @@ export function GenNode({ id, data, selected }: NodeProps): React.JSX.Element {
   // The node's wired/dropped inputs, resolved to thumbnails (same as the Frame node). Shown as a
   // strip at the top so dropping several images one-by-one visibly accumulates and each is removable.
   const inputThumbs = resolveInputThumbs(inputs, { assets, allFrames, takesByFrame, inputsByFrame })
-  // Input dots are driven by the model's API: each only shows when the model actually takes that
-  // kind of input. The media dot is typed to match (image vs video); audio gets its own dot.
-  const imageInput = def.inputs.some((p) => p.kind === 'image' || p.kind === 'image[]')
-  const videoInput = def.inputs.some((p) => p.kind === 'video')
-  const audioInput = def.inputs.some((p) => p.kind === 'audio')
-  const wantsMedia = imageInput || videoInput
-  const mediaIsVideo = videoInput && !imageInput
-  const requiresMedia = def.inputs.some(
-    (p) => p.required && (p.kind === 'image' || p.kind === 'image[]' || p.kind === 'video'),
+  // Caption a thumb with its port only when the model has more than one dot to tell apart.
+  const portLabels = new Map(
+    def.inputs.length > 1
+      ? inputs.flatMap((i) => {
+          const port = def.inputs.find((p) => p.id === i.handle)
+          return port ? [[i.id, port.label] as const] : []
+        })
+      : [],
   )
-  const requiresAudio = def.inputs.some((p) => p.required && p.kind === 'audio')
+  // Input dots are driven by the model's API: one dot per declared input port, so a model with two
+  // image inputs (a start and an end keyframe) gets two dots the user can tell apart.
+  const ports = dotPorts(def)
   const hasPrompt = connectors.some(
     (c) => c.toItemId === id && (c.data?.targetHandle as string | undefined) === 'prompt',
   )
-  // Coarse: inputs aren't tagged by kind, so we only nudge when nothing is wired at all.
-  const requiredKinds = [
-    ...(requiresMedia ? [mediaIsVideo ? 'video' : 'image'] : []),
-    ...(requiresAudio ? ['audio'] : []),
-  ]
+  const wiredHandles = new Set(
+    connectors
+      .filter((c) => c.toItemId === id)
+      .map((c) => portIdForHandle(def, c.data?.targetHandle as string | undefined))
+      .filter((p): p is string => !!p),
+  )
+  // A required port counts as satisfied by anything untagged too: dropped inputs carry no port.
+  const untagged = inputs.some((i) => !i.handle)
+  const unmet = ports.filter(
+    (p) => p.required && !wiredHandles.has(p.id) && !inputs.some((i) => i.handle === p.id),
+  )
   const missing =
     !hasPrompt && !def.promptOptional
       ? 'Connect a Prompt node'
-      : requiredKinds.length > 0 && inputs.length === 0
-        ? `Wire ${requiredKinds.join(' & ')} input${requiredKinds.length > 1 ? 's' : ''}`
+      : unmet.length > 0 && !untagged
+        ? `Wire ${unmet.map((p) => p.label.toLowerCase()).join(' & ')}`
         : null
   const pct = typeof progress === 'number' ? Math.round(progress * 100) : null
   const price = def.estimatePrice?.(frame.params) ?? null
@@ -186,30 +194,22 @@ export function GenNode({ id, data, selected }: NodeProps): React.JSX.Element {
       icon: <span className="text-xs font-bold leading-none">T</span>,
       label: def.promptOptional ? 'Prompt (optional)' : 'Prompt',
     },
-    ...(wantsMedia
-      ? [
-          {
-            id: 'in',
-            colorClass: '!bg-emerald-400',
-            icon: mediaIsVideo ? (
-              <VideoGlyph className="h-3.5 w-3.5" />
-            ) : (
-              <ImageGlyph className="h-3.5 w-3.5" />
-            ),
-            label: mediaIsVideo ? 'Video' : 'Image',
-          },
-        ]
-      : []),
-    ...(audioInput
-      ? [
-          {
-            id: 'audio',
-            colorClass: '!bg-violet-400',
-            icon: <AudioGlyph className="h-3.5 w-3.5" />,
-            label: 'Audio',
-          },
-        ]
-      : []),
+    ...ports.map((p) => {
+      const family = mediaFamily(p.kind)
+      return {
+        id: handleIdForPort(def, p),
+        colorClass: family === 'audio' ? '!bg-violet-400' : '!bg-emerald-400',
+        icon:
+          family === 'audio' ? (
+            <AudioGlyph className="h-3.5 w-3.5" />
+          ) : family === 'video' ? (
+            <VideoGlyph className="h-3.5 w-3.5" />
+          ) : (
+            <ImageGlyph className="h-3.5 w-3.5" />
+          ),
+        label: p.required ? p.label : `${p.label} (optional)`,
+      }
+    }),
   ]
 
   const canDrop = (e: React.DragEvent): boolean =>
@@ -290,6 +290,7 @@ export function GenNode({ id, data, selected }: NodeProps): React.JSX.Element {
                 url: t.url,
                 kind: t.kind,
                 poster: t.poster,
+                label: portLabels.get(t.id),
               }))}
               onSelect={(i) => {
                 const t = inputThumbs[i]

--- a/src/renderer/views/Moodboard/nodes/GraphNode.tsx
+++ b/src/renderer/views/Moodboard/nodes/GraphNode.tsx
@@ -253,7 +253,12 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
   // control floated on the output node.
   const isLoader = descriptor.outputKind == null
   const fileParam = core?.params?.file
-  const fileLabel = fileParam ? String(fileParam) : 'Auto'
+  // Name the weights rather than saying "Auto": the point of the label is to tell you what will
+  // load. A generation node's provider resolves this; a plain loader has none, so fall back to the
+  // first file in its catalog, which is the one the engine auto-picks anyway.
+  const fileField = descriptor.params.find((p) => p.key === 'file')
+  const fileFallback = fileField?.default || fileField?.options?.[0]?.value
+  const fileLabel = String(fileParam || fileFallback || 'Not installed')
   // An extension-provided node carries its owning extension's id (`ext:<id>:<module>`) - surface it
   // as a chip so it's clear which extension a canvas node came from.
   const extName = isExtensionNode(descriptor.source) ? extensionOf(descriptor.source) : null
@@ -345,16 +350,25 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
               selectParams.map((field) => {
                 const opts = field.options ?? []
                 const hasAuto = opts.some((o) => o.value === '')
+                // A node saved before Core resolved these still stores "", which matches no option
+                // and renders blank; fall back to the resolved default.
+                const stored = core.params?.[field.key]
+                // Empty means "engine auto-picks", which is the first file; show that rather than a
+                // blank select. Display only - the stored value stays empty until the user picks.
+                const fallback = field.default || opts[0]?.value || ''
+                const selected = stored == null || stored === '' ? fallback : stored
                 return (
                   <select
                     key={field.key}
-                    value={String(core.params?.[field.key] ?? field.default ?? '')}
+                    value={String(selected)}
                     onChange={(e) => setParam(field.key, e.target.value)}
                     title={field.label}
                     className="nodrag w-full min-w-0 rounded border border-border bg-panel px-1.5 py-1 text-[10px] text-zinc-200 outline-none focus:border-accent"
                   >
-                    {/* Empty value = auto-pick the first file; shown as a "Select …" prompt. */}
-                    {!hasAuto && <option value="">{`Select ${field.label}`}</option>}
+                    {/* Only when nothing resolved: otherwise the concrete file is already shown. */}
+                    {!hasAuto && !field.default && (
+                      <option value="">{`Select ${field.label}`}</option>
+                    )}
                     {opts.map((o) => (
                       <option key={o.value} value={o.value}>
                         {o.label}

--- a/src/renderer/views/Moodboard/nodes/GraphNode.tsx
+++ b/src/renderer/views/Moodboard/nodes/GraphNode.tsx
@@ -5,12 +5,16 @@ import { isExtensionNode, extensionOf } from '@shared/extensions'
 import { useCoreNodesStore } from '../../../store/coreNodesStore'
 import { useGenerationStore } from '../../../store/generationStore'
 import { useGraphSelectionStore } from '../../../store/graphSelectionStore'
+import { useAssetStore } from '../../../store/assetStore'
+import { useFrameStore } from '../../../store/frameStore'
 import { useMoodboardStore } from '../../../store/moodboardStore'
 import { activeDownload, useModelRequirementsStore } from '../../../store/modelRequirementsStore'
 import { useExtensionsStore } from '../../../store/extensionsStore'
 import { useLightboxStore } from '../../../store/lightboxStore'
 import { matchControlAspect } from '../../../lib/matchControlAspect'
+import { resolveCoreInputThumbs } from './coreInputThumbs'
 import { NodeFrame } from './NodeFrame'
+import { ReferenceStrip } from './ReferenceStrip'
 import { NodeRunToolbar } from './NodeRunToolbar'
 import {
   AdjustIcon,
@@ -104,6 +108,10 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
   const updateItem = useMoodboardStore((s) => s.updateItem)
   const setConnectedPromptText = useMoodboardStore((s) => s.setConnectedPromptText)
   const connectors = useMoodboardStore((s) => s.connectors)
+  const items = useMoodboardStore((s) => s.items)
+  const assets = useAssetStore((s) => s.assets)
+  const frames = useFrameStore((s) => s.frames)
+  const takesByFrame = useFrameStore((s) => s.takesByFrame)
   const openLightbox = useLightboxStore((s) => s.open)
   const coreType = item?.type === 'core' ? item.data.core?.type : undefined
   const descriptor = useCoreNodesStore((s) =>
@@ -249,6 +257,19 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
   // An extension-provided node carries its owning extension's id (`ext:<id>:<module>`) - surface it
   // as a chip so it's clear which extension a canvas node came from.
   const extName = isExtensionNode(descriptor.source) ? extensionOf(descriptor.source) : null
+
+  // A reference list (FLUX.2 and friends): the prompt addresses these by position, "the jacket from
+  // image 2", so the card numbers them in wiring order - the same order graph_build sends the engine.
+  const listPort = descriptor.inputs.find((p) => p.kind === 'image[]')
+  const references = listPort
+    ? resolveCoreInputThumbs(itemId, listPort.id, {
+        items,
+        connectors,
+        assets,
+        frames,
+        takesByFrame,
+      })
+    : []
 
   // Split each side into content (top-packed) and model-family (bottom-packed) ports.
   const inContent = descriptor.inputs.filter((p) => !isModelPort(p.kind))
@@ -424,6 +445,7 @@ export function GraphNode({ id, data, selected }: NodeProps): React.JSX.Element 
         <div className="relative flex h-full w-full flex-col">
           {/* Edge-to-edge output preview. */}
           <div className="relative min-h-0 flex-1 overflow-hidden bg-black">
+            {references.length > 0 && <ReferenceStrip references={references} />}
             {core.output?.kind === 'image' ? (
               <img
                 src={resolveMedia(core.output.filePath)}

--- a/src/renderer/views/Moodboard/nodes/LoaderNode.tsx
+++ b/src/renderer/views/Moodboard/nodes/LoaderNode.tsx
@@ -52,6 +52,7 @@ export function LoaderNode({ id, selected }: NodeProps): React.JSX.Element {
     assetId,
     sourceFrameId: null,
     position,
+    handle: null,
   }))
   const thumbs = resolveInputThumbs(asInputs, {
     assets,

--- a/src/renderer/views/Moodboard/nodes/NodeRunToolbar.tsx
+++ b/src/renderer/views/Moodboard/nodes/NodeRunToolbar.tsx
@@ -31,6 +31,7 @@ export function NodeRunToolbar({
     <NodeToolbar isVisible={isTarget} position={Position.Top} align="end" offset={12}>
       {busy ? (
         <button
+          data-run-toolbar
           onClick={onStop}
           title={stopLabel}
           className="nodrag flex items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-1 text-[11px] font-medium text-zinc-200 shadow-lg hover:bg-black/40 hover:text-white"
@@ -40,6 +41,7 @@ export function NodeRunToolbar({
         </button>
       ) : (
         <button
+          data-run-toolbar
           onClick={onRun}
           disabled={disabled}
           title={disabled ? disabledReason : runLabel}

--- a/src/renderer/views/Moodboard/nodes/PromptNode.tsx
+++ b/src/renderer/views/Moodboard/nodes/PromptNode.tsx
@@ -11,7 +11,18 @@ import { NodeBadge, NodeBadgeRow } from './NodeBadge'
 export function PromptNode({ id, selected }: NodeProps): React.JSX.Element {
   const item = useMoodboardStore((s) => s.items.find((it) => it.id === id))
   const updateItem = useMoodboardStore((s) => s.updateItem)
-  const [text, setText] = useState<string>(() => (item?.data.promptText as string) ?? '')
+  const stored = (item?.data.promptText as string | undefined) ?? ''
+  const [text, setText] = useState<string>(stored)
+  // Re-seed when the stored text changes underneath us. The node mounts as soon as the item is
+  // created, so anything that writes the text a moment later (a getting-started card, a recipe
+  // rebuilt from a dropped image, an undo) would otherwise leave the textarea showing the empty
+  // value it mounted with. Adjusting state during render rather than in an effect is React's own
+  // guidance for this, and avoids a frame of stale text.
+  const [seeded, setSeeded] = useState(stored)
+  if (seeded !== stored) {
+    setSeeded(stored)
+    setText(stored)
+  }
 
   const commit = (): void => {
     if (!item) return

--- a/src/renderer/views/Moodboard/nodes/ReferenceStrip.tsx
+++ b/src/renderer/views/Moodboard/nodes/ReferenceStrip.tsx
@@ -1,0 +1,33 @@
+import { resolveMedia } from '../../../lib/media'
+import type { CoreInputThumb } from './coreInputThumbs'
+
+/**
+ * The numbered reference images wired into a node's list input, docked at the top of its preview.
+ *
+ * Numbering is the point, not decoration: FLUX.2 resolves "the jacket from image 2" against the
+ * order the references arrive in, so the card has to show which is which for the prompt to be
+ * writable at all. Order follows the wires, so re-wiring is how you re-order.
+ */
+export function ReferenceStrip({
+  references,
+}: {
+  references: CoreInputThumb[]
+}): React.JSX.Element | null {
+  if (references.length === 0) return null
+  return (
+    <div className="nodrag nowheel absolute inset-x-0 top-0 z-10 flex gap-1 overflow-x-auto bg-gradient-to-b from-black/80 via-black/40 to-transparent px-1.5 pb-5 pt-1.5">
+      {references.map((ref) => (
+        <div
+          key={`${ref.sourceId}-${ref.index}`}
+          title={`Reference ${ref.index} (${ref.label}) - call it "image ${ref.index}" in the prompt`}
+          className="relative h-9 w-9 shrink-0 overflow-hidden rounded border border-border"
+        >
+          <img src={resolveMedia(ref.filePath)} alt="" className="h-full w-full object-cover" />
+          <span className="absolute bottom-0 right-0 rounded-tl bg-black/75 px-1 text-[9px] font-medium leading-tight text-zinc-200">
+            {ref.index}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/views/Moodboard/nodes/ThumbStrip.tsx
+++ b/src/renderer/views/Moodboard/nodes/ThumbStrip.tsx
@@ -8,6 +8,8 @@ export interface StripItem {
   kind: 'image' | 'video' | 'audio'
   /** Poster still for a video, so we can render a cheap <img> instead of a heavy <video>. */
   poster?: string
+  /** Which input port this feeds, on models that have more than one of a kind. */
+  label?: string
 }
 
 /**
@@ -51,7 +53,9 @@ export function ThumbStrip({
               onSelect?.(i)
             }}
             title={
-              manage ? `Input ${i + 1} of ${items.length}` : `View ${i + 1} of ${items.length}`
+              manage
+                ? `${it.label ?? 'Input'} ${i + 1} of ${items.length}`
+                : `View ${i + 1} of ${items.length}`
             }
             className={`h-8 w-8 overflow-hidden rounded-md border-2 bg-black/60 transition ${
               i === selected
@@ -69,6 +73,11 @@ export function ThumbStrip({
               <img src={it.poster ?? it.url} alt="" className="h-full w-full object-cover" />
             )}
           </button>
+          {it.label && (
+            <span className="pointer-events-none absolute inset-x-0 bottom-0 truncate rounded-b-md bg-black/80 px-0.5 text-center text-[7px] leading-tight text-zinc-300">
+              {it.label}
+            </span>
+          )}
           {onRemove && (
             <button
               onClick={(e) => {

--- a/src/renderer/views/Moodboard/nodes/coreInputThumbs.test.ts
+++ b/src/renderer/views/Moodboard/nodes/coreInputThumbs.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveCoreInputThumbs, type ThumbContext } from './coreInputThumbs'
+import type { Asset, Frame, MoodboardConnector, MoodboardItem, Take } from '@shared/types'
+
+const item = (over: Partial<MoodboardItem> & { id: string; type: MoodboardItem['type'] }) =>
+  ({ projectId: 'p', surface: 'studio', x: 0, y: 0, zIndex: 0, data: {}, ...over }) as MoodboardItem
+
+const asset = (id: string): Asset =>
+  ({ id, projectId: 'p', name: id, filePath: `assets/${id}.png`, kind: 'image' }) as Asset
+
+const wire = (from: string, to: string, handle: string): MoodboardConnector => ({
+  id: `${from}->${to}:${handle}`,
+  projectId: 'p',
+  surface: 'studio',
+  fromItemId: from,
+  toItemId: to,
+  label: null,
+  createdAt: 0,
+  data: { targetHandle: handle },
+})
+
+const ctx = (over: Partial<ThumbContext>): ThumbContext => ({
+  items: [],
+  connectors: [],
+  assets: [],
+  frames: [],
+  takesByFrame: {},
+  ...over,
+})
+
+describe('resolveCoreInputThumbs', () => {
+  it('numbers references from 1 in wiring order', () => {
+    const thumbs = resolveCoreInputThumbs(
+      'gen',
+      'image',
+      ctx({
+        items: [
+          item({ id: 'gen', type: 'core' }),
+          item({ id: 'a', type: 'asset', assetId: 'a1' }),
+          item({ id: 'b', type: 'asset', assetId: 'a2' }),
+        ],
+        connectors: [wire('a', 'gen', 'image'), wire('b', 'gen', 'image')],
+        assets: [asset('a1'), asset('a2')],
+      }),
+    )
+    expect(thumbs.map((t) => [t.index, t.filePath])).toEqual([
+      [1, 'assets/a1.png'],
+      [2, 'assets/a2.png'],
+    ])
+  })
+
+  it('ignores wires into other handles', () => {
+    const thumbs = resolveCoreInputThumbs(
+      'gen',
+      'image',
+      ctx({
+        items: [item({ id: 'gen', type: 'core' }), item({ id: 'p', type: 'asset', assetId: 'a1' })],
+        connectors: [wire('p', 'gen', 'control_image')],
+        assets: [asset('a1')],
+      }),
+    )
+    expect(thumbs).toEqual([])
+  })
+
+  it('expands a Load Assets node into one numbered reference per asset', () => {
+    // Must match the engine's fan-out, or the numbers on the card would not be the numbers the
+    // prompt addresses.
+    const thumbs = resolveCoreInputThumbs(
+      'gen',
+      'image',
+      ctx({
+        items: [
+          item({ id: 'gen', type: 'core' }),
+          item({ id: 'loader', type: 'loader', data: { assetIds: ['a1', 'a2', 'a3'] } }),
+        ],
+        connectors: [wire('loader', 'gen', 'image')],
+        assets: [asset('a1'), asset('a2'), asset('a3')],
+      }),
+    )
+    expect(thumbs.map((t) => t.index)).toEqual([1, 2, 3])
+    expect(thumbs.map((t) => t.filePath)).toEqual([
+      'assets/a1.png',
+      'assets/a2.png',
+      'assets/a3.png',
+    ])
+  })
+
+  it('keeps numbering continuous across a loader and a plain asset', () => {
+    const thumbs = resolveCoreInputThumbs(
+      'gen',
+      'image',
+      ctx({
+        items: [
+          item({ id: 'gen', type: 'core' }),
+          item({ id: 'loader', type: 'loader', data: { assetIds: ['a1', 'a2'] } }),
+          item({ id: 'solo', type: 'asset', assetId: 'a3' }),
+        ],
+        connectors: [wire('loader', 'gen', 'image'), wire('solo', 'gen', 'image')],
+        assets: [asset('a1'), asset('a2'), asset('a3')],
+      }),
+    )
+    expect(thumbs.map((t) => [t.index, t.filePath])).toEqual([
+      [1, 'assets/a1.png'],
+      [2, 'assets/a2.png'],
+      [3, 'assets/a3.png'],
+    ])
+  })
+
+  it('takes a frame at its hero take, not the newest', () => {
+    const takes = [
+      { id: 't1', frameId: 'f1', filePath: 'takes/1.png' } as Take,
+      { id: 't2', frameId: 'f1', filePath: 'takes/2.png' } as Take,
+    ]
+    const thumbs = resolveCoreInputThumbs(
+      'gen',
+      'image',
+      ctx({
+        items: [item({ id: 'gen', type: 'core' }), item({ id: 'f', type: 'frame', frameId: 'f1' })],
+        connectors: [wire('f', 'gen', 'image')],
+        frames: [{ id: 'f1', heroTakeId: 't1' } as Frame],
+        takesByFrame: { f1: takes },
+      }),
+    )
+    expect(thumbs[0]?.filePath).toBe('takes/1.png')
+  })
+
+  it('takes a wired Core node at its current output', () => {
+    const thumbs = resolveCoreInputThumbs(
+      'gen',
+      'image',
+      ctx({
+        items: [
+          item({ id: 'gen', type: 'core' }),
+          item({
+            id: 'up',
+            type: 'core',
+            data: {
+              core: {
+                type: 'black-forest-labs/flux-2',
+                params: {},
+                output: { takeId: 't', filePath: 'takes/up.png', kind: 'image' },
+              },
+            },
+          }),
+        ],
+        connectors: [wire('up', 'gen', 'image')],
+      }),
+    )
+    expect(thumbs[0]?.filePath).toBe('takes/up.png')
+  })
+
+  it('skips sources with nothing rendered or nothing selected', () => {
+    const thumbs = resolveCoreInputThumbs(
+      'gen',
+      'image',
+      ctx({
+        items: [
+          item({ id: 'gen', type: 'core' }),
+          item({ id: 'empty', type: 'controlSpace' }),
+          item({ id: 'unrendered', type: 'frame', frameId: 'f9' }),
+          item({ id: 'ok', type: 'asset', assetId: 'a1' }),
+        ],
+        connectors: [
+          wire('empty', 'gen', 'image'),
+          wire('unrendered', 'gen', 'image'),
+          wire('ok', 'gen', 'image'),
+        ],
+        assets: [asset('a1')],
+      }),
+    )
+    // The one resolvable source is reference 1, so the numbering never has a gap.
+    expect(thumbs).toHaveLength(1)
+    expect(thumbs[0]).toMatchObject({ index: 1, filePath: 'assets/a1.png' })
+  })
+})

--- a/src/renderer/views/Moodboard/nodes/coreInputThumbs.ts
+++ b/src/renderer/views/Moodboard/nodes/coreInputThumbs.ts
@@ -1,0 +1,115 @@
+/**
+ * Resolve the images wired into a Core node's list input, in wiring order.
+ *
+ * FLUX.2 addresses reference images by position - "the jacket from image 2" - so the order the user
+ * wired them in is meaning, not decoration. The node face numbers them so the prompt can name them,
+ * which means this must produce exactly what `graph_build.py` sends to the engine: connector order,
+ * and a Load Assets node contributing every asset it holds rather than only its first.
+ *
+ * Pure: the caller passes the stores' data in, so this is testable without React.
+ */
+import type { Asset, Frame, MoodboardConnector, MoodboardItem, Take } from '@shared/types'
+
+export interface CoreInputThumb {
+  /** 1-based, matching how a prompt refers to it ("image 1"). */
+  index: number
+  /** Project-relative media path, still to be run through `resolveMedia`. */
+  filePath: string
+  /** The canvas item this came from, for the hover title. */
+  sourceId: string
+  label: string
+}
+
+export interface ThumbContext {
+  items: MoodboardItem[]
+  connectors: MoodboardConnector[]
+  assets: Asset[]
+  frames: Frame[]
+  takesByFrame: Record<string, Take[]>
+}
+
+/** Every image feeding `handle` on `itemId`, numbered from 1 in wiring order. */
+export function resolveCoreInputThumbs(
+  itemId: string,
+  handle: string,
+  ctx: ThumbContext,
+): CoreInputThumb[] {
+  const wired = ctx.connectors.filter(
+    (c) => c.toItemId === itemId && (c.data?.targetHandle ?? 'in') === handle,
+  )
+  const thumbs: CoreInputThumb[] = []
+  for (const connector of wired) {
+    const source = ctx.items.find((i) => i.id === connector.fromItemId)
+    if (!source) continue
+    for (const filePath of sourcePaths(source, ctx)) {
+      thumbs.push({
+        index: thumbs.length + 1,
+        filePath,
+        sourceId: source.id,
+        label: sourceLabel(source, ctx),
+      })
+    }
+  }
+  return thumbs
+}
+
+/**
+ * The image(s) one canvas item contributes. A Load Assets node contributes all of them, matching
+ * the engine's fan-out; every other kind contributes at most one.
+ */
+function sourcePaths(item: MoodboardItem, ctx: ThumbContext): string[] {
+  switch (item.type) {
+    case 'loader': {
+      const ids = item.data.assetIds ?? []
+      return ids.map((id) => assetPath(id, ctx)).filter(isPresent)
+    }
+    case 'controlSpace': {
+      const path = item.data.controlAssetId ? assetPath(item.data.controlAssetId, ctx) : undefined
+      return path ? [path] : []
+    }
+    case 'asset': {
+      const path = item.assetId ? assetPath(item.assetId, ctx) : undefined
+      return path ? [path] : []
+    }
+    case 'core': {
+      // A wired Core node contributes its current output - the same hero-take boundary the engine
+      // freezes upstream nodes at, so nothing upstream is recomputed.
+      const path = item.data.core?.output?.filePath
+      return path ? [path] : []
+    }
+    case 'frame':
+    case 'preview': {
+      const path = item.frameId ? heroPath(item.frameId, ctx) : undefined
+      return path ? [path] : []
+    }
+    default:
+      return []
+  }
+}
+
+function sourceLabel(item: MoodboardItem, ctx: ThumbContext): string {
+  if (item.type === 'controlSpace') return 'Control Space'
+  if (item.type === 'loader') return 'Load Assets'
+  if (item.type === 'asset' && item.assetId) {
+    return ctx.assets.find((a) => a.id === item.assetId)?.name ?? 'Asset'
+  }
+  if (item.type === 'core') return item.data.core?.type ?? 'Node'
+  return 'Frame'
+}
+
+function assetPath(assetId: string, ctx: ThumbContext): string | undefined {
+  return ctx.assets.find((a) => a.id === assetId)?.filePath
+}
+
+/** A frame contributes its chosen take, falling back to the newest when none is pinned. */
+function heroPath(frameId: string, ctx: ThumbContext): string | undefined {
+  const takes = ctx.takesByFrame[frameId] ?? []
+  if (takes.length === 0) return undefined
+  const frame = ctx.frames.find((f) => f.id === frameId)
+  const hero = frame?.heroTakeId ? takes.find((t) => t.id === frame.heroTakeId) : undefined
+  return (hero ?? takes[takes.length - 1]).filePath
+}
+
+function isPresent(value: string | undefined): value is string {
+  return value != null
+}

--- a/src/renderer/views/Moodboard/nodes/inputThumbs.test.ts
+++ b/src/renderer/views/Moodboard/nodes/inputThumbs.test.ts
@@ -56,6 +56,7 @@ const input = (over: Partial<FrameInput>): FrameInput => ({
   assetId: null,
   sourceFrameId: null,
   position: 0,
+  handle: null,
   ...over,
 })
 

--- a/src/renderer/views/Moodboard/useMenuPlacement.ts
+++ b/src/renderer/views/Moodboard/useMenuPlacement.ts
@@ -1,0 +1,50 @@
+import { useLayoutEffect, useRef, useState } from 'react'
+
+export interface MenuPlacement<T extends HTMLElement> {
+  ref: React.RefObject<T | null>
+  /** Container-relative position for the popup. */
+  style: React.CSSProperties
+  /** Cap for the scroll area so the list never runs past the canvas edge. */
+  maxHeight: number | undefined
+  /** True when the menu was flipped to grow upward from the anchor. */
+  flipped: boolean
+}
+
+/**
+ * Keep a popup anchored to a canvas point fully on screen.
+ *
+ * Two problems this solves, both only visible near the bottom edge. A menu anchored at the click
+ * point runs off the canvas, and the part you cannot see is the part you wanted. Worse, the obvious
+ * recovery of scrolling does nothing useful: React Flow owns the wheel, so the canvas zooms instead
+ * of the list scrolling. The scroll container needs React Flow's `nowheel` class as well as this.
+ *
+ * So: flip above the anchor when there is more room up there, and cap the height to whatever room
+ * remains either way. Measured after layout rather than guessed, because the list's height depends
+ * on how many nodes are installed.
+ */
+export function useMenuPlacement<T extends HTMLElement>(
+  x: number,
+  y: number,
+  /** True when the caller already grows the menu upward (the toolbar's + button). */
+  above: boolean,
+): MenuPlacement<T> {
+  const ref = useRef<T>(null)
+  const [maxHeight, setMaxHeight] = useState<number>()
+  const [flipped, setFlipped] = useState(false)
+
+  useLayoutEffect(() => {
+    const el = ref.current
+    const container = el?.offsetParent as HTMLElement | null
+    if (!el || !container) return
+    const margin = 12
+    const below = container.clientHeight - y - margin
+    const above_ = y - margin
+    // Flip only when it helps: a menu that fits below stays below, and one that fits nowhere still
+    // opens downward rather than off the top.
+    const shouldFlip = !above && el.scrollHeight > below && above_ > below
+    setFlipped(shouldFlip)
+    setMaxHeight(Math.max(160, shouldFlip || above ? above_ : below))
+  }, [x, y, above])
+
+  return { ref, style: { left: x, top: y }, maxHeight, flipped }
+}

--- a/src/renderer/views/Trainer/TrainerAddMenu.tsx
+++ b/src/renderer/views/Trainer/TrainerAddMenu.tsx
@@ -1,0 +1,81 @@
+/**
+ * The Trainer's node list, opened from the toolbar's + or by double-clicking empty canvas.
+ *
+ * Mirrors the Studio Add menu's shape and placement rules rather than sharing it: the Studio one is
+ * built around fal models and Core descriptors, while the Trainer's four node kinds are a fixed
+ * list. What it does share is `useMenuPlacement`, so a list opened near the bottom edge flips and
+ * caps instead of running off the canvas.
+ */
+import { useMemo } from 'react'
+
+import { useMenuPlacement } from '../Moodboard/useMenuPlacement'
+
+export interface AddEntry<K extends string> {
+  kind: K
+  label: string
+  icon: React.JSX.Element
+  category: string
+}
+
+export function TrainerAddMenu<K extends string>({
+  x,
+  y,
+  above = false,
+  entries,
+  onPick,
+  onClose,
+}: {
+  /** Container-relative anchor point (px). */
+  x: number
+  y: number
+  /** True when the caller centres on x and grows upward (the toolbar button). */
+  above?: boolean
+  entries: readonly AddEntry<K>[]
+  onPick: (kind: K) => void
+  onClose: () => void
+}): React.JSX.Element {
+  const place = useMenuPlacement<HTMLDivElement>(x, y, above)
+  const groups = useMemo(() => {
+    const out = new Map<string, AddEntry<K>[]>()
+    for (const entry of entries)
+      out.set(entry.category, [...(out.get(entry.category) ?? []), entry])
+    return [...out.entries()]
+  }, [entries])
+
+  return (
+    <>
+      <div className="absolute inset-0 z-20" onClick={onClose} />
+      <div
+        ref={place.ref}
+        className={`absolute z-30 flex w-52 select-none flex-col overflow-hidden rounded-md border border-border bg-panel text-xs shadow-xl ${
+          above ? '-translate-x-1/2 -translate-y-full' : place.flipped ? '-translate-y-full' : ''
+        }`}
+        style={place.style}
+      >
+        {/* `nowheel` keeps React Flow from swallowing the wheel and zooming instead of scrolling. */}
+        <div className="nowheel overflow-y-auto p-1" style={{ maxHeight: place.maxHeight }}>
+          {groups.map(([category, group]) => (
+            <div key={category}>
+              <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-zinc-500">
+                {category}
+              </div>
+              {group.map((entry) => (
+                <button
+                  key={entry.kind}
+                  onClick={() => {
+                    onPick(entry.kind)
+                    onClose()
+                  }}
+                  className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-zinc-200 hover:bg-surface"
+                >
+                  <span className="text-zinc-400">{entry.icon}</span>
+                  {entry.label}
+                </button>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/renderer/views/Trainer/TrainerCanvas.tsx
+++ b/src/renderer/views/Trainer/TrainerCanvas.tsx
@@ -3,7 +3,7 @@
  * Resource node. Same React Flow + node-card design as the Studio moodboard, but backed by the
  * `trainer` surface so the two boards stay separate.
  */
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Background,
   BackgroundVariant,
@@ -15,6 +15,7 @@ import {
   type Edge,
   type Node,
   type NodeChange,
+  type EdgeTypes,
   type NodeTypes,
   type OnConnect,
 } from '@xyflow/react'
@@ -23,6 +24,9 @@ import { studio } from '@/lib/studio'
 import { useTrainerBoardStore, type TrainerNodeKind } from '../../store/trainerBoardStore'
 import { useModelRequirementsStore } from '../../store/modelRequirementsStore'
 import { BoardActionsContext } from '../Moodboard/nodes/boardActions'
+import { CanvasToolbar } from '../Moodboard/CanvasToolbar'
+import { TrainerDeletableEdge } from './edges/TrainerDeletableEdge'
+import { TrainerAddMenu } from './TrainerAddMenu'
 import { ModelRequirementsModal } from '../Moodboard/nodes/ModelRequirementsModal'
 import { ResourceNode } from '../Moodboard/nodes/ResourceNode'
 import {
@@ -36,6 +40,11 @@ import { CaptionNode } from './nodes/CaptionNode'
 import { LossGraphNode } from './nodes/LossGraphNode'
 import { TrainDatasetNode } from './nodes/TrainDatasetNode'
 import { TrainerNode } from './nodes/TrainerNode'
+
+// Clicking a connector selects it and shows the ✕ to unlink, same as the Studio canvas.
+const edgeTypes: EdgeTypes = {
+  deletable: TrainerDeletableEdge,
+}
 
 const nodeTypes: NodeTypes = {
   trainDataset: TrainDatasetNode,
@@ -69,51 +78,6 @@ function toNode(item: MoodboardItem): Node {
   }
 }
 
-function AddMenu({ onAdd }: { onAdd: (kind: TrainerNodeKind) => void }): React.JSX.Element {
-  const [open, setOpen] = useState(false)
-  const groups = useMemo(() => {
-    const out = new Map<string, typeof ADDABLE>()
-    for (const entry of ADDABLE)
-      out.set(entry.category, [...(out.get(entry.category) ?? []), entry])
-    return [...out.entries()]
-  }, [])
-
-  return (
-    <div className="absolute left-3 top-3 z-10">
-      <button
-        onClick={() => setOpen((o) => !o)}
-        className="rounded-md border border-border bg-panel/95 px-3 py-1.5 text-xs font-medium text-zinc-200 shadow-sm backdrop-blur hover:bg-panel"
-      >
-        + Add node
-      </button>
-      {open && (
-        <div className="mt-1 w-52 rounded-md border border-border bg-panel/95 p-1 shadow-lg backdrop-blur">
-          {groups.map(([category, entries]) => (
-            <div key={category}>
-              <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-zinc-500">
-                {category}
-              </div>
-              {entries.map((e) => (
-                <button
-                  key={e.kind}
-                  onClick={() => {
-                    onAdd(e.kind)
-                    setOpen(false)
-                  }}
-                  className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-zinc-200 hover:bg-surface"
-                >
-                  <span className="text-zinc-400">{e.icon}</span>
-                  {e.label}
-                </button>
-              ))}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
-
 function Canvas(): React.JSX.Element {
   const items = useTrainerBoardStore((s) => s.items)
   const connectors = useTrainerBoardStore((s) => s.connectors)
@@ -126,6 +90,9 @@ function Canvas(): React.JSX.Element {
   const disconnect = useTrainerBoardStore((s) => s.disconnect)
 
   const [nodes, setNodes] = useState<Node[]>([])
+  const [tool, setTool] = useState<'select' | 'pan'>('select')
+  const [addMenu, setAddMenu] = useState<{ x: number; y: number; above: boolean } | null>(null)
+  const wrapperRef = useRef<HTMLDivElement>(null)
   const rf = useReactFlow()
 
   useEffect(() => {
@@ -174,6 +141,7 @@ function Canvas(): React.JSX.Element {
         target: c.toItemId,
         sourceHandle: (c.data?.sourceHandle as string | null) ?? undefined,
         targetHandle: (c.data?.targetHandle as string | null) ?? undefined,
+        type: 'deletable',
       })),
     [connectors],
   )
@@ -193,23 +161,43 @@ function Canvas(): React.JSX.Element {
 
   const boardActions = useMemo(() => ({ updateItem, deleteItem }), [updateItem, deleteItem])
 
+  /** Double-click empty canvas opens the node list there, matching the Studio canvas. */
+  const onCanvasDoubleClick = (e: React.MouseEvent): void => {
+    if (tool !== 'select') return
+    if (!(e.target as HTMLElement).classList.contains('react-flow__pane')) return
+    window.getSelection()?.removeAllRanges() // the double-click also word-selects nearby text
+    const rect = wrapperRef.current?.getBoundingClientRect()
+    setAddMenu({
+      x: rect ? e.clientX - rect.left : e.clientX,
+      y: rect ? e.clientY - rect.top : e.clientY,
+      above: false,
+    })
+  }
+
   return (
-    <div className="relative h-full min-h-0 w-full">
+    <div
+      ref={wrapperRef}
+      className="relative h-full min-h-0 w-full"
+      onDoubleClick={onCanvasDoubleClick}
+    >
       {error && (
         <div className="absolute left-1/2 top-3 z-20 -translate-x-1/2 rounded-md bg-red-500/10 px-3 py-1.5 text-xs text-red-400">
           {error}
         </div>
       )}
-      <AddMenu onAdd={addAtViewport} />
       <BoardActionsContext.Provider value={boardActions}>
         <ReactFlow
           nodes={nodes}
           edges={edges}
           nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
           connectionMode={ConnectionMode.Loose}
           deleteKeyCode={['Backspace', 'Delete']}
           zoomOnDoubleClick={false}
           defaultEdgeOptions={{ interactionWidth: 20 }}
+          panOnDrag={tool === 'pan' ? true : [1, 2]}
+          selectionOnDrag={tool === 'select'}
+          nodesDraggable={tool === 'select'}
           onNodesChange={onNodesChange}
           onNodeDragStop={(_e, node) =>
             void updateItem(node.id, { x: node.position.x, y: node.position.y })
@@ -225,6 +213,29 @@ function Canvas(): React.JSX.Element {
           <Background variant={BackgroundVariant.Dots} gap={16} size={1} className="opacity-40" />
         </ReactFlow>
       </BoardActionsContext.Provider>
+      <CanvasToolbar
+        tool={tool}
+        onSelectTool={() => setTool('select')}
+        onPanTool={() => setTool('pan')}
+        onOpenAdd={(buttonRect) => {
+          const rect = wrapperRef.current?.getBoundingClientRect()
+          setAddMenu({
+            x: buttonRect.left + buttonRect.width / 2 - (rect?.left ?? 0),
+            y: buttonRect.top - 8 - (rect?.top ?? 0),
+            above: true,
+          })
+        }}
+      />
+      {addMenu && (
+        <TrainerAddMenu
+          x={addMenu.x}
+          y={addMenu.y}
+          above={addMenu.above}
+          entries={ADDABLE}
+          onPick={addAtViewport}
+          onClose={() => setAddMenu(null)}
+        />
+      )}
       <ModelRequirementsModal />
     </div>
   )

--- a/src/renderer/views/Trainer/TrainerSettingsPanel.tsx
+++ b/src/renderer/views/Trainer/TrainerSettingsPanel.tsx
@@ -51,9 +51,14 @@ const BASES: Record<TrainingArch, { value: TrainingBaseMode; label: string }[]> 
     { value: 'raw', label: 'Krea 2 RAW (recommended)' },
     { value: 'turbo_adapter', label: 'Krea 2 Turbo (+ training adapter)' },
   ],
+  // FLUX.2 has no de-distillation adapter: you train on a Base checkpoint and the adapter still
+  // loads on the distilled build for generation, which is both faster and better.
+  flux2: [{ value: 'raw', label: 'FLUX.2 Base (required)' }],
 }
 
-/** Only Krea 2 has a 4-bit base path, so the control is hidden for Z-Image rather than lying. */
+/** Krea 2 and FLUX.2 have a 4-bit base path; the control is hidden for Z-Image rather than lying. */
+const QUANTIZABLE: TrainingArch[] = ['krea2', 'flux2']
+
 const QUANTS: { value: TrainingBaseQuant; label: string }[] = [
   { value: 'auto', label: 'Auto (fit to this GPU)' },
   { value: 'none', label: 'Full precision (bf16)' },
@@ -75,6 +80,7 @@ const SCOPES: { value: TrainingLoraScope; label: string }[] = [
 const ARCHS: { value: TrainingArch; label: string }[] = [
   { value: 'z-image', label: 'Z-Image' },
   { value: 'krea2', label: 'Krea 2' },
+  { value: 'flux2', label: 'FLUX.2' },
 ]
 
 function NumberField({
@@ -248,9 +254,14 @@ export function TrainerSettingsPanel({ itemId }: { itemId: string }): React.JSX.
             Train on RAW, then generate with Krea 2 Turbo - the LoRA carries over.
           </span>
         )}
+        {arch === 'flux2' && (
+          <span className="text-[10px] text-zinc-600">
+            Train on Base, then generate with the distilled build - the LoRA carries over.
+          </span>
+        )}
       </label>
 
-      {arch === 'krea2' && (
+      {QUANTIZABLE.includes(arch) && (
         <label className="flex flex-col gap-1 text-[11px] text-zinc-400">
           Base precision
           <select
@@ -271,7 +282,7 @@ export function TrainerSettingsPanel({ itemId }: { itemId: string }): React.JSX.
         </label>
       )}
 
-      {arch === 'krea2' && (hp.baseQuant ?? 'auto') !== 'nf4' && (
+      {QUANTIZABLE.includes(arch) && (hp.baseQuant ?? 'auto') !== 'nf4' && (
         <label className="flex flex-col gap-1 text-[11px] text-zinc-400">
           CPU offload
           <select

--- a/src/renderer/views/Trainer/TrainerSettingsPanel.tsx
+++ b/src/renderer/views/Trainer/TrainerSettingsPanel.tsx
@@ -146,6 +146,10 @@ export function TrainerSettingsPanel({ itemId }: { itemId: string }): React.JSX.
   const dirty = JSON.stringify(hp) !== JSON.stringify(applied)
 
   if (!item) return null
+  // The sidebar is shared by every Trainer node that has settings, so it dispatches on the item.
+  // Everything below this point is training hyperparams and only applies to the Trainer node.
+  if (item.type === 'caption')
+    return <CaptionSettings itemId={itemId} overwrite={Boolean(item.data.overwrite)} />
 
   const arch: TrainingArch = hp.arch ?? 'z-image'
   const set = <K extends keyof TrainingHyperparams>(key: K, value: TrainingHyperparams[K]): void =>
@@ -427,6 +431,48 @@ export function TrainerSettingsPanel({ itemId }: { itemId: string }): React.JSX.
           </div>
         </div>
       </Modal>
+    </div>
+  )
+}
+
+/** Caption node settings. Small today, but it is where the Adjust button has to lead: a button that
+ * silently toggled a hidden flag read as broken, because nothing on the node showed what it did. */
+function CaptionSettings({
+  itemId,
+  overwrite,
+}: {
+  itemId: string
+  overwrite: boolean
+}): React.JSX.Element {
+  const patchData = useTrainerBoardStore((s) => s.patchData)
+  const toggleSettings = useTrainerBoardStore((s) => s.toggleSettings)
+  return (
+    <div className="flex w-80 shrink-0 flex-col gap-3 overflow-y-auto border-l border-border bg-surface/40 p-4">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-zinc-200">Caption settings</span>
+        <button
+          onClick={() => toggleSettings(itemId)}
+          className="rounded p-1 text-zinc-400 hover:bg-panel hover:text-zinc-200"
+          title="Close"
+        >
+          <XIcon className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <label className="flex items-start gap-2 text-[11px] text-zinc-400">
+        <input
+          type="checkbox"
+          checked={overwrite}
+          onChange={(e) => void patchData(itemId, { overwrite: e.target.checked })}
+          className="mt-0.5 accent-emerald-500"
+        />
+        <span className="flex flex-col gap-0.5">
+          <span className="text-zinc-200">Re-caption every image</span>
+          <span className="text-zinc-500">
+            Off, only images with an empty caption are captioned, so hand-written captions survive a
+            re-run. On, every caption is replaced.
+          </span>
+        </span>
+      </label>
     </div>
   )
 }

--- a/src/renderer/views/Trainer/edges/TrainerDeletableEdge.tsx
+++ b/src/renderer/views/Trainer/edges/TrainerDeletableEdge.tsx
@@ -1,0 +1,9 @@
+import { type EdgeProps } from '@xyflow/react'
+
+import { useTrainerBoardStore } from '../../../store/trainerBoardStore'
+import { DeletableEdgeBody } from '../../Moodboard/edges/DeletableEdge'
+
+/** The Studio connector, bound to the Trainer's store: click a link, get a ✕ to unlink it. */
+export function TrainerDeletableEdge(props: EdgeProps): React.JSX.Element {
+  return <DeletableEdgeBody {...props} disconnect={useTrainerBoardStore((s) => s.disconnect)} />
+}

--- a/src/renderer/views/Trainer/nodes/CaptionNode.tsx
+++ b/src/renderer/views/Trainer/nodes/CaptionNode.tsx
@@ -8,13 +8,8 @@ import { Handle, Position, type NodeProps } from '@xyflow/react'
 import { useTrainingStore } from '../../../store/trainingStore'
 import { useTrainerBoardStore } from '../../../store/trainerBoardStore'
 import { NodeFrame } from '../../Moodboard/nodes/NodeFrame'
-import {
-  AdjustIcon,
-  CaptionGlyph,
-  NodeBadge,
-  NodeBadgeRow,
-  PlayIcon,
-} from '../../Moodboard/nodes/NodeBadge'
+import { AdjustIcon, CaptionGlyph, NodeBadge, NodeBadgeRow } from '../../Moodboard/nodes/NodeBadge'
+import { NodeRunToolbar } from '../../Moodboard/nodes/NodeRunToolbar'
 import { DATASET_HANDLE, wiredDatasetId } from './handles'
 
 export function CaptionNode({ id, selected }: NodeProps): React.JSX.Element {
@@ -27,6 +22,8 @@ export function CaptionNode({ id, selected }: NodeProps): React.JSX.Element {
   const loadItems = useTrainingStore((s) => s.loadItems)
   const autoCaption = useTrainingStore((s) => s.autoCaption)
   const captioning = useTrainingStore((s) => s.captioning)
+  const toggleSettings = useTrainerBoardStore((s) => s.toggleSettings)
+  const settingsItemId = useTrainerBoardStore((s) => s.settingsItemId)
 
   useEffect(() => {
     void loadDatasets()
@@ -52,6 +49,16 @@ export function CaptionNode({ id, selected }: NodeProps): React.JSX.Element {
 
   return (
     <>
+      {/* The same floating control every runnable node uses, rather than one buried in the footer. */}
+      <NodeRunToolbar
+        isTarget={!!selected}
+        busy={captioning}
+        onRun={() => datasetId && void autoCaption(datasetId, overwrite)}
+        onStop={() => {}}
+        disabled={!datasetId || total === 0}
+        disabledReason={!datasetId ? 'Wire or pick a dataset first' : 'This dataset has no images'}
+        runLabel="Auto-caption"
+      />
       <NodeBadgeRow dragNodeId={id}>
         <NodeBadge icon={<CaptionGlyph />}>Caption</NodeBadge>
         {total > 0 && (
@@ -112,24 +119,16 @@ export function CaptionNode({ id, selected }: NodeProps): React.JSX.Element {
           <div className="flex items-center justify-between border-t border-border bg-surface/90 px-2 py-1">
             {/* The model is configurable (INLINE_CAPTIONER_MODEL), so don't name one here. */}
             <span className="text-[10px] text-zinc-500">Auto-caption</span>
-            <div className="flex items-center gap-1">
-              <button
-                data-gen-settings-toggle
-                onClick={() => void patchData(id, { overwrite: !overwrite })}
-                title={overwrite ? 'Re-caption every image' : 'Only caption empty captions'}
-                className={`nodrag rounded p-1 ${overwrite ? 'text-emerald-400' : 'text-zinc-400'} hover:bg-panel`}
-              >
-                <AdjustIcon className="h-4 w-4" />
-              </button>
-              <button
-                onClick={() => datasetId && void autoCaption(datasetId, overwrite)}
-                disabled={!datasetId || captioning || total === 0}
-                title="Auto-caption"
-                className="nodrag rounded p-1 text-emerald-400 hover:bg-panel disabled:opacity-40"
-              >
-                <PlayIcon className="h-4 w-4" />
-              </button>
-            </div>
+            <button
+              data-gen-settings-toggle
+              onClick={() => toggleSettings(id)}
+              title="Adjust caption settings"
+              className={`nodrag rounded p-1 hover:bg-panel ${
+                settingsItemId === id ? 'text-zinc-100' : 'text-zinc-400'
+              }`}
+            >
+              <AdjustIcon className="h-4 w-4" />
+            </button>
           </div>
         </div>
       </NodeFrame>

--- a/src/renderer/views/Trainer/nodes/TrainerNode.tsx
+++ b/src/renderer/views/Trainer/nodes/TrainerNode.tsx
@@ -29,6 +29,7 @@ import { DATASET_HANDLE, RUN_HANDLE, wiredDatasetId } from './handles'
 function requirementType(arch: string, baseMode: string): string {
   if (arch === 'krea2')
     return baseMode === 'turbo_adapter' ? 'krea/krea-2-turbo' : 'krea/krea-2-raw'
+  if (arch === 'flux2') return 'black-forest-labs/flux-2'
   return 'alibaba/z-image-turbo'
 }
 

--- a/src/shared/coreNodes.ts
+++ b/src/shared/coreNodes.ts
@@ -102,9 +102,29 @@ export interface ModelComponent {
 }
 
 /** A node's model requirements with live presence (from `models:requirements`). */
+/**
+ * Whether the node's models fit this machine, from the engine's own device policy.
+ *
+ * Only meaningful once the components are installed: it sizes what is on disk, so a fresh install
+ * with nothing downloaded reports a zero footprint and an optimistic `fits`. Gate every use on
+ * `allPresent`.
+ */
+export interface ModelFitEstimate {
+  /** How the weights would load: 'resident' | 'int8' | 'nf4' | 'offload' | 'wont-fit'. */
+  plan: string
+  fits: boolean
+  requiredVramMb: number
+  totalVramMb: number | null
+  freeVramMb: number | null
+  freeRamMb: number | null
+  /** Set when the plan is worth surfacing (quantized, offloaded, or will not fit). */
+  warning: string | null
+}
+
 export interface ModelRequirements {
   components: ModelComponent[]
   allPresent: boolean
+  estimate?: ModelFitEstimate | null
 }
 
 const ENGINE_KINDS: readonly PortKind[] = [

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -300,6 +300,8 @@ export interface ResolvedFalInputs {
   images: string[]
   videos: string[]
   audios: string[]
+  /** The same URIs keyed by the input port each was wired to; untagged inputs are absent. */
+  byHandle: Record<string, string[]>
   prompt: string | null
 }
 
@@ -379,12 +381,20 @@ export interface InlineStudioApi {
     heroTakes(): Promise<Result<Take[]>>
     /** All frame inputs across the project (group by frameId in the renderer). */
     listInputs(): Promise<Result<FrameInput[]>>
-    /** Append a library asset as an input of the frame. */
-    addInput(frameId: string, assetId: string): Promise<Result<FrameInput>>
+    /** Append a library asset as an input of the frame, optionally tagged with an input port id. */
+    addInput(frameId: string, assetId: string, handle?: string | null): Promise<Result<FrameInput>>
     /** Append several library assets as inputs at once (atomic; skips duplicates). */
-    addInputs(frameId: string, assetIds: string[]): Promise<Result<FrameInput[]>>
+    addInputs(
+      frameId: string,
+      assetIds: string[],
+      handle?: string | null,
+    ): Promise<Result<FrameInput[]>>
     /** Link another frame's output as an input (resolves to its hero take). */
-    addSourceInput(frameId: string, sourceFrameId: string): Promise<Result<FrameInput>>
+    addSourceInput(
+      frameId: string,
+      sourceFrameId: string,
+      handle?: string | null,
+    ): Promise<Result<FrameInput>>
     /** Remove an input by its library asset id (Frame Inspector). */
     removeInput(frameId: string, assetId: string): Promise<Result<void>>
     /** Remove one input by its row id - works for asset AND flow-link inputs. */

--- a/src/shared/nodes/flux2.test.ts
+++ b/src/shared/nodes/flux2.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import { FLUX_2, FLUX_2_EDIT } from './flux2'
+import { getNodeDef, listNodeDefs } from './registry'
+import type { ResolvedInputs } from './types'
+
+const RESOLVED: ResolvedInputs = {
+  images: ['https://a/1.png', 'https://a/2.png'],
+} as ResolvedInputs
+
+describe('fal FLUX.2 nodes', () => {
+  it('are registered and findable by their fal endpoint id', () => {
+    expect(getNodeDef('fal-ai/flux-2')).toBe(FLUX_2)
+    expect(getNodeDef('fal-ai/flux-2/edit')).toBe(FLUX_2_EDIT)
+    expect(listNodeDefs()).toContain(FLUX_2_EDIT)
+  })
+
+  it('takes references as an ordered list, since the prompt addresses them by position', () => {
+    expect(FLUX_2_EDIT.inputs[0]).toMatchObject({ kind: 'image[]', required: true })
+    const body = FLUX_2_EDIT.buildRequest({ prompt: 'the fox from image 1' }, RESOLVED)
+    // Order preserved: "image 1" must be the first wire.
+    expect(body.image_urls).toEqual(['https://a/1.png', 'https://a/2.png'])
+  })
+
+  it('text-to-image takes no inputs and sends no image_urls', () => {
+    expect(FLUX_2.inputs).toEqual([])
+    const body = FLUX_2.buildRequest({ prompt: 'a fox' }, {} as ResolvedInputs)
+    expect(body).not.toHaveProperty('image_urls')
+    expect(body.prompt).toBe('a fox')
+  })
+
+  it('sends the schema defaults when the user has not touched a param', () => {
+    // These mirror fal's own defaults; drifting from them changes output for no stated reason.
+    const body = FLUX_2.buildRequest({ prompt: 'x' }, {} as ResolvedInputs)
+    expect(body).toMatchObject({
+      image_size: 'landscape_4_3',
+      num_inference_steps: 28,
+      guidance_scale: 2.5,
+      num_images: 1,
+      acceleration: 'none',
+      output_format: 'png',
+    })
+  })
+
+  it('passes explicit params through and stays inside the API bounds', () => {
+    const body = FLUX_2.buildRequest(
+      { prompt: 'x', num_inference_steps: 50, guidance_scale: 0, num_images: 4 },
+      {} as ResolvedInputs,
+    )
+    expect(body).toMatchObject({ num_inference_steps: 50, guidance_scale: 0, num_images: 4 })
+    const steps = FLUX_2.params.find((p) => p.key === 'num_inference_steps')
+    expect(steps).toMatchObject({ min: 4, max: 50 })
+    const guidance = FLUX_2.params.find((p) => p.key === 'guidance_scale')
+    expect(guidance).toMatchObject({ min: 0, max: 20 })
+  })
+
+  it('omits the seed unless one is set, so runs stay random by default', () => {
+    expect(FLUX_2.buildRequest({ prompt: 'x' }, {} as ResolvedInputs)).not.toHaveProperty('seed')
+    expect(FLUX_2.buildRequest({ prompt: 'x', seed: 7 }, {} as ResolvedInputs).seed).toBe(7)
+  })
+
+  it('prices per image', () => {
+    const one = FLUX_2.estimatePrice?.({ num_images: 1 })
+    const four = FLUX_2.estimatePrice?.({ num_images: 4 })
+    expect(four?.amount).toBeCloseTo((one?.amount ?? 0) * 4, 5)
+  })
+})

--- a/src/shared/nodes/flux2.ts
+++ b/src/shared/nodes/flux2.ts
@@ -1,0 +1,94 @@
+/**
+ * fal.ai FLUX.2 - text-to-image and multi-reference editing, hosted.
+ * See https://fal.ai/models/fal-ai/flux-2 and https://fal.ai/models/fal-ai/flux-2/edit.
+ *
+ * The same family the local `black-forest-labs/flux-2` Core node runs, without the ~16 GB of
+ * weights. The edit endpoint takes an **array** of reference images and the prompt addresses them
+ * by position ("the jacket from image 2"), so it maps onto the same `image[]` port and the numbered
+ * reference strip the Core node uses.
+ */
+import {
+  approxPrice,
+  constantEndpoint,
+  numberParam,
+  selectParam,
+  seedParam,
+  putSeed,
+} from './builders'
+import type { NodeDef, ResolvedInputs } from './types'
+
+/** fal's named sizes; the API also accepts an explicit {width,height} we do not expose. */
+const IMAGE_SIZES = [
+  'square_hd',
+  'square',
+  'portrait_4_3',
+  'portrait_16_9',
+  'landscape_4_3',
+  'landscape_16_9',
+] as const
+const OUTPUT_FORMATS = ['jpeg', 'png', 'webp'] as const
+/** Trades a little fidelity for latency; `none` is the reference path. */
+const ACCELERATION = ['none', 'regular', 'high'] as const
+
+/** Params shared by both endpoints, in the order they matter to a user. */
+function sharedParams() {
+  return [
+    selectParam('image_size', 'Image size', IMAGE_SIZES, 'landscape_4_3'),
+    numberParam('num_inference_steps', 'Steps', 28, { min: 4, max: 50, step: 1 }),
+    numberParam('guidance_scale', 'Guidance', 2.5, { min: 0, max: 20, step: 0.5 }),
+    numberParam('num_images', 'Count', 1, { min: 1, max: 4, step: 1 }),
+    selectParam('acceleration', 'Acceleration', ACCELERATION, 'none'),
+    selectParam('output_format', 'Output format', OUTPUT_FORMATS, 'png'),
+    seedParam(),
+  ]
+}
+
+function sharedBody(params: Record<string, unknown>): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    prompt: String(params.prompt ?? ''),
+    image_size: params.image_size ?? 'landscape_4_3',
+    num_inference_steps: Number(params.num_inference_steps ?? 28),
+    guidance_scale: Number(params.guidance_scale ?? 2.5),
+    num_images: Number(params.num_images ?? 1),
+    acceleration: params.acceleration ?? 'none',
+    output_format: params.output_format ?? 'png',
+  }
+  putSeed(body, params)
+  return body
+}
+
+const perImage = (params: Record<string, unknown>, unit: number) =>
+  approxPrice(unit * Math.max(1, Number(params.num_images ?? 1)))
+
+export const FLUX_2: NodeDef = {
+  id: 'fal-ai/flux-2',
+  title: 'FLUX.2',
+  category: 'Image',
+  provider: 'fal',
+  outputKind: 'image',
+  inputs: [],
+  params: sharedParams(),
+  outputs: [{ id: 'images', label: 'Image(s)', kind: 'image[]' }],
+  resolveEndpoint: constantEndpoint('fal-ai/flux-2'),
+  buildRequest: (params) => sharedBody(params),
+  estimatePrice: (params) => perImage(params, 0.04),
+}
+
+export const FLUX_2_EDIT: NodeDef = {
+  id: 'fal-ai/flux-2/edit',
+  title: 'FLUX.2 · Edit',
+  category: 'Image',
+  provider: 'fal',
+  outputKind: 'image',
+  // A list input: one reference edits that image, several compose from them. Order is the order
+  // the prompt refers to them in.
+  inputs: [{ id: 'image_urls', label: 'Reference image(s)', kind: 'image[]', required: true }],
+  params: sharedParams(),
+  outputs: [{ id: 'images', label: 'Image(s)', kind: 'image[]' }],
+  resolveEndpoint: constantEndpoint('fal-ai/flux-2/edit'),
+  buildRequest: (params, resolved: ResolvedInputs) => ({
+    ...sharedBody(params),
+    image_urls: resolved.images,
+  }),
+  estimatePrice: (params) => perImage(params, 0.04),
+}

--- a/src/shared/nodes/handles.test.ts
+++ b/src/shared/nodes/handles.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { dotPorts, handleIdForPort, portIdForHandle } from './handles'
+import { MINIMAX_H3_I2V } from './minimaxH3I2V'
+import { MINIMAX_H3_REF2V } from './minimaxH3Ref2V'
+import { SEEDANCE_I2V } from './seedanceI2V'
+import { SONILO_V2M } from './soniloVideoToMusic'
+import { emptyResolvedInputs, portMedia, type NodeDef, type ResolvedInputs } from './types'
+
+describe('canvas handle ids', () => {
+  it('keeps the legacy `in` / `audio` ids for the first port of each kind', () => {
+    // Renaming these would orphan every connector in every existing project.
+    expect(handleIdForPort(SEEDANCE_I2V, SEEDANCE_I2V.inputs[0])).toBe('in')
+    expect(handleIdForPort(SONILO_V2M, SONILO_V2M.inputs[0])).toBe('in')
+    const [images, video, audio] = MINIMAX_H3_REF2V.inputs
+    expect(handleIdForPort(MINIMAX_H3_REF2V, images)).toBe('in')
+    expect(handleIdForPort(MINIMAX_H3_REF2V, video)).toBe('reference_video_urls')
+    expect(handleIdForPort(MINIMAX_H3_REF2V, audio)).toBe('audio')
+  })
+
+  it('gives a second port of the same kind its own id', () => {
+    const [start, end] = MINIMAX_H3_I2V.inputs
+    expect(handleIdForPort(MINIMAX_H3_I2V, start)).toBe('in')
+    expect(handleIdForPort(MINIMAX_H3_I2V, end)).toBe('end_image')
+  })
+
+  it('resolves a handle back to the port it means', () => {
+    expect(portIdForHandle(MINIMAX_H3_I2V, 'in')).toBe('image')
+    expect(portIdForHandle(MINIMAX_H3_I2V, 'end_image')).toBe('end_image')
+    expect(portIdForHandle(MINIMAX_H3_I2V, 'prompt')).toBeNull()
+    expect(portIdForHandle(MINIMAX_H3_I2V, undefined)).toBeNull()
+  })
+
+  it('orders dots media-first, then audio', () => {
+    expect(dotPorts(MINIMAX_H3_REF2V).map((p) => p.id)).toEqual([
+      'reference_image_urls',
+      'reference_video_urls',
+      'reference_audio_urls',
+    ])
+  })
+})
+
+describe('portMedia', () => {
+  const twoImagePorts: NodeDef = MINIMAX_H3_I2V
+
+  it('prefers an explicit wire over the kind bucket', () => {
+    const resolved: ResolvedInputs = {
+      ...emptyResolvedInputs(),
+      images: ['data:a', 'data:b'],
+      byHandle: { end_image: ['data:b'] },
+    }
+    expect(portMedia(twoImagePorts, resolved, 'end_image')).toEqual(['data:b'])
+    // 'a' is the only unclaimed image, so it fills the start port.
+    expect(portMedia(twoImagePorts, resolved, 'image')).toEqual(['data:a'])
+  })
+
+  it('never hands an explicitly-wired item to another port', () => {
+    const resolved: ResolvedInputs = {
+      ...emptyResolvedInputs(),
+      images: ['data:only'],
+      byHandle: { end_image: ['data:only'] },
+    }
+    expect(portMedia(twoImagePorts, resolved, 'image')).toEqual([])
+  })
+
+  it('falls back positionally when nothing is tagged', () => {
+    const resolved: ResolvedInputs = { ...emptyResolvedInputs(), images: ['data:a', 'data:b'] }
+    expect(portMedia(twoImagePorts, resolved, 'image')).toEqual(['data:a'])
+    expect(portMedia(twoImagePorts, resolved, 'end_image')).toEqual(['data:b'])
+  })
+
+  it('gives a list port the whole untagged bucket', () => {
+    const resolved: ResolvedInputs = {
+      ...emptyResolvedInputs(),
+      images: ['data:a', 'data:b', 'data:c'],
+    }
+    expect(portMedia(MINIMAX_H3_REF2V, resolved, 'reference_image_urls')).toEqual([
+      'data:a',
+      'data:b',
+      'data:c',
+    ])
+  })
+
+  it('is unchanged for a def with a single port of a kind', () => {
+    const resolved: ResolvedInputs = { ...emptyResolvedInputs(), images: ['data:a'] }
+    expect(portMedia(SEEDANCE_I2V, resolved, 'image')).toEqual(['data:a'])
+  })
+
+  it('returns nothing for an unknown port', () => {
+    expect(portMedia(SEEDANCE_I2V, emptyResolvedInputs(), 'nope')).toEqual([])
+  })
+})

--- a/src/shared/nodes/handles.ts
+++ b/src/shared/nodes/handles.ts
@@ -1,0 +1,42 @@
+/**
+ * Mapping between a node def's input ports and the canvas handle ids its dots render with.
+ *
+ * The canvas has always named a Generate node's dots `in` (media) and `audio`, and every existing
+ * project's connectors store those strings - renaming them would orphan the edges on the canvas. So
+ * the first image/video port and the first audio port keep those legacy ids; any further port uses
+ * its own id. What gets persisted as an input's `handle` is always the real port id.
+ */
+import { mediaFamily, type InputPort, type NodeDef } from './types'
+
+/** Ports share a dot-naming group when they draw from the same media bucket - except audio, which
+ *  has always had its own dot, so it groups on its own. */
+function dotGroup(port: InputPort): 'media' | 'audio' | null {
+  const family = mediaFamily(port.kind)
+  if (family === null) return null
+  return family === 'audio' ? 'audio' : 'media'
+}
+
+/** The ports a Generate node renders dots for, in top-to-bottom order (media first, then audio). */
+export function dotPorts(def: NodeDef): InputPort[] {
+  return [
+    ...def.inputs.filter((p) => dotGroup(p) === 'media'),
+    ...def.inputs.filter((p) => dotGroup(p) === 'audio'),
+  ]
+}
+
+/** The canvas handle id a port's dot renders with. */
+export function handleIdForPort(def: NodeDef, port: InputPort): string {
+  const group = dotGroup(port)
+  if (group === null) return port.id
+  const peers = def.inputs.filter((p) => dotGroup(p) === group)
+  return peers[0] === port ? (group === 'audio' ? 'audio' : 'in') : port.id
+}
+
+/** The port id a canvas handle refers to, or null when the handle isn't one of this def's inputs. */
+export function portIdForHandle(def: NodeDef, handleId: string | null | undefined): string | null {
+  if (!handleId) return null
+  for (const port of def.inputs) {
+    if (handleIdForPort(def, port) === handleId) return port.id
+  }
+  return null
+}

--- a/src/shared/nodes/minimaxH3.test.ts
+++ b/src/shared/nodes/minimaxH3.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import { MINIMAX_H3_T2V } from './minimaxH3T2V'
+import { MINIMAX_H3_I2V } from './minimaxH3I2V'
+import { MINIMAX_H3_REF2V } from './minimaxH3Ref2V'
+import { getNodeDef, modelOwnerLabel } from './registry'
+import { defaultParams, emptyResolvedInputs, type ResolvedInputs } from './types'
+
+const withImages = (images: string[]): ResolvedInputs => ({ ...emptyResolvedInputs(), images })
+const byHandle = (map: Record<string, string[]>): ResolvedInputs => ({
+  ...emptyResolvedInputs(),
+  images: Object.values(map).flat(),
+  byHandle: map,
+})
+
+describe('MiniMax H3 · text → video', () => {
+  it('sends prompt, duration, 2K resolution and aspect ratio', () => {
+    expect(MINIMAX_H3_T2V.resolveEndpoint(emptyResolvedInputs())).toBe('minimax/h3/text-to-video')
+    const body = MINIMAX_H3_T2V.buildRequest(
+      { ...defaultParams(MINIMAX_H3_T2V), prompt: 'a kitten' },
+      emptyResolvedInputs(),
+    )
+    expect(body).toEqual({
+      prompt: 'a kitten',
+      duration: 5,
+      resolution: '2K',
+      aspect_ratio: '16:9',
+    })
+  })
+
+  it('takes no inputs and declares no seed param (H3 has none)', () => {
+    expect(MINIMAX_H3_T2V.inputs).toEqual([])
+    expect(MINIMAX_H3_T2V.params.map((p) => p.key)).toEqual([
+      'resolution',
+      'duration',
+      'aspect_ratio',
+    ])
+    expect(MINIMAX_H3_T2V.outputKind).toBe('video')
+  })
+
+  it('clamps duration to fal’s 5..15 range', () => {
+    const at = (duration: number): unknown =>
+      MINIMAX_H3_T2V.buildRequest({ prompt: 'p', duration }, emptyResolvedInputs()).duration
+    expect(at(1)).toBe(5)
+    expect(at(9)).toBe(9)
+    expect(at(99)).toBe(15)
+  })
+
+  it('prices at $0.26 per second of 2K output', () => {
+    expect(MINIMAX_H3_T2V.estimatePrice?.({ duration: 5 })?.amount).toBeCloseTo(1.3, 5)
+    expect(MINIMAX_H3_T2V.estimatePrice?.({ duration: 15 })?.amount).toBeCloseTo(3.9, 5)
+    expect(MINIMAX_H3_T2V.estimatePrice?.({ duration: 5 })?.approx).toBe(true)
+  })
+})
+
+describe('MiniMax H3 · image → video', () => {
+  it('declares a required start image and an optional end image', () => {
+    expect(MINIMAX_H3_I2V.inputs).toEqual([
+      { id: 'image', label: 'Image', kind: 'image', required: true },
+      { id: 'end_image', label: 'End image', kind: 'image', required: false },
+    ])
+  })
+
+  it('omits end_image_url when only a start frame is wired', () => {
+    const body = MINIMAX_H3_I2V.buildRequest({ prompt: 'p' }, withImages(['data:start']))
+    expect(body.image_url).toBe('data:start')
+    expect(body.end_image_url).toBeUndefined()
+  })
+
+  it('routes each port by handle, not by insertion order', () => {
+    const body = MINIMAX_H3_I2V.buildRequest(
+      { prompt: 'p' },
+      byHandle({ end_image: ['data:end'], image: ['data:start'] }),
+    )
+    expect(body.image_url).toBe('data:start')
+    expect(body.end_image_url).toBe('data:end')
+  })
+
+  it('falls back to wiring order for untagged inputs', () => {
+    const body = MINIMAX_H3_I2V.buildRequest(
+      { prompt: 'p' },
+      withImages(['data:start', 'data:end']),
+    )
+    expect(body.image_url).toBe('data:start')
+    expect(body.end_image_url).toBe('data:end')
+  })
+
+  it('sends no aspect_ratio - H3 takes framing from the start image', () => {
+    const body = MINIMAX_H3_I2V.buildRequest(
+      { ...defaultParams(MINIMAX_H3_I2V), prompt: 'p' },
+      withImages(['data:start']),
+    )
+    expect(body).toEqual({
+      prompt: 'p',
+      duration: 5,
+      resolution: '2K',
+      image_url: 'data:start',
+    })
+  })
+})
+
+describe('MiniMax H3 · reference → video', () => {
+  it('maps each reference bucket and omits the empty ones', () => {
+    const body = MINIMAX_H3_REF2V.buildRequest(
+      { prompt: 'Image 1 is the lead' },
+      { ...emptyResolvedInputs(), images: ['data:a', 'data:b'] },
+    )
+    expect(body.reference_image_urls).toEqual(['data:a', 'data:b'])
+    expect(body.reference_video_urls).toBeUndefined()
+    expect(body.reference_audio_urls).toBeUndefined()
+    expect(body.aspect_ratio).toBe('adaptive')
+  })
+
+  it('carries video and audio references through', () => {
+    const body = MINIMAX_H3_REF2V.buildRequest(
+      { prompt: 'p' },
+      {
+        ...emptyResolvedInputs(),
+        images: ['data:i'],
+        videos: ['data:v'],
+        audios: ['data:s'],
+      },
+    )
+    expect(body.reference_image_urls).toEqual(['data:i'])
+    expect(body.reference_video_urls).toEqual(['data:v'])
+    expect(body.reference_audio_urls).toEqual(['data:s'])
+  })
+
+  it('trims to fal’s per-kind caps and the 12-file total', () => {
+    const many = (prefix: string, n: number): string[] =>
+      Array.from({ length: n }, (_, i) => `${prefix}${i}`)
+    const body = MINIMAX_H3_REF2V.buildRequest(
+      { prompt: 'p' },
+      {
+        ...emptyResolvedInputs(),
+        images: many('i', 12),
+        videos: many('v', 5),
+        audios: many('s', 5),
+      },
+    )
+    const images = body.reference_image_urls as string[]
+    const videos = body.reference_video_urls as string[]
+    expect(images).toHaveLength(9)
+    expect(videos).toHaveLength(3)
+    // 9 + 3 already fills the 12-file budget, so audio yields.
+    expect(body.reference_audio_urls).toBeUndefined()
+  })
+})
+
+describe('H3 registry wiring', () => {
+  it('registers all three endpoints under a MiniMax group', () => {
+    for (const id of [
+      'minimax/h3/text-to-video',
+      'minimax/h3/image-to-video',
+      'minimax/h3/reference-to-video',
+    ]) {
+      expect(getNodeDef(id)?.id).toBe(id)
+      expect(modelOwnerLabel(id)).toBe('MiniMax')
+    }
+  })
+})

--- a/src/shared/nodes/minimaxH3I2V.ts
+++ b/src/shared/nodes/minimaxH3I2V.ts
@@ -1,0 +1,33 @@
+/**
+ * fal.ai `minimax/h3/image-to-video` - MiniMax H3 (Hailuo 03) image-to-video, 2K.
+ *
+ * Two image ports: the first frame, and an optional last frame that turns the run into a
+ * first-to-last keyframe interpolation. There is no `aspect_ratio` field here - H3 takes the output
+ * framing from the start image. See https://fal.ai/models/minimax/h3/image-to-video.
+ */
+import { constantEndpoint } from './builders'
+import { H3_BASE_PARAMS, buildH3Body, estimateH3Price } from './minimaxH3Shared'
+import { portMedia, type NodeDef, type ResolvedInputs } from './types'
+
+export const MINIMAX_H3_I2V: NodeDef = {
+  id: 'minimax/h3/image-to-video',
+  title: 'MiniMax H3 · Image → Video',
+  category: 'Video',
+  provider: 'fal',
+  outputKind: 'video',
+  inputs: [
+    { id: 'image', label: 'Image', kind: 'image', required: true },
+    { id: 'end_image', label: 'End image', kind: 'image', required: false },
+  ],
+  params: H3_BASE_PARAMS,
+  outputs: [{ id: 'video', label: 'Video', kind: 'video' }],
+  resolveEndpoint: constantEndpoint('minimax/h3/image-to-video'),
+  buildRequest: (params, resolved: ResolvedInputs) => {
+    const end = portMedia(MINIMAX_H3_I2V, resolved, 'end_image')[0]
+    return buildH3Body(params, {
+      image_url: portMedia(MINIMAX_H3_I2V, resolved, 'image')[0] ?? '',
+      ...(end ? { end_image_url: end } : {}),
+    })
+  },
+  estimatePrice: (params) => estimateH3Price(params),
+}

--- a/src/shared/nodes/minimaxH3Ref2V.ts
+++ b/src/shared/nodes/minimaxH3Ref2V.ts
@@ -1,0 +1,57 @@
+/**
+ * fal.ai `minimax/h3/reference-to-video` - MiniMax H3 (Hailuo 03) reference-to-video, 2K.
+ *
+ * The prompt addresses references by modality and position ("Image 1 is the protagonist, Video 1 is
+ * the camera move"), so wiring order is meaning. All references are optional, but fal rejects a set
+ * that is audio only. See https://fal.ai/models/minimax/h3/reference-to-video.
+ */
+import { constantEndpoint, selectParam } from './builders'
+import { H3_ASPECT_RATIOS, H3_BASE_PARAMS, buildH3Body, estimateH3Price } from './minimaxH3Shared'
+import { portMedia, type NodeDef, type ResolvedInputs } from './types'
+
+// fal's caps: 9 images, 3 videos, 3 audios, and no more than 12 files across all three. We trim to
+// them rather than let an over-wired node fail at the API.
+const MAX_IMAGES = 9
+const MAX_VIDEOS = 3
+const MAX_AUDIOS = 3
+const MAX_TOTAL = 12
+
+export const MINIMAX_H3_REF2V: NodeDef = {
+  id: 'minimax/h3/reference-to-video',
+  title: 'MiniMax H3 · Reference → Video',
+  category: 'Video',
+  provider: 'fal',
+  outputKind: 'video',
+  inputs: [
+    { id: 'reference_image_urls', label: 'Images', kind: 'image[]', required: false },
+    { id: 'reference_video_urls', label: 'Video', kind: 'video[]', required: false },
+    { id: 'reference_audio_urls', label: 'Audio', kind: 'audio[]', required: false },
+  ],
+  params: [
+    ...H3_BASE_PARAMS,
+    selectParam('aspect_ratio', 'Aspect ratio', ['adaptive', ...H3_ASPECT_RATIOS], 'adaptive'),
+  ],
+  outputs: [{ id: 'video', label: 'Video', kind: 'video' }],
+  resolveEndpoint: constantEndpoint('minimax/h3/reference-to-video'),
+  buildRequest: (params, resolved: ResolvedInputs) => {
+    const images = portMedia(MINIMAX_H3_REF2V, resolved, 'reference_image_urls').slice(
+      0,
+      MAX_IMAGES,
+    )
+    const videos = portMedia(MINIMAX_H3_REF2V, resolved, 'reference_video_urls').slice(
+      0,
+      MAX_VIDEOS,
+    )
+    // Images and video carry the subject, so audio yields first when the combined cap bites.
+    const audios = portMedia(MINIMAX_H3_REF2V, resolved, 'reference_audio_urls')
+      .slice(0, MAX_AUDIOS)
+      .slice(0, Math.max(0, MAX_TOTAL - images.length - videos.length))
+    return buildH3Body(params, {
+      aspect_ratio: String(params.aspect_ratio ?? 'adaptive'),
+      ...(images.length > 0 ? { reference_image_urls: images } : {}),
+      ...(videos.length > 0 ? { reference_video_urls: videos } : {}),
+      ...(audios.length > 0 ? { reference_audio_urls: audios } : {}),
+    })
+  },
+  estimatePrice: (params) => estimateH3Price(params),
+}

--- a/src/shared/nodes/minimaxH3Shared.ts
+++ b/src/shared/nodes/minimaxH3Shared.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared params + request/price helpers for MiniMax H3 (Hailuo 03): text / image / reference → video.
+ * The three endpoints take the same generation controls; only their inputs and framing differ.
+ */
+import { approxPrice, numberParam, selectParam } from './builders'
+import type { ParamField, PriceEstimate } from './types'
+
+// H3 is 2K-only - fal's schema pins `resolution` to the literal "2K". Kept as a one-option select so
+// the node reads the same as fal's own form and the price rate below has a visible source.
+const RESOLUTIONS = ['2K'] as const
+
+export const H3_ASPECT_RATIOS = ['21:9', '16:9', '4:3', '1:1', '3:4', '9:16'] as const
+
+/** USD per second of 2K output. Reference surcharges are extra; see `estimateH3Price`. */
+const RATE_PER_SECOND = 0.26
+
+const MIN_DURATION = 5
+const MAX_DURATION = 15
+
+/** Resolution + duration, shared by all three H3 endpoints. Aspect ratio is per-endpoint. */
+export const H3_BASE_PARAMS: ParamField[] = [
+  selectParam('resolution', 'Resolution', RESOLUTIONS, '2K'),
+  numberParam('duration', `Duration (${MIN_DURATION} to ${MAX_DURATION}s)`, MIN_DURATION, {
+    min: MIN_DURATION,
+    max: MAX_DURATION,
+    step: 1,
+  }),
+]
+
+export function h3Duration(params: Record<string, unknown>): number {
+  const raw = Math.round(Number(params.duration ?? MIN_DURATION))
+  if (!Number.isFinite(raw)) return MIN_DURATION
+  return Math.min(MAX_DURATION, Math.max(MIN_DURATION, raw))
+}
+
+/** Build an H3 request body: shared controls + `extra` input/framing fields. */
+export function buildH3Body(
+  params: Record<string, unknown>,
+  extra: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    prompt: String(params.prompt ?? ''),
+    duration: h3Duration(params),
+    resolution: '2K',
+    ...extra,
+  }
+}
+
+/**
+ * Base cost only. Reference-to-video also bills for images past the first five and for reference
+ * video, but `estimatePrice` sees params and not the wired inputs, so those cannot be counted here.
+ */
+export function estimateH3Price(params: Record<string, unknown>): PriceEstimate {
+  return approxPrice(RATE_PER_SECOND * h3Duration(params))
+}

--- a/src/shared/nodes/minimaxH3T2V.ts
+++ b/src/shared/nodes/minimaxH3T2V.ts
@@ -1,0 +1,25 @@
+/**
+ * fal.ai `minimax/h3/text-to-video` - MiniMax H3 (Hailuo 03) text-to-video, 2K.
+ * See https://fal.ai/models/minimax/h3/text-to-video.
+ */
+import { constantEndpoint, selectParam } from './builders'
+import { H3_ASPECT_RATIOS, H3_BASE_PARAMS, buildH3Body, estimateH3Price } from './minimaxH3Shared'
+import type { NodeDef } from './types'
+
+export const MINIMAX_H3_T2V: NodeDef = {
+  id: 'minimax/h3/text-to-video',
+  title: 'MiniMax H3 · Text → Video',
+  category: 'Video',
+  provider: 'fal',
+  outputKind: 'video',
+  inputs: [],
+  params: [
+    ...H3_BASE_PARAMS,
+    selectParam('aspect_ratio', 'Aspect ratio', H3_ASPECT_RATIOS, '16:9'),
+  ],
+  outputs: [{ id: 'video', label: 'Video', kind: 'video' }],
+  resolveEndpoint: constantEndpoint('minimax/h3/text-to-video'),
+  buildRequest: (params) =>
+    buildH3Body(params, { aspect_ratio: String(params.aspect_ratio ?? '16:9') }),
+  estimatePrice: (params) => estimateH3Price(params),
+}

--- a/src/shared/nodes/registry.ts
+++ b/src/shared/nodes/registry.ts
@@ -15,6 +15,9 @@ import { FLUX_2, FLUX_2_EDIT } from './flux2'
 import { SONILO_V2M } from './soniloVideoToMusic'
 import { SONILO_T2M } from './soniloTextToMusic'
 import { SONILO_V2V } from './soniloVideoToVideo'
+import { MINIMAX_H3_T2V } from './minimaxH3T2V'
+import { MINIMAX_H3_I2V } from './minimaxH3I2V'
+import { MINIMAX_H3_REF2V } from './minimaxH3Ref2V'
 
 export const NODE_DEFS: readonly NodeDef[] = [
   GPT_IMAGE_2,
@@ -24,6 +27,9 @@ export const NODE_DEFS: readonly NodeDef[] = [
   SEEDANCE_T2V,
   SEEDANCE_I2V,
   SEEDANCE_REF2V,
+  MINIMAX_H3_T2V,
+  MINIMAX_H3_I2V,
+  MINIMAX_H3_REF2V,
   KREA_V2,
   FLUX_2,
   FLUX_2_EDIT,
@@ -52,6 +58,8 @@ const OWNER_LABELS: Record<string, string> = {
   bytedance: 'ByteDance',
   krea: 'Krea',
   sonilo: 'Sonilo',
+  // H3's ids have no `fal-ai/` prefix, unlike MiniMax's older Hailuo endpoints.
+  minimax: 'MiniMax',
 }
 
 export function modelOwner(id: string): string {

--- a/src/shared/nodes/registry.ts
+++ b/src/shared/nodes/registry.ts
@@ -11,6 +11,7 @@ import { SEEDANCE_T2V } from './seedanceT2V'
 import { SEEDANCE_I2V } from './seedanceI2V'
 import { SEEDANCE_REF2V } from './seedanceRef2V'
 import { KREA_V2 } from './kreaV2'
+import { FLUX_2, FLUX_2_EDIT } from './flux2'
 import { SONILO_V2M } from './soniloVideoToMusic'
 import { SONILO_T2M } from './soniloTextToMusic'
 import { SONILO_V2V } from './soniloVideoToVideo'
@@ -24,6 +25,8 @@ export const NODE_DEFS: readonly NodeDef[] = [
   SEEDANCE_I2V,
   SEEDANCE_REF2V,
   KREA_V2,
+  FLUX_2,
+  FLUX_2_EDIT,
   SONILO_V2M,
   SONILO_T2M,
   SONILO_V2V,

--- a/src/shared/nodes/types.ts
+++ b/src/shared/nodes/types.ts
@@ -10,7 +10,15 @@
  */
 
 /** The common input/output type system. Ports declare what kind of media flows through them. */
-export type PortKind = 'image' | 'image[]' | 'video' | 'audio' | 'text' | 'path'
+export type PortKind =
+  | 'image'
+  | 'image[]'
+  | 'video'
+  | 'video[]'
+  | 'audio'
+  | 'audio[]'
+  | 'text'
+  | 'path'
 
 /** A typed input socket on a node (left side). */
 export interface InputPort {
@@ -69,6 +77,11 @@ export interface ResolvedInputs {
   videos: string[]
   audios: string[]
   texts: string[]
+  /**
+   * The same URIs keyed by the input port each was wired to. Only defs with two ports of one kind
+   * need this - read it through `portMedia`, never directly, so untagged inputs still resolve.
+   */
+  byHandle: Record<string, string[]>
 }
 
 /** An estimated cost for one generation. Models price differently (per image / MP / second / …). */
@@ -137,7 +150,46 @@ export function defaultParams(def: NodeDef): ParamValues {
   return out
 }
 
+/**
+ * The media wired to one of a def's input ports.
+ *
+ * Prefers the explicit per-port routing (`byHandle`, set when the user wires an edge into a specific
+ * dot). Falls back to the kind buckets for untagged inputs - drag-drop, and every input made before
+ * inputs recorded their port - handing the def's Nth port of that kind the Nth untagged item, or the
+ * whole bucket for a list port. For a def with one port of a kind this is exactly the old behaviour.
+ */
+export function portMedia(def: NodeDef, resolved: ResolvedInputs, portId: string): string[] {
+  const explicit = resolved.byHandle[portId]
+  if (explicit?.length) return explicit
+  const port = def.inputs.find((p) => p.id === portId)
+  if (!port) return []
+  const family = mediaFamily(port.kind)
+  if (!family) return []
+  const bucket =
+    family === 'video' ? resolved.videos : family === 'audio' ? resolved.audios : resolved.images
+  // Anything already claimed by an explicit wire is not up for positional fallback.
+  const claimed = new Set(Object.values(resolved.byHandle).flat())
+  const untagged = bucket.filter((uri) => !claimed.has(uri))
+  if (isListPort(port.kind)) return untagged
+  const peers = def.inputs.filter((p) => mediaFamily(p.kind) === family)
+  const picked = untagged[peers.indexOf(port)]
+  return picked === undefined ? [] : [picked]
+}
+
+/** Which resolved-input bucket a port draws from, or null for non-media kinds. */
+export function mediaFamily(kind: PortKind): 'image' | 'video' | 'audio' | null {
+  if (kind === 'image' || kind === 'image[]') return 'image'
+  if (kind === 'video' || kind === 'video[]') return 'video'
+  if (kind === 'audio' || kind === 'audio[]') return 'audio'
+  return null
+}
+
+/** True when a port accepts several wires, so its order carries meaning. */
+export function isListPort(kind: PortKind): boolean {
+  return kind === 'image[]' || kind === 'video[]' || kind === 'audio[]'
+}
+
 /** An empty `ResolvedInputs` (all kinds empty) - a convenience for callers/tests. */
 export function emptyResolvedInputs(): ResolvedInputs {
-  return { images: [], masks: [], videos: [], audios: [], texts: [] }
+  return { images: [], masks: [], videos: [], audios: [], texts: [], byHandle: {} }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -423,7 +423,7 @@ export interface ModelDownloadErrorEvent {
 
 /** Turbo needs a training adapter to avoid "turbo drift"; a de-turbo base trains without one. */
 /** The model family a LoRA is trained for. */
-export type TrainingArch = 'z-image' | 'krea2'
+export type TrainingArch = 'z-image' | 'krea2' | 'flux2'
 
 /**
  * Which base checkpoint a run trains against. `raw` is Krea 2's undistilled base (the recommended

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -74,6 +74,8 @@ export interface FrameInput {
   assetId: string | null
   sourceFrameId: string | null
   position: number
+  /** The model input port this was wired to, or null when untagged (drag-drop / pre-v17 rows). */
+  handle: string | null
 }
 
 /** Every ComfyUI render of a frame becomes an immutable Take. */


### PR DESCRIPTION
## FLUX.2 locally, MiniMax H3 on fal

Adds FLUX.2 to the built in engine, the MiniMax H3 family as API nodes, and
getting started cards so a new project is one click from a working graph.

Ships as 1.2.6.

### FLUX.2 on your own GPU

- One node covers the whole family: klein 4B, klein 9B, both Base builds, the KV
  variant and dev.
- Checkpoints are identified by their tensor shapes, never by filename, so
  `diffusion_models/` can hold Z-Image, Krea 2 and FLUX.2 side by side.
- A diffusers folder counts as a checkpoint. That is the only practical way to
  get a 32B dev build onto a 24 GB card.
- Multi reference composition. Wire several images into one node and address
  them by position in the prompt. The node numbers them on its face.
- ControlNet support, and LoRA training in the Trainer tab against Base builds.
- Staged loading when the encoder and transformer cannot be co resident. The
  prompt is encoded first and the encoder freed before the transformer loads.

### MiniMax H3 API nodes

- Three nodes: text to video, image to video, reference to video.
- 2K only, 5 to 15 seconds, $0.26 per second. The node shows a live estimate.
- Image to video has a second image port for an optional end frame, which gives
  first to last keyframe generation.
- Reference to video takes up to 9 images plus reference video and audio, and
  trims to fal's caps rather than failing at the API.
- No seed and no prompt optimizer. Neither exists in H3's schema, unlike older
  MiniMax endpoints.

### Getting started cards

- An empty canvas now offers five ways to start instead of nothing.
- Each card says how that model will run on this specific GPU, and is never
  gating, since the device policy fits the model either way.
- One click builds a prompt node wired into a model node with settings and a
  prompt already filled in.
- Includes an API Nodes card for people with no GPU, opening on MiniMax H3.

### New: per port input routing

- `frame_inputs` now records which input port each input was wired to.
- Lets a model declare two ports of the same kind and tell them apart, which is
  what makes the end frame work.
- Untagged inputs still resolve by media kind, so existing projects and drag and
  drop behave exactly as before.
- Reading goes through one helper, `portMedia`, so the fallback lives in one
  place.

### Fixes

- Wiring a Load Assets node into a Generate node drew an edge and recorded no
  input at all. The request went out with an empty URL and fal answered with a
  422 that pointed nowhere near the cause.
- A FLUX.2 model pick stored as a full path resolved to nothing and surfaced as
  `'None' is not a FLUX.2 diffusion model`.
- The FLUX.2 pre flight check reported a checkpoint present when only the
  `variant` param resolved, so a missing file failed late and opaquely instead
  of at the guard.
- Number params in the fal Adjust panel could not be cleared. An emptied box
  snapped straight back to 0.
- The settings panel persisted on pointerdown, before the input blurred and
  clamped, so an out of range value stuck in the field while the request quietly
  used a different one.
- Prompt nodes showed empty text when something wrote the prompt just after
  mount, such as a getting started card.