### PR TITLE
Minimax h3 lora training

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 Inline Studio is a free, open-source app for **AI filmmaking on a node canvas**, powered by the built-in **Inline Core** engine (local diffusion models) and hosted [fal](https://fal.ai) models. It gives AI filmmakers a free-form canvas to build a whole visual pipeline, from moodboard to final cut.
 
 - **Non-destructive by default** - every render is kept as a versioned take; generating again adds one, nothing is overwritten.
-- **Local diffusion generation engine** - the built-in Inline Core engine runs popular diffusion models on your own GPU from a single model file, no external server. Currently supported: **Z-Image Turbo**, **Krea 2** (RAW + Turbo), and **FLUX.2**.
+- **Local diffusion generation engine** - the built-in Inline Core engine runs popular diffusion models on your own GPU from a single model file, no external server. Currently supported: **Z-Image Turbo**, **Krea 2** (RAW + Turbo), **FLUX.2**, and **MiniMax H3** for video with sound.
 - **Hosted models via API Nodes** - reach for closed models with no GPU and no setup for instant creative range; see [API Nodes](#api-nodes).
 - **Mix both in the same film** - Inline Studio handles everything around the render: exploring options, keeping what works, and shaping a repeatable process you can iterate on and share.
 
@@ -165,7 +165,7 @@ The friendly launcher (in `core/`) maps flags onto the engine's `INLINE_*` envir
 - **Versioned, non-destructive takes** - every render is kept. Generating again adds a new take; nothing is overwritten. Star the keeper and it flows downstream.
 - **Chain frames into a generative pipeline** - wire one frame's output into the next frame's input. Refine a shot, feed it forward, regenerate the source, and everything downstream follows.
 - **Video editing on the canvas** - the **Video Director node** is a timeline-in-a-node that assembles your rendered frames into a single cut, with layered audio (the videos' own audio plus your own music/VO), per-input and per-layer volume, an in-node preview to scrub, and high-res export; the **Trim Video/Audio node** lets you drop in a clip, drag the in/out handles over its filmstrip/waveform, and pass just the trimmed segment downstream.
-- **Local generation, built in** - the Inline Core engine runs diffusion models on your own GPU. Z-Image Turbo, Krea 2, and FLUX.2 from single model files (or a diffusers folder for a prequantized build), no external server to set up.
+- **Local generation, built in** - the Inline Core engine runs diffusion models on your own GPU. Z-Image Turbo, Krea 2, FLUX.2, and MiniMax H3 video from single model files (or a diffusers folder for a prequantized build), no external server to set up.
 - **Multi-reference composition** - with **FLUX.2**, wire several images into one node and compose from them: "the character from image 1 wearing the jacket from image 2". The node numbers the references on its face so the prompt can address them by position. One image edits it, several combine them. See [FLUX.2](#flux2).
 - **Train your own LoRAs** - the Trainer tab is a second canvas where the dataset, captioning, training run, and loss curve are all nodes. The finished LoRA drops into `models/loras/` and shows up in the LoRA loader node, ready to generate with. See [LoRA training](#lora-training).
 - **API Nodes for hosted models** - run closed models right on the canvas with no GPU. Add a Generate node, pick a model, and bring your own provider key. See [API Nodes](#api-nodes).
@@ -186,10 +186,10 @@ From the home screen, **Export** zips a project into one archive. Import it on t
 
 Pick whatever fits the shot, and mix both in one film. However you render, the frame keeps its full take history, so you never lose a good version.
 
-| How you render                          | What it's like                                                                                                                                                                                                                                                                                                                                                                        | What you need                                                                                                                                                                                             |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Local GPU: Inline Core** _(built in)_ | Drop a **Z-Image Turbo**, **Krea 2**, or **FLUX.2** node, wire a prompt, hit Run: one node, no loader/sampler wiring. A single `.safetensors` is usually all you bring (a prequantized build can be a diffusers folder); the engine pairs it with a VAE + text-encoder and downloads nothing behind your back. Two or more GPUs? It can split one image's denoise across them (xDiT). | Your own GPU. No account, no external server. Low-VRAM friendly: it auto-fits the model to your card (streaming weights, int8, then NF4) so a model too big for full precision still runs, with no flags. |
-| **Hosted: API Nodes**                   | Add a Generate node and pick a model: hosted, closed models across image, video, and audio. No GPU, instant range. See [API Nodes](#api-nodes) for the model list and providers.                                                                                                                                                                                                      | A provider key (currently [fal](https://fal.ai/dashboard/keys)); it stays on your machine, and you pay per render (each node estimates the price first).                                                  |
+| How you render                          | What it's like                                                                                                                                                                                                                                                                                                                                                                                        | What you need                                                                                                                                                                                             |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Local GPU: Inline Core** _(built in)_ | Drop a **Z-Image Turbo**, **Krea 2**, **FLUX.2**, or **MiniMax H3** node, wire a prompt, hit Run: one node, no loader/sampler wiring. A single `.safetensors` is usually all you bring (a prequantized build can be a diffusers folder); the engine pairs it with a VAE + text-encoder and downloads nothing behind your back. Two or more GPUs? It can split one image's denoise across them (xDiT). | Your own GPU. No account, no external server. Low-VRAM friendly: it auto-fits the model to your card (streaming weights, int8, then NF4) so a model too big for full precision still runs, with no flags. |
+| **Hosted: API Nodes**                   | Add a Generate node and pick a model: hosted, closed models across image, video, and audio. No GPU, instant range. See [API Nodes](#api-nodes) for the model list and providers.                                                                                                                                                                                                                      | A provider key (currently [fal](https://fal.ai/dashboard/keys)); it stays on your machine, and you pay per render (each node estimates the price first).                                                  |
 
 For local generation, either drop a `.safetensors` into `core/models/diffusion_models/`, or add a model node and use its **model popup** (a blinking hint shows up when something's missing) to download the diffusion model, VAE, and text-encoder into `core/models/`, with visible progress. The canvas and planning work with no models at all. See [Krea 2](#krea-2) and [FLUX.2](#flux2) for those models' files and VRAM.
 
@@ -292,6 +292,7 @@ Worth knowing before you start a download this size:
 - **This is a big model.** 144 GB for the first three nodes, 210 GB with the reference node. A 33B transformer runs beside a 32B conditioner, but not at the same time: the prompt is encoded first, the conditioner then steps off the card, and the denoiser takes it for the whole denoise. Two things make that fit. The modulation weights, 40% of the transformer, are factorised at load and take it from 66.3 GB to 40.3 GB. The video VAE stays resident when the card has room, rather than streaming leaf by leaf. Measured on a 45 GB card: **a 10 second clip at 960x544 takes about 7.2 minutes, peaking at 38.9 GB VRAM and 46.7 GB of system RAM that cannot be reclaimed**, so plan on 64 GB of RAM. Smaller cards stream more and are slower. If that is out of reach, the same model is available as an API node with no setup at all.
 - **Canvas is the biggest speed lever.** 960x544 renders about 2.3x faster per step than the trained 1344x768, and the difference is far larger than any other setting.
 - **Only the bf16 builds load.** The `int8_convrot` and `pruned` files carry scale tensors and a reworked modulation branch that only ComfyUI reads, the same story as the Krea 2 files above. The node's model picker lists them with the reason rather than hiding them, so a wasted download at least explains itself. Memory saving is the device policy's job here.
+- **LoRAs work.** Every H3 node has a LoRA input, and adapters are fused into each block as it streams, before the factorisation and the quantisation. You can train one in the Trainer tab: see [LoRA training](#lora-training). An H3 LoRA is trained on stills and applies to video, so it carries look and style rather than motion.
 
 ### ControlNet
 
@@ -389,7 +390,7 @@ A dataset's trigger word is prepended to every caption during training, so the m
 
 ### Architecture and base model modes
 
-The Trainer's Adjust panel picks the **architecture** first (Z-Image, Krea 2, or FLUX.2), then a base within it. Training directly on a step-distilled checkpoint breaks the distillation down (turbo drift), so each architecture offers a way around that.
+The Trainer's Adjust panel picks the **architecture** first (Z-Image, Krea 2, FLUX.2, or MiniMax H3), then a base within it. Training directly on a step-distilled checkpoint breaks the distillation down (turbo drift), so each architecture offers a way around that.
 
 **Krea 2** avoids the problem outright, which is why it is the recommended path:
 
@@ -399,6 +400,13 @@ The Trainer's Adjust panel picks the **architecture** first (Z-Image, Krea 2, or
 **FLUX.2** works like Krea 2, with no adapter to download:
 
 - **FLUX.2 Base** is the only option, and the trainer refuses a distilled checkpoint rather than letting a run produce a bad adapter hours later. Put `flux-2-klein-base-4b.safetensors` in `models/diffusion_models/`, train, then generate with the distilled **klein 4B** checkpoint. The LoRA carries over unchanged.
+
+**MiniMax H3** is the video model, and it trains on **still images**:
+
+- **FL2VA** is the only base, and it is undistilled, so there is no adapter and nothing to drift. Put `minimax_h3_fl2va_bf16.safetensors` in `models/diffusion_models/`, train on stills, then wire the LoRA into any of the four H3 nodes. It loads on the Reference to Video node too, which uses a different checkpoint file: the two partitions are the same architecture.
+- **What it learns** is appearance - look, style, character, lighting. It does not learn motion or sound, because it never sees any. This is how image LoRAs for video models are normally trained, and it is the same thing every other H3 trainer does today.
+- **The base is 4-bit, always.** H3 is 40GB after the AdaLN factorisation, before activations or the adapter, so full precision is refused rather than offered and then failing. There is no base-precision control for H3 for the same reason.
+- **Bring a big card and a lot of patience.** The download alone is about 124GB, and the run encodes latents and captions in two separate passes before the base loads, because H3's video VAE and its 32B conditioner cannot be resident at the same time.
 
 **Z-Image** is distilled either way:
 
@@ -447,6 +455,8 @@ The LoRA a run produces lands in `models/loras/` and shows up in the LoRA loader
 | FLUX.2  | Base (klein 4B) | 512  | **4-bit**      | 8.6GB         | not measured  |
 | FLUX.2  | Base (klein 4B) | 1024 | bf16           | 9.9GB         | not measured  |
 | FLUX.2  | Base (klein 4B) | 1024 | **4-bit**      | 9.9GB         | not measured  |
+
+**MiniMax H3 is not in the table yet.** Its training path is built and tested, but the peak-VRAM sweep has not been run, and putting an estimate in a column full of measurements would be worse than the gap. What is known from the component sizes rather than from a run: the base is 40GB after the AdaLN factorisation and roughly a quarter of that at 4-bit, the 32B conditioner is about 19GB during the caption pass, and the two never overlap. A 16GB card is out regardless, since the conditioner pass alone exceeds it. The numbers land here once the sweep has run.
 
 A training adapter is free: it is fused into the base before training starts, so Turbo-plus-adapter and the undistilled base peak identically.
 
@@ -509,7 +519,7 @@ Only for **local** generation. The built-in Inline Core engine renders on the GP
 
 ### What models can I run?
 
-See [Two ways to generate](#two-ways-to-generate): local Z-Image, [Krea 2](#krea-2), or [FLUX.2](#flux2) on your own GPU, or hosted fal models. Adding a new local model is a Core change (a model runner), no UI release.
+See [Two ways to generate](#two-ways-to-generate): local Z-Image, [Krea 2](#krea-2), [FLUX.2](#flux2), or [MiniMax H3](#minimax-h3) on your own GPU, or hosted fal models. Adding a new local model is a Core change (a model runner), no UI release.
 
 ## Contributing
 
@@ -526,6 +536,8 @@ The LoRA trainer's approach to training on a step-distilled model follows [**ai-
 Krea 2 support follows the reference implementations in [**diffusers**](https://github.com/huggingface/diffusers) (`Krea2Pipeline` and the Krea 2 DreamBooth LoRA example). Krea 2 is released by [Krea AI](https://www.krea.ai/) under the [Krea AI Community License](https://www.krea.ai/krea-2-licensing); the weights are the user's to obtain and use under that license.
 
 [**FLUX.2**](https://bfl.ai/blog/flux-2) is released by Black Forest Labs. klein 4B, its Base build, and the VAE are Apache 2.0; dev and the 9B builds carry non-commercial terms. The weights are the user's to obtain and use under those.
+
+[**MiniMax H3**](https://huggingface.co/MiniMaxAI/MiniMax-H3) is released by MiniMax under the MiniMax H3 Community License; the weights are the user's to obtain and use under that. Support is built on the [**diffusers**](https://github.com/huggingface/diffusers) integration from its MiniMax-H3 pull request, vendored with provenance until it lands upstream.
 
 ## Help shape Inline Studio
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 <h3 align="center">AI filmmaking on a node canvas</h3>
 
-<p align="center">Inline Studio is a free, open-source app for AI filmmakers. Build a whole visual pipeline on a free-form node canvas, from moodboard to final cut, with local diffusion models (the built-in Inline Core engine) and hosted fal models. Train your own LoRAs on the same canvas. Every render is kept as a versioned, non-destructive take.</p>
+<p align="center">Inline Studio is a free, open-source app for AI filmmakers. Generate locally on your own GPU and train your own LoRAs on the same node canvas, with the built-in Inline Core engine and hosted fal models. Build a whole visual pipeline from moodboard to final cut, and every render is kept as a versioned, non-destructive take.</p>
 
 <p align="center">
   <a href="LICENSE"><img alt="License: GPLv3" src="https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge"></a>
   <a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/Python-3.11%2B-blue?style=for-the-badge&logo=python&logoColor=white"></a>
-  <a href="../../releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/Release-v1.2.61-blue?style=for-the-badge"></a>
+  <a href="../../releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/Release-v1.2.62-blue?style=for-the-badge"></a>
   <a href="https://discord.gg/cSUS88VdY9"><img alt="Join our Discord" src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white&style=for-the-badge"></a>
 </p>
 
@@ -15,12 +15,19 @@
 
 [**New here? Check out our getting started guide →**](https://inlinestudio.art/getting-started)
 
+**Contents:** [What is Inline Studio?](#what-is-inline-studio) · [Get Started](#get-started) ·
+[Features](#features) · [LoRA training](#lora-training) · [How it works](#how-it-works) ·
+[Two ways to generate](#two-ways-to-generate) · [Inline Core engine](#inline-core-generation-engine)
+([Krea 2](#krea-2), [FLUX.2](#flux2), [MiniMax H3](#minimax-h3), [ControlNet](#controlnet)) ·
+[API Nodes](#api-nodes) · [FAQ](#faq) · [Contributing](#contributing)
+
 ## What is Inline Studio?
 
 Inline Studio is a free, open-source app for **AI filmmaking on a node canvas**, powered by the built-in **Inline Core** engine (local diffusion models) and hosted [fal](https://fal.ai) models. It gives AI filmmakers a free-form canvas to build a whole visual pipeline, from moodboard to final cut.
 
 - **Non-destructive by default** - every render is kept as a versioned take; generating again adds one, nothing is overwritten.
-- **Local diffusion generation engine** - the built-in Inline Core engine runs popular diffusion models on your own GPU from a single model file, no external server. Currently supported: **Z-Image Turbo**, **Krea 2** (RAW + Turbo), **FLUX.2**, and **MiniMax H3** for video with sound.
+- **Local diffusion generation engine** - the built-in Inline Core engine runs popular diffusion models locally, on your own GPU, from a single model file, no external server. Currently supported: **Z-Image Turbo**, **Krea 2** (RAW + Turbo), **FLUX.2**, and **MiniMax H3** for video with sound.
+- **Train LoRAs locally** - the Trainer canvas fine-tunes Z-Image, Krea 2, FLUX.2 or MiniMax H3 on your own images, on your own GPU. With a 4-bit base, Krea 2 trains at 512px inside about 12GB, so a 16GB card can train a LoRA for a 26GB model. See [LoRA training](#lora-training).
 - **Hosted models via API Nodes** - reach for closed models with no GPU and no setup for instant creative range; see [API Nodes](#api-nodes).
 - **Mix both in the same film** - Inline Studio handles everything around the render: exploring options, keeping what works, and shaping a repeatable process you can iterate on and share.
 
@@ -100,7 +107,7 @@ Three gotchas:
 **Known limits, so you can judge before installing:**
 
 - **Local model coverage is Z-Image Turbo, Krea 2 and FLUX.2** today. SDXL and others are planned; hosted models via [API Nodes](#api-nodes) need no GPU at all.
-- **Krea 2 is a 12.9B model and needs a big card to generate.** The bf16 checkpoint is 26 GB on disk, and generation peaks around 36 GB at 1024 with guidance on, so a 40 GB+ GPU is the practical floor for inference. **Training is cheaper than generating**, because the 4-bit base path puts Krea 2 LoRA training at 512 inside 12 GB - see [Benchmark results](#benchmark-results). Z-Image remains the low-VRAM path for generation.
+- **Krea 2 is a 12.9B model and needs a big card to generate.** The bf16 checkpoint is 26 GB on disk, and generation peaks around 36 GB at 1024 with guidance on, so a 40 GB+ GPU is the practical floor for inference. **Training is cheaper than generating**, because the 4-bit base path puts Krea 2 LoRA training at 512 inside 12 GB - see [Benchmark results](TRAINING.md#benchmark-results). Z-Image remains the low-VRAM path for generation.
 - **1024² with Guidance (CFG) above 0 needs more than 16 GB.** CFG runs the prompt and negative prompt together, doubling the denoise. Z-Image Turbo is distilled to run CFG-free - at Guidance 0, 1024² fits in ~11.5 GB. FLUX.2 klein 4B peaks near 17.9 GB at bf16, so 24 GB holds it resident and a 16 GB card runs it quantized instead.
 
 </details>
@@ -165,14 +172,52 @@ The friendly launcher (in `core/`) maps flags onto the engine's `INLINE_*` envir
 - **Versioned, non-destructive takes** - every render is kept. Generating again adds a new take; nothing is overwritten. Star the keeper and it flows downstream.
 - **Chain frames into a generative pipeline** - wire one frame's output into the next frame's input. Refine a shot, feed it forward, regenerate the source, and everything downstream follows.
 - **Video editing on the canvas** - the **Video Director node** is a timeline-in-a-node that assembles your rendered frames into a single cut, with layered audio (the videos' own audio plus your own music/VO), per-input and per-layer volume, an in-node preview to scrub, and high-res export; the **Trim Video/Audio node** lets you drop in a clip, drag the in/out handles over its filmstrip/waveform, and pass just the trimmed segment downstream.
-- **Local generation, built in** - the Inline Core engine runs diffusion models on your own GPU. Z-Image Turbo, Krea 2, FLUX.2, and MiniMax H3 video from single model files (or a diffusers folder for a prequantized build), no external server to set up.
+- **Local generation, built in** - the Inline Core engine runs diffusion models locally, on your own GPU. Z-Image Turbo, Krea 2, FLUX.2, and MiniMax H3 video from single model files (or a diffusers folder for a prequantized build), no external server to set up.
 - **Multi-reference composition** - with **FLUX.2**, wire several images into one node and compose from them: "the character from image 1 wearing the jacket from image 2". The node numbers the references on its face so the prompt can address them by position. One image edits it, several combine them. See [FLUX.2](#flux2).
-- **Train your own LoRAs** - the Trainer tab is a second canvas where the dataset, captioning, training run, and loss curve are all nodes. The finished LoRA drops into `models/loras/` and shows up in the LoRA loader node, ready to generate with. See [LoRA training](#lora-training).
+- **Train your own LoRAs locally** - the Trainer tab is a second canvas where the dataset, captioning, training run, and loss curve are all nodes. Training runs on your own GPU, the finished LoRA drops into `models/loras/`, and it shows up in the LoRA loader node ready to generate with. See [LoRA training](#lora-training).
 - **API Nodes for hosted models** - run closed models right on the canvas with no GPU. Add a Generate node, pick a model, and bring your own provider key. See [API Nodes](#api-nodes).
 - **Community extensions** - install custom nodes from a GitHub repo in one click, security-reviewed and dependency-isolated. Browse the [registry](https://github.com/inlineresearch/Inline-Registry) or [build your own](https://github.com/inlineresearch/Inline-Studio-Extension-Guide).
 - **Free & open source (GPL-3.0)** - one process (Python + a browser); runs on macOS, Windows, and Linux.
 
 [**Follow our Animated Short Film with LTX 2.3 and GPT Image Generation tutorial →**](https://inlinestudio.art/projects/circuit-race)
+
+## LoRA training
+
+Train a LoRA on your own images without leaving the app, on your own GPU, with no cloud step. The **Trainer** tab is a second canvas: wire up the nodes, press Start, and watch it run. When the run finishes, the `.safetensors` lands in `models/loras/`, where the LoRA loader node picks it up automatically, so you can generate with it over in the Studio tab straight away.
+
+![Inline Studio Trainer tab showing the LoRA training node graph with a dataset, live logs, and a loss curve](https://raw.githubusercontent.com/inlineresearch/Inline-Studio/main/screenshots/lora-trainer.png)
+
+Five nodes, wired left to right, with the hyperparameters behind an Adjust button so the node face stays a status surface:
+
+```
+[ Load Dataset ] --> [ Caption ] --> [ Train LoRA ] --> [ Graph ]
+                                          |
+                                          +--> Resources (VRAM monitor)
+```
+
+### Does my card fit?
+
+Peak VRAM at 512px, 12 steps, rank 16, batch 1, gradient checkpointing on:
+
+| Architecture              | 512px peak | 16GB card      |
+| ------------------------- | ---------- | -------------- |
+| FLUX.2 (klein Base 4B)    | ~8.6GB     | yes            |
+| Krea 2 (4-bit base)       | ~11.9GB    | yes            |
+| Z-Image                   | ~13.4GB    | yes            |
+| MiniMax H3 (4-bit, video) | ~20.6GB    | no, needs 24GB |
+
+Training is cheaper than generating, and a LoRA trained at 512 applies at any generation resolution. Full per-card matrix, both resolutions and the timings: [Benchmark results](TRAINING.md#benchmark-results).
+
+If you installed with `--extra all` from [Get Started](#get-started), the trainer is ready. Otherwise:
+
+```bash
+cd core
+./webui.sh --install --extra training   # Windows: .\webui.bat --install --extra training
+```
+
+For a worked example, see [`inlineresearch/skin-lora-krea-2-raw`](https://huggingface.co/inlineresearch/skin-lora-krea-2-raw), a photorealistic skin LoRA trained here on the Krea 2 RAW base from the 26 image and caption pairs published as [`inlineresearch/krea2-skin-lora`](https://huggingface.co/datasets/inlineresearch/krea2-skin-lora).
+
+**[TRAINING.md](TRAINING.md) is the full reference:** [which base to train on](TRAINING.md#architecture-and-base-model-modes) · [measured benchmarks](TRAINING.md#benchmark-results) · [datasets and outputs](TRAINING.md#datasets-and-outputs) · [stop and resume](TRAINING.md#stop-and-resume) · [trigger words](TRAINING.md#trigger-words) · [base precision](TRAINING.md#base-precision)
 
 ## How it works
 
@@ -186,10 +231,10 @@ From the home screen, **Export** zips a project into one archive. Import it on t
 
 Pick whatever fits the shot, and mix both in one film. However you render, the frame keeps its full take history, so you never lose a good version.
 
-| How you render                          | What it's like                                                                                                                                                                                                                                                                                                                                                                                        | What you need                                                                                                                                                                                             |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Local GPU: Inline Core** _(built in)_ | Drop a **Z-Image Turbo**, **Krea 2**, **FLUX.2**, or **MiniMax H3** node, wire a prompt, hit Run: one node, no loader/sampler wiring. A single `.safetensors` is usually all you bring (a prequantized build can be a diffusers folder); the engine pairs it with a VAE + text-encoder and downloads nothing behind your back. Two or more GPUs? It can split one image's denoise across them (xDiT). | Your own GPU. No account, no external server. Low-VRAM friendly: it auto-fits the model to your card (streaming weights, int8, then NF4) so a model too big for full precision still runs, with no flags. |
-| **Hosted: API Nodes**                   | Add a Generate node and pick a model: hosted, closed models across image, video, and audio. No GPU, instant range. See [API Nodes](#api-nodes) for the model list and providers.                                                                                                                                                                                                                      | A provider key (currently [fal](https://fal.ai/dashboard/keys)); it stays on your machine, and you pay per render (each node estimates the price first).                                                  |
+| How you render                          | What it's like                                                                                                                                                                                                                                                                                                                                                                                        | What you need                                                                                                                                                                                                             |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Local GPU: Inline Core** _(built in)_ | Drop a **Z-Image Turbo**, **Krea 2**, **FLUX.2**, or **MiniMax H3** node, wire a prompt, hit Run: one node, no loader/sampler wiring. A single `.safetensors` is usually all you bring (a prequantized build can be a diffusers folder); the engine pairs it with a VAE + text-encoder and downloads nothing behind your back. Two or more GPUs? It can split one image's denoise across them (xDiT). | Runs locally on your own GPU. No account, no external server. Low-VRAM friendly: it auto-fits the model to your card (streaming weights, int8, then NF4) so a model too big for full precision still runs, with no flags. |
+| **Hosted: API Nodes**                   | Add a Generate node and pick a model: hosted, closed models across image, video, and audio. No GPU, instant range. See [API Nodes](#api-nodes) for the model list and providers.                                                                                                                                                                                                                      | A provider key (currently [fal](https://fal.ai/dashboard/keys)); it stays on your machine, and you pay per render (each node estimates the price first).                                                                  |
 
 For local generation, either drop a `.safetensors` into `core/models/diffusion_models/`, or add a model node and use its **model popup** (a blinking hint shows up when something's missing) to download the diffusion model, VAE, and text-encoder into `core/models/`, with visible progress. The canvas and planning work with no models at all. See [Krea 2](#krea-2) and [FLUX.2](#flux2) for those models' files and VRAM.
 
@@ -353,160 +398,6 @@ Video costs $0.26 per second at 2K, so the node's price badge reads about $1.30 
 
 ![Inline Studio dashboard with recent AI film projects](https://raw.githubusercontent.com/inlineresearch/Inline-Studio/main/screenshots/screenshot-dashboard.png)
 
-## LoRA training
-
-Train a LoRA on your own images without leaving the app. The **Trainer** tab is a second canvas: wire up the nodes, press Start, and watch it run. When the run finishes, the `.safetensors` lands in `models/loras/`, where the LoRA loader node picks it up automatically, so you can generate with it over in the Studio tab straight away.
-
-![Inline Studio Trainer tab showing the LoRA training node graph with a dataset, live logs, and a loss curve](https://raw.githubusercontent.com/inlineresearch/Inline-Studio/main/screenshots/lora-trainer.png)
-
-### The graph
-
-Five nodes, wired left to right:
-
-- **Load Dataset** picks a training dataset and feeds it downstream. The node face stays a preview (thumbnails, image and caption counts); the images and captions themselves are edited in the side panel.
-- **Caption** runs a local captioner over the images that need one, with per-image progress. Captions stay editable afterwards, and a wired dataset overrides the node's own picker.
-- **Train LoRA** runs the job. Hyperparameters live behind the Adjust button, off the node face, so the node stays a status surface: a live step counter, the trainer's streaming logs, and a progress bar. The run control is a single chip that reads Start, Stop, or Resume depending on where the run is.
-- **Graph** plots the loss curve for whichever run is wired into it, with loss values on the y axis and the step range on the x axis.
-- **Resources** is a read-only readout of CPU, RAM, and VRAM as circular gauges. It takes no connections, and you can drop it on the Studio canvas too.
-
-<details>
-<summary><b>Datasets, resuming, trigger words, and base model modes</b></summary>
-
-### Datasets and outputs
-
-The sidebar has two tabs. **Datasets** is where you create a dataset, give it a trigger word, add images (drag and drop from your file manager works), and edit captions. **Outputs** lists what training has produced: finished LoRAs with their rank, step count, and resolution, plus any run that stopped early, each with a Resume button.
-
-For a worked example, see [`inlineresearch/skin-lora-krea-2-raw`](https://huggingface.co/inlineresearch/skin-lora-krea-2-raw) - a photorealistic skin LoRA trained here on the Krea 2 RAW base from the 26 image and caption pairs published as [`inlineresearch/krea2-skin-lora`](https://huggingface.co/datasets/inlineresearch/krea2-skin-lora).
-
-### Stop and resume
-
-Changing a setting in the Adjust panel stages it behind an **Update** button rather than applying as you type. A checkpoint encodes the rank, LoRA targets and base it was built with, so if the node has a run you could resume, applying asks first and then discards that run's checkpoints. Finished runs' LoRA files are never touched.
-
-Stopping a run flushes a checkpoint before the process exits, so Resume continues from the step it left off instead of starting over. A checkpoint holds the adapter weights, the optimiser state, the RNG state, and the step number, which is what makes a resumed run a continuation rather than a restart. Runs cut short by a crash or a server restart are recovered the same way and show up under Outputs ready to resume.
-
-### Trigger words
-
-A dataset's trigger word is prepended to every caption during training, so the model sees captions in the form `mytoken, a photo of ...`. Put the same token at the front of your prompt to pull the LoRA in. It is worth matching the phrasing of your captions too: if they all say "an oil painting of", a prompt written the same way will hit the trained style far more reliably than the trigger word alone.
-
-### Architecture and base model modes
-
-The Trainer's Adjust panel picks the **architecture** first (Z-Image, Krea 2, FLUX.2, or MiniMax H3), then a base within it. Training directly on a step-distilled checkpoint breaks the distillation down (turbo drift), so each architecture offers a way around that.
-
-**Krea 2** avoids the problem outright, which is why it is the recommended path:
-
-- **Krea 2 RAW** trains on the undistilled base. Nothing to fuse, nothing to drift. Put `krea2_raw_bf16.safetensors` in `models/diffusion_models/`, train, then generate with the **Krea 2 Turbo** node - the LoRA carries over unchanged.
-- **Krea 2 Turbo + training adapter** exists for people who only hold Turbo. Put [ostris/krea2_turbo_training_adapter](https://huggingface.co/ostris/krea2_turbo_training_adapter) in `models/loras/`, or point `INLINE_KREA2_TRAIN_ADAPTER` at it.
-
-**FLUX.2** works like Krea 2, with no adapter to download:
-
-- **FLUX.2 Base** is the only option, and the trainer refuses a distilled checkpoint rather than letting a run produce a bad adapter hours later. Put `flux-2-klein-base-4b.safetensors` in `models/diffusion_models/`, train, then generate with the distilled **klein 4B** checkpoint. The LoRA carries over unchanged.
-
-**MiniMax H3** is the video model, and it trains on **still images**:
-
-- **FL2VA** is the only base, and it is undistilled, so there is no adapter and nothing to drift. Put `minimax_h3_fl2va_bf16.safetensors` in `models/diffusion_models/`, train on stills, then wire the LoRA into any of the four H3 nodes. It loads on the Reference to Video node too, which uses a different checkpoint file: the two partitions are the same architecture.
-- **What it learns** is appearance - look, style, character, lighting. It does not learn motion or sound, because it never sees any. This is how image LoRAs for video models are normally trained, and it is the same thing every other H3 trainer does today.
-- **The base is 4-bit, always.** H3 is 40GB after the AdaLN factorisation, before activations or the adapter, so full precision is refused rather than offered and then failing. There is no base-precision control for H3 for the same reason.
-- **Bring a big card and a lot of patience.** The download alone is about 124GB, and the run encodes latents and captions in two separate passes before the base loads, because H3's video VAE and its 32B conditioner cannot be resident at the same time.
-
-**Z-Image** is distilled either way:
-
-- **Turbo + training adapter** fuses a de-distillation adapter into the base for the duration of training and drops it when the LoRA is saved, which preserves the 8-step speed. Put [ostris/zimage_turbo_training_adapter](https://huggingface.co/ostris/zimage_turbo_training_adapter) in `models/loras/`; any filename containing `adapter` is detected automatically, or point `INLINE_ZIMAGE_TRAIN_ADAPTER` at a specific file. Keep runs short, since the adapter slows the breakdown rather than preventing it.
-- **De-Turbo** trains without an adapter and needs no extra download.
-
-</details>
-
-### Install
-
-If you installed with `--extra all` from [Get Started](#get-started), the trainer is already set up - nothing more to do. To add it to a leaner install, its dependencies (PEFT, 8-bit Adam, the captioner) sit behind the `training` extra:
-
-```bash
-cd core
-./webui.sh --install --extra training   # Windows: .\webui.bat --install --extra training
-```
-
-Nothing is downloaded behind your back. Training has no downloader of its own: it reuses whatever is already in `models/diffusion_models/`, `models/vae/` and `models/text_encoders/` for the architecture you pick, which is normally what a generate node's model popup fetched for you. If a file is missing, the run stops and names it.
-
-Two things the model popup does not cover, so you fetch them yourself:
-
-- **Training adapters** for the Turbo base modes: [Z-Image](https://huggingface.co/ostris/zimage_turbo_training_adapter) or [Krea 2](https://huggingface.co/ostris/krea2_turbo_training_adapter), dropped in `models/loras/`.
-- **The captioner**, fetched once into the Hugging Face cache the first time you press Auto-caption.
-
-The LoRA a run produces lands in `models/loras/` and shows up in the LoRA loader node straight away, so you can wire it into a generate node and try it without leaving the app.
-
-### Benchmark results
-
-12 steps at rank 16, batch 1, gradient checkpointing on. The number is `torch.cuda.max_memory_allocated`, so leave headroom for the CUDA context and allocator slack.
-
-| Model   | Base mode       | Res  | Base precision | L40S (46GB)   | T4 (15GB)     |
-| ------- | --------------- | ---- | -------------- | ------------- | ------------- |
-| Z-Image | De-Turbo        | 512  | bf16           | 13.1GB        | 13.4GB        |
-| Z-Image | De-Turbo        | 1024 | bf16           | 14.9GB        | out of memory |
-| Z-Image | Turbo + adapter | 512  | bf16           | 13.1GB        | 13.4GB        |
-| Z-Image | Turbo + adapter | 1024 | bf16           | 14.9GB        | out of memory |
-| Krea 2  | RAW             | 512  | bf16           | 30.4GB        | out of memory |
-| Krea 2  | RAW             | 512  | **4-bit**      | 11.7GB        | **11.9GB**    |
-| Krea 2  | RAW             | 1024 | bf16           | out of memory | out of memory |
-| Krea 2  | RAW             | 1024 | **4-bit**      | **27.8GB**    | out of memory |
-| Krea 2  | Turbo + adapter | 512  | bf16           | 30.4GB        | out of memory |
-| Krea 2  | Turbo + adapter | 512  | **4-bit**      | 11.7GB        | **11.9GB**    |
-| Krea 2  | Turbo + adapter | 1024 | bf16           | out of memory | out of memory |
-| Krea 2  | Turbo + adapter | 1024 | **4-bit**      | **27.8GB**    | out of memory |
-| FLUX.2  | Base (klein 4B) | 512  | bf16           | 8.6GB         | not measured  |
-| FLUX.2  | Base (klein 4B) | 512  | **4-bit**      | 8.6GB         | not measured  |
-| FLUX.2  | Base (klein 4B) | 1024 | bf16           | 9.9GB         | not measured  |
-| FLUX.2  | Base (klein 4B) | 1024 | **4-bit**      | 9.9GB         | not measured  |
-
-**MiniMax H3 is not in the table yet.** Its training path is built and tested, but the peak-VRAM sweep has not been run, and putting an estimate in a column full of measurements would be worse than the gap. What is known from the component sizes rather than from a run: the base is 40GB after the AdaLN factorisation and roughly a quarter of that at 4-bit, the 32B conditioner is about 19GB during the caption pass, and the two never overlap. A 16GB card is out regardless, since the conditioner pass alone exceeds it. The numbers land here once the sweep has run.
-
-A training adapter is free: it is fused into the base before training starts, so Turbo-plus-adapter and the undistilled base peak identically.
-
-**FLUX.2 is the cheapest of the three to train, and 4-bit does nothing for it.** Both precisions peak at the same number because the peak is not the transformer: klein's base is 7.4GB while its Qwen3-4B text encoder is 7.5GB, so the caption and latent caching pass at the start of the run costs more than training itself does. Dropping the frozen base to 4-bit shrinks a part of the run that was never the high-water mark, and the step gets slower for nothing. Leave base precision on Auto for FLUX.2, which is what it already picks. The rows above are klein Base 4B, the only checkpoint the trainer accepts for this architecture.
-
-Which card fits what (24GB and 32GB are interpolated, not measured, as are the FLUX.2 columns on 16GB: those peaks were measured on an L40S and leave room on a smaller card, but no 16GB run has been done):
-
-| Card | Z-Image 512 | Z-Image 1024 | Krea 2 512 | Krea 2 1024 | FLUX.2 512 | FLUX.2 1024 |
-| ---- | ----------- | ------------ | ---------- | ----------- | ---------- | ----------- |
-| 16GB | yes         | no           | yes, 4-bit | no          | yes        | yes         |
-| 24GB | yes         | yes          | yes        | no          | yes        | yes         |
-| 32GB | yes         | yes          | yes        | yes, 4-bit  | yes        | yes         |
-| 48GB | yes         | yes          | yes        | 4-bit only  | yes        | yes         |
-
-Fitting and being usable are different questions. Turing has no native bf16, so a T4 runs the same work about 4x slower:
-
-| Configuration                     | L40S | T4   |
-| --------------------------------- | ---- | ---- |
-| Krea 2 RAW 512, 4-bit             | 192s | 824s |
-| Krea 2 Turbo + adapter 512, 4-bit | 219s | 872s |
-| Z-Image 512                       | 85s  | 285s |
-
-A 1500-step Krea 2 run is roughly 40 minutes on an L40S and 3 hours on a T4.
-
-FLUX.2 is quicker than either. On an L40S, klein Base 4B trains at about 0.3s a step at 512 and 1.0s a step at 1024, so a 1500-step run comes in around 8 minutes at 512 and 25 minutes at 1024. Forcing the 4-bit base costs about 10 percent a step at both resolutions. FLUX.2 has not been timed on a T4.
-
-**Krea 2 at 512 with the 4-bit base is the configuration to reach for on a small card.** 1024 needs about 32GB and no setting closes that gap: activations scale with image tokens, and gradient checkpointing and memory-efficient attention are already on. Train at 512 instead, since a LoRA trained at 512 applies at any generation resolution.
-
-System RAM matters as well. Checkpoints are read tensor by tensor rather than mapped whole, so Krea 2 trains in about 3GB of host RAM. Without that, Linux refuses to map a file larger than physical RAM when there is no swap, and a 26GB checkpoint cannot be opened on a 16GB machine at all.
-
-### Dataset and adapter options
-
-Three settings shape what the adapter learns rather than what it costs:
-
-- **LoRA scope.** _Full_ adapts the attention and feed-forward layers, which is stronger on short style runs. _Attention only_ is the Krea 2 authors' advice for long runs, where adapting everything starts to cost prompt adherence.
-- **Caption dropout** (default 0.05) trains a fraction of steps against an empty caption, so the LoRA still holds when a prompt does not repeat the trigger word verbatim.
-- **Flip images** mirrors every image, doubling a small dataset. Both orientations are encoded from pixels rather than by flipping cached latents, so the mirrored copy is exact. Leave it off for anything with text or a deliberate asymmetry.
-
-### Base precision
-
-Krea 2's base is 26GB at bf16, which is what makes it expensive to fine-tune. The Trainer's **Base precision** setting freezes that base at 4-bit (NF4) while the LoRA itself stays full precision - the QLoRA arrangement - so only the frozen base loses fidelity:
-
-- **Auto** (default) sizes the base _plus its activations at your chosen resolution_ against your GPU and picks for you. Weights alone are not enough to decide: a 48GB card holds Krea 2's 26GB base comfortably and then runs out at 1024.
-- **Full precision (bf16)** forces the unquantized base.
-- **4-bit (NF4)** forces the quantized base.
-
-The setting appears for Krea 2 and FLUX.2, but it only pays off on Krea 2. Z-Image has no 4-bit path and does not need one: it trains in about 15 GB at 1024, so bf16 already fits the cards people have. FLUX.2 has the path and gains nothing from it, because klein 4B is smaller than its own text encoder and the peak sits in the caching pass either way, so Auto leaves it at bf16. See [Benchmark results](#benchmark-results).
-
-To keep the peak down, the VAE and text encoder are loaded first, used to cache latents and captions, then freed before the transformer loads, so the two never stack. Which half then owns the peak depends on the model: for Z-Image and Krea 2 it is the transformer, for FLUX.2 klein it is the caching pass. If you do hit an out-of-memory error, lower the training resolution before changing anything else.
-
 ## FAQ
 
 ### Is Inline Studio free?
@@ -517,9 +408,13 @@ Yes. Inline Studio is free and open source under the [GPL-3.0 license](LICENSE).
 
 Only for **local** generation. The built-in Inline Core engine renders on the GPU of whatever machine runs it (you can also run it on a remote GPU box and open the UI from your laptop). Hosted **fal** models need no GPU at all, and the canvas + planning work with no GPU either.
 
+### Can I train a LoRA locally?
+
+Yes, that is what the [Trainer tab](#lora-training) is for, and it runs entirely on your own GPU with no cloud step. It trains LoRAs for Z-Image, Krea 2, FLUX.2, and MiniMax H3. Training is cheaper than generating: FLUX.2 klein Base trains at 512px in about 8.6GB, Z-Image in about 13GB, and Krea 2 with a 4-bit base in about 12GB, so a 16GB card handles all three. See [Benchmark results](TRAINING.md#benchmark-results) for the measured table.
+
 ### What models can I run?
 
-See [Two ways to generate](#two-ways-to-generate): local Z-Image, [Krea 2](#krea-2), [FLUX.2](#flux2), or [MiniMax H3](#minimax-h3) on your own GPU, or hosted fal models. Adding a new local model is a Core change (a model runner), no UI release.
+See [Two ways to generate](#two-ways-to-generate): Z-Image, [Krea 2](#krea-2), [FLUX.2](#flux2), or [MiniMax H3](#minimax-h3) locally on your own GPU, or hosted fal models. You can train a LoRA locally for any of the four as well, see [LoRA training](#lora-training). Adding a new local model is a Core change (a model runner), no UI release.
 
 ## Contributing
 

--- a/TRAINING.md
+++ b/TRAINING.md
@@ -1,0 +1,183 @@
+# Train a LoRA locally on your own GPU
+
+The full reference for Inline Studio's **Trainer**: which base to train on, what it costs in VRAM
+on a real card, and every setting that shapes the result. For the short version and a screenshot of
+the canvas, see [LoRA training in the README](README.md#lora-training).
+
+Inline Studio trains LoRAs for **Z-Image**, **Krea 2**, **FLUX.2** and **MiniMax H3** on your own
+GPU, with no cloud step and nothing uploaded. Training is cheaper than generating: a 16GB card
+trains all three image models at 512px, and a LoRA trained at 512 applies at any generation
+resolution.
+
+**Contents:** [The graph](#the-graph) · [Datasets and outputs](#datasets-and-outputs) ·
+[Stop and resume](#stop-and-resume) · [Trigger words](#trigger-words) ·
+[Architecture and base model modes](#architecture-and-base-model-modes) · [Install](#install) ·
+[**Benchmark results**](#benchmark-results) ·
+[Dataset and adapter options](#dataset-and-adapter-options) · [Base precision](#base-precision)
+
+## The graph
+
+Five nodes, wired left to right:
+
+- **Load Dataset** picks a training dataset and feeds it downstream. The node face stays a preview (thumbnails, image and caption counts); the images and captions themselves are edited in the side panel.
+- **Caption** runs a local captioner over the images that need one, with per-image progress. Captions stay editable afterwards, and a wired dataset overrides the node's own picker.
+- **Train LoRA** runs the job. Hyperparameters live behind the Adjust button, off the node face, so the node stays a status surface: a live step counter, the trainer's streaming logs, and a progress bar. The run control is a single chip that reads Start, Stop, or Resume depending on where the run is.
+- **Graph** plots the loss curve for whichever run is wired into it, with loss values on the y axis and the step range on the x axis.
+- **Resources** is a read-only readout of CPU, RAM, and VRAM as circular gauges. It takes no connections, and you can drop it on the Studio canvas too.
+
+## Datasets and outputs
+
+The sidebar has two tabs. **Datasets** is where you create a dataset, give it a trigger word, add images (drag and drop from your file manager works), and edit captions. **Outputs** lists what training has produced: finished LoRAs with their rank, step count, and resolution, plus any run that stopped early, each with a Resume button.
+
+For a worked example, see [`inlineresearch/skin-lora-krea-2-raw`](https://huggingface.co/inlineresearch/skin-lora-krea-2-raw) - a photorealistic skin LoRA trained here on the Krea 2 RAW base from the 26 image and caption pairs published as [`inlineresearch/krea2-skin-lora`](https://huggingface.co/datasets/inlineresearch/krea2-skin-lora).
+
+## Stop and resume
+
+Changing a setting in the Adjust panel stages it behind an **Update** button rather than applying as you type. A checkpoint encodes the rank, LoRA targets and base it was built with, so if the node has a run you could resume, applying asks first and then discards that run's checkpoints. Finished runs' LoRA files are never touched.
+
+Stopping a run flushes a checkpoint before the process exits, so Resume continues from the step it left off instead of starting over. A checkpoint holds the adapter weights, the optimiser state, the RNG state, and the step number, which is what makes a resumed run a continuation rather than a restart. Runs cut short by a crash or a server restart are recovered the same way and show up under Outputs ready to resume.
+
+## Trigger words
+
+A dataset's trigger word is prepended to every caption during training, so the model sees captions in the form `mytoken, a photo of ...`. Put the same token at the front of your prompt to pull the LoRA in. It is worth matching the phrasing of your captions too: if they all say "an oil painting of", a prompt written the same way will hit the trained style far more reliably than the trigger word alone.
+
+## Architecture and base model modes
+
+The Trainer's Adjust panel picks the **architecture** first (Z-Image, Krea 2, FLUX.2, or MiniMax H3), then a base within it. Training directly on a step-distilled checkpoint breaks the distillation down (turbo drift), so each architecture offers a way around that.
+
+**Krea 2** avoids the problem outright, which is why it is the recommended path:
+
+- **Krea 2 RAW** trains on the undistilled base. Nothing to fuse, nothing to drift. Put `krea2_raw_bf16.safetensors` in `models/diffusion_models/`, train, then generate with the **Krea 2 Turbo** node - the LoRA carries over unchanged.
+- **Krea 2 Turbo + training adapter** exists for people who only hold Turbo. Put [ostris/krea2_turbo_training_adapter](https://huggingface.co/ostris/krea2_turbo_training_adapter) in `models/loras/`, or point `INLINE_KREA2_TRAIN_ADAPTER` at it.
+
+**FLUX.2** works like Krea 2, with no adapter to download:
+
+- **FLUX.2 Base** is the only option, and the trainer refuses a distilled checkpoint rather than letting a run produce a bad adapter hours later. Put `flux-2-klein-base-4b.safetensors` in `models/diffusion_models/`, train, then generate with the distilled **klein 4B** checkpoint. The LoRA carries over unchanged.
+
+**MiniMax H3** is the video model, and it trains on **still images**:
+
+- **FL2VA** is the only base, and it is undistilled, so there is no adapter and nothing to drift. Put `minimax_h3_fl2va_bf16.safetensors` in `models/diffusion_models/`, train on stills, then wire the LoRA into any of the four H3 nodes. It loads on the Reference to Video node too, which uses a different checkpoint file: the two partitions are the same architecture.
+- **What it learns** is appearance - look, style, character, lighting. It does not learn motion or sound, because it never sees any. This is how image LoRAs for video models are normally trained, and it is the same thing every other H3 trainer does today.
+- **The base is 4-bit, always.** H3 is 40GB after the AdaLN factorisation and 11.7GB after quantisation, so full precision is refused rather than offered and then failing. There is no base-precision control for H3 for the same reason.
+- **It needs about 21GB and roughly seven minutes of startup.** The run encodes latents and captions in two passes that never overlap, because H3's fp32 video VAE and its 32B conditioner cannot be resident together, and the conditioner pass is what sets the peak. See [Benchmark results](#benchmark-results) for the phase-by-phase split. The download is about 124GB before any of that.
+
+**Z-Image** is distilled either way:
+
+- **Turbo + training adapter** fuses a de-distillation adapter into the base for the duration of training and drops it when the LoRA is saved, which preserves the 8-step speed. Put [ostris/zimage_turbo_training_adapter](https://huggingface.co/ostris/zimage_turbo_training_adapter) in `models/loras/`; any filename containing `adapter` is detected automatically, or point `INLINE_ZIMAGE_TRAIN_ADAPTER` at a specific file. Keep runs short, since the adapter slows the breakdown rather than preventing it.
+- **De-Turbo** trains without an adapter and needs no extra download.
+
+## Install
+
+If you installed with `--extra all` from [Get Started](README.md#get-started), the trainer is already set up - nothing more to do. To add it to a leaner install, its dependencies (PEFT, 8-bit Adam, the captioner) sit behind the `training` extra:
+
+```bash
+cd core
+./webui.sh --install --extra training   # Windows: .\webui.bat --install --extra training
+```
+
+Nothing is downloaded behind your back. Training has no downloader of its own: it reuses whatever is already in `models/diffusion_models/`, `models/vae/` and `models/text_encoders/` for the architecture you pick, which is normally what a generate node's model popup fetched for you. If a file is missing, the run stops and names it.
+
+Two things the model popup does not cover, so you fetch them yourself:
+
+- **Training adapters** for the Turbo base modes: [Z-Image](https://huggingface.co/ostris/zimage_turbo_training_adapter) or [Krea 2](https://huggingface.co/ostris/krea2_turbo_training_adapter), dropped in `models/loras/`.
+- **The captioner**, fetched once into the Hugging Face cache the first time you press Auto-caption.
+
+The LoRA a run produces lands in `models/loras/` and shows up in the LoRA loader node straight away, so you can wire it into a generate node and try it without leaving the app.
+
+## Benchmark results
+
+12 steps at rank 16, batch 1, gradient checkpointing on. The number is `torch.cuda.max_memory_allocated`, so leave headroom for the CUDA context and allocator slack.
+
+| Model      | Base mode       | Res  | Base precision | L40S (46GB)   | T4 (15GB)     |
+| ---------- | --------------- | ---- | -------------- | ------------- | ------------- |
+| Z-Image    | De-Turbo        | 512  | bf16           | 13.1GB        | 13.4GB        |
+| Z-Image    | De-Turbo        | 1024 | bf16           | 14.9GB        | out of memory |
+| Z-Image    | Turbo + adapter | 512  | bf16           | 13.1GB        | 13.4GB        |
+| Z-Image    | Turbo + adapter | 1024 | bf16           | 14.9GB        | out of memory |
+| Krea 2     | RAW             | 512  | bf16           | 30.4GB        | out of memory |
+| Krea 2     | RAW             | 512  | **4-bit**      | 11.7GB        | **11.9GB**    |
+| Krea 2     | RAW             | 1024 | bf16           | out of memory | out of memory |
+| Krea 2     | RAW             | 1024 | **4-bit**      | **27.8GB**    | out of memory |
+| Krea 2     | Turbo + adapter | 512  | bf16           | 30.4GB        | out of memory |
+| Krea 2     | Turbo + adapter | 512  | **4-bit**      | 11.7GB        | **11.9GB**    |
+| Krea 2     | Turbo + adapter | 1024 | bf16           | out of memory | out of memory |
+| Krea 2     | Turbo + adapter | 1024 | **4-bit**      | **27.8GB**    | out of memory |
+| FLUX.2     | Base (klein 4B) | 512  | bf16           | 8.6GB         | not measured  |
+| FLUX.2     | Base (klein 4B) | 512  | **4-bit**      | 8.6GB         | not measured  |
+| FLUX.2     | Base (klein 4B) | 1024 | bf16           | 9.9GB         | not measured  |
+| FLUX.2     | Base (klein 4B) | 1024 | **4-bit**      | 9.9GB         | not measured  |
+| MiniMax H3 | FL2VA           | 512  | **4-bit**      | **20.6GB**    | not measured  |
+| MiniMax H3 | FL2VA           | 768  | **4-bit**      | **20.6GB**    | not measured  |
+
+**MiniMax H3's peak is set before training starts, which is why both resolutions read the same.** The run has three phases that never overlap, and the tallest one is not the one doing the learning:
+
+| Phase                      | Peak   | What is resident                               |
+| -------------------------- | ------ | ---------------------------------------------- |
+| Latent caching (video VAE) | 10.8GB | The fp32 video VAE, then dropped               |
+| Caption caching (Qwen3-VL) | 20.5GB | The 32B conditioner at 4-bit, then dropped     |
+| Training                   | 11.7GB | The 4-bit base, 62GB on disk, plus activations |
+
+So 20.6GB is what a card has to survive, and the caption pass sets it. Training itself sits at 11.7GB, and a 512px still is only 310 rows of packed sequence against 630 at 768px, which is why the resolution barely moves anything: on H3 the weights are the cost, not the activations. The AdaLN factorisation is what makes the base figure possible at all, taking the transformer from 62GB on disk to 40GB before quantisation and 11.7GB after. Host RAM stays near 1.1GB throughout, because each block is shrunk as its tensors land rather than after the whole model is read.
+
+A 16GB card cannot train H3: the caption pass alone needs 20.5GB. Below about 24GB there is no configuration that fits.
+
+A training adapter is free: it is fused into the base before training starts, so Turbo-plus-adapter and the undistilled base peak identically.
+
+**FLUX.2 is the cheapest of the three to train, and 4-bit does nothing for it.** Both precisions peak at the same number because the peak is not the transformer: klein's base is 7.4GB while its Qwen3-4B text encoder is 7.5GB, so the caption and latent caching pass at the start of the run costs more than training itself does. Dropping the frozen base to 4-bit shrinks a part of the run that was never the high-water mark, and the step gets slower for nothing. Leave base precision on Auto for FLUX.2, which is what it already picks. The rows above are klein Base 4B, the only checkpoint the trainer accepts for this architecture.
+
+Which card fits what (24GB and 32GB are interpolated, not measured, as are the FLUX.2 columns on 16GB: those peaks were measured on an L40S and leave room on a smaller card, but no 16GB run has been done):
+
+| Card | Z-Image 512 | Z-Image 1024 | Krea 2 512 | Krea 2 1024 | FLUX.2 512 | FLUX.2 1024 | MiniMax H3 |
+| ---- | ----------- | ------------ | ---------- | ----------- | ---------- | ----------- | ---------- |
+| 16GB | yes         | no           | yes, 4-bit | no          | yes        | yes         | no         |
+| 24GB | yes         | yes          | yes        | no          | yes        | yes         | yes        |
+| 32GB | yes         | yes          | yes        | yes, 4-bit  | yes        | yes         | yes        |
+| 48GB | yes         | yes          | yes        | 4-bit only  | yes        | yes         | yes        |
+
+H3 has one column because 512 and 768 cost the same: its high-water mark is the caption pass, not the resolution. The 24GB entry is interpolated from the measured 20.6GB peak, not measured on a 24GB card.
+
+Fitting and being usable are different questions. Turing has no native bf16, so a T4 runs the same work about 4x slower:
+
+| Configuration                     | L40S | T4   |
+| --------------------------------- | ---- | ---- |
+| Krea 2 RAW 512, 4-bit             | 192s | 824s |
+| Krea 2 Turbo + adapter 512, 4-bit | 219s | 872s |
+| Z-Image 512                       | 85s  | 285s |
+
+A 1500-step Krea 2 run is roughly 40 minutes on an L40S and 3 hours on a T4.
+
+FLUX.2 is quicker than either. On an L40S, klein Base 4B trains at about 0.3s a step at 512 and 1.0s a step at 1024, so a 1500-step run comes in around 8 minutes at 512 and 25 minutes at 1024. Forcing the 4-bit base costs about 10 percent a step at both resolutions. FLUX.2 has not been timed on a T4.
+
+**MiniMax H3's steps are fast and its startup is not.** On an L40S a step is about 0.63s at 512 and 0.77s at 768, so a 1500-step run is roughly 16 to 19 minutes of actual training. Getting there takes about 7 minutes first: the 62GB checkpoint streams block by block while each one is factorised and quantised, and the two caching passes run before it. Startup is per run and does not scale with steps, so it hurts a short run far more than a long one. H3 has not been timed on a T4, and would not fit one.
+
+**Krea 2 at 512 with the 4-bit base is the configuration to reach for on a small card.** 1024 needs about 32GB and no setting closes that gap: activations scale with image tokens, and gradient checkpointing and memory-efficient attention are already on. Train at 512 instead, since a LoRA trained at 512 applies at any generation resolution.
+
+System RAM matters as well. Checkpoints are read tensor by tensor rather than mapped whole, so Krea 2 trains in about 3GB of host RAM. Without that, Linux refuses to map a file larger than physical RAM when there is no swap, and a 26GB checkpoint cannot be opened on a 16GB machine at all.
+
+## Dataset and adapter options
+
+Three settings shape what the adapter learns rather than what it costs:
+
+- **LoRA scope.** _Full_ adapts the attention and feed-forward layers, which is stronger on short style runs. _Attention only_ is the Krea 2 authors' advice for long runs, where adapting everything starts to cost prompt adherence.
+- **Caption dropout** (default 0.05) trains a fraction of steps against an empty caption, so the LoRA still holds when a prompt does not repeat the trigger word verbatim.
+- **Flip images** mirrors every image, doubling a small dataset. Both orientations are encoded from pixels rather than by flipping cached latents, so the mirrored copy is exact. Leave it off for anything with text or a deliberate asymmetry.
+
+## Base precision
+
+Krea 2's base is 26GB at bf16, which is what makes it expensive to fine-tune. The Trainer's **Base precision** setting freezes that base at 4-bit (NF4) while the LoRA itself stays full precision - the QLoRA arrangement - so only the frozen base loses fidelity:
+
+- **Auto** (default) sizes the base _plus its activations at your chosen resolution_ against your GPU and picks for you. Weights alone are not enough to decide: a 48GB card holds Krea 2's 26GB base comfortably and then runs out at 1024.
+- **Full precision (bf16)** forces the unquantized base.
+- **4-bit (NF4)** forces the quantized base.
+
+The setting appears for Krea 2 and FLUX.2, but it only pays off on Krea 2. Z-Image has no 4-bit path and does not need one: it trains in about 15 GB at 1024, so bf16 already fits the cards people have. FLUX.2 has the path and gains nothing from it, because klein 4B is smaller than its own text encoder and the peak sits in the caching pass either way, so Auto leaves it at bf16. See [Benchmark results](#benchmark-results).
+
+To keep the peak down, the VAE and text encoder are loaded first, used to cache latents and captions, then freed before the transformer loads, so the two never stack. Which half then owns the peak depends on the model: for Z-Image and Krea 2 it is the transformer, for FLUX.2 klein it is the caching pass. If you do hit an out-of-memory error, lower the training resolution before changing anything else.
+
+---
+
+Per-model walkthroughs, with the same measured figures written for a first read rather than a
+reference: [Krea 2](https://inlinestudio.art/lora-training/krea-2) ·
+[Z-Image](https://inlinestudio.art/lora-training/z-image) ·
+[FLUX.2](https://inlinestudio.art/lora-training/flux-2). Back to the
+[README](README.md), or the [full guide on the site](https://inlinestudio.art/lora-training).

--- a/core/README.md
+++ b/core/README.md
@@ -5,17 +5,24 @@ The generation engine behind Inline. It takes a typed node graph (JSON) and retu
 low-VRAM laptops up to multi-GPU machines that split a single image's sampling across GPUs (via
 xDiT). It is Inline Studio's built-in render backend.
 
-Models today: **Z-Image** (Alibaba Tongyi), a 6B rectified-flow diffusion transformer and the model
-xDiT already supports, so the multi-GPU split works on it from the start; and **Krea 2** (Krea AI),
-a 12.9B single-stream MMDiT released as an undistilled RAW base plus an 8-step distilled Turbo.
+Models today, all running locally on your own GPU: **Z-Image** (Alibaba Tongyi), a 6B rectified-flow
+diffusion transformer and the model xDiT already supports, so the multi-GPU split works on it from the
+start; **Krea 2** (Krea AI), a 12.9B single-stream MMDiT released as an undistilled RAW base plus an
+8-step distilled Turbo; **FLUX.2** (Black Forest Labs); and **MiniMax H3**, which generates video and
+its soundtrack in a single pass.
 
-> Status: early, and running end to end against a stub engine. In place and tested: the graph engine,
-> the typed `/v1` HTTP + websocket API (durable runs, streamed progress, coalescing), the model-dir
-> scan, the device + memory policy (profiles, dtype, offload, int8), the low-level primitive node
-> vocabulary. The Z-Image loader is written and validates on a GPU.
-> Cross-request batching, single-image multi-GPU (an xDiT worker group behind the sampler seam, with
-> the policy and IPC round-trip tested), and out-of-process custom nodes are built as seams but not
-> yet running on real hardware.
+Core also runs the **LoRA trainer** behind Inline Studio's Trainer canvas, so the same engine that
+generates can fine-tune Z-Image, Krea 2, FLUX.2 and MiniMax H3 on your own images without a cloud
+step. Training is cheaper than generating: Krea 2 fits a 16GB card at 512px with a 4-bit base. Its
+dependencies sit behind the `training` extra. See the
+[LoRA training guide](https://inlinestudio.art/lora-training) for the measured VRAM table.
+
+> Status: the graph engine, the typed `/v1` HTTP + websocket API (durable runs, streamed progress,
+> coalescing), the model-dir scan, the device + memory policy (profiles, dtype, offload, int8), the
+> low-level primitive node vocabulary, the model runners above, and the LoRA trainer all run on real
+> hardware. Cross-request batching, single-image multi-GPU (an xDiT worker group behind the sampler
+> seam, with the policy and IPC round-trip tested), and out-of-process custom nodes are built as
+> seams but are not yet exercised on real hardware.
 
 ## Engine design
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 # PyPI name; the import package is `inline_core` (src/inline_core).
 name = "inline-core"
-version = "1.2.61"
+version = "1.2.62"
 description = "The generation engine behind Inline Studio."
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/core/scripts/minimax_h3_lora_check.py
+++ b/core/scripts/minimax_h3_lora_check.py
@@ -1,0 +1,145 @@
+"""Render the same seed with and without a LoRA, and measure what changed.
+
+The question a unit test cannot answer: does an adapter trained by the Trainer actually reach the
+denoiser at generation time? A LoRA that changes nothing means the fuse silently missed its
+targets; one that produces noise means the training convention is wrong. Both pass a test suite.
+
+Two loads in one process, because the pipeline cache keys on the LoRA stack and evicting between
+them is the same path a user takes when they wire an adapter in.
+
+    cd core && PYTHONPATH=src .venv/bin/python scripts/minimax_h3_lora_check.py \
+        --lora ../outputs/.../skin-h3.safetensors "a close-up portrait ..."
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+logger = logging.getLogger("h3lora")
+OUT = Path(__file__).resolve().parents[2] / "outputs" / "minimax-h3-bench" / "lora-check"
+
+
+def _render(policy: Any, prompt: str, loras: tuple[Any, ...], args: Any) -> dict[str, Any]:
+    import torch
+
+    from inline_core.models import pipeline_runtime as rt
+    from inline_core.models.minimaxh3.pipeline import load_pipeline, render_staged
+    from inline_core.models.minimaxh3.runner import GRID
+    from inline_core.models.video_params import snap_canvas, snap_frames
+
+    width, height = snap_canvas(args.width, args.height, multiple=32, minimum=32)
+    frames = snap_frames(args.seconds, GRID)
+
+    started = time.perf_counter()
+    pipe = load_pipeline(policy, params={}, partition="fl2va", loras=loras)
+    load_s = round(time.perf_counter() - started, 1)
+
+    rt.reset_peak_vram()
+    started = time.perf_counter()
+    state = render_staged(
+        pipe, policy.placement("denoiser").device,
+        prompt=prompt, num_frames=frames, height=height, width=width,
+        num_inference_steps=args.steps, output_type="pil",
+        generator=torch.Generator(device="cpu").manual_seed(args.seed),
+    )
+    return {
+        "load_s": load_s,
+        "generate_s": round(time.perf_counter() - started, 1),
+        "videos": state.get("videos"),
+        "audio": state.get("audio"),
+        "sampling_rate": state.get("sampling_rate"),
+        "frames": frames,
+        "size": (width, height),
+    }
+
+
+def _difference(a: Any, b: Any) -> dict[str, float]:
+    """Mean absolute pixel difference between two clips, in 0-255 units."""
+    import numpy as np
+
+    left = np.stack([np.asarray(f, dtype=np.float32) for f in a])
+    right = np.stack([np.asarray(f, dtype=np.float32) for f in b])
+    delta = np.abs(left - right)
+    return {
+        "mean_abs": round(float(delta.mean()), 4),
+        "max_abs": round(float(delta.max()), 2),
+        "changed_fraction": round(float((delta > 1.0).mean()), 4),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("prompt")
+    parser.add_argument("--lora", required=True)
+    parser.add_argument("--strength", type=float, default=1.0)
+    parser.add_argument("--label", default="lora-check")
+    parser.add_argument("--width", type=int, default=608)
+    parser.add_argument("--height", type=int, default=352)
+    parser.add_argument("--seconds", type=float, default=5.0)
+    parser.add_argument("--steps", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=1234)
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S")
+
+    from inline_core.device.memory import MemoryPolicy
+    from inline_core.graph.loader_runners import LoraRef
+    from inline_core.models.minimaxh3.runner import GRID
+    from inline_core.runtime.video_encode import encode_video_file
+
+    out = OUT.parent / args.label
+    out.mkdir(parents=True, exist_ok=True)
+    policy = MemoryPolicy()
+    record: dict[str, Any] = {"prompt": args.prompt, "seed": args.seed, "steps": args.steps}
+
+    # Base first, so the LoRA'd load is the one that has to evict a live pipeline - which is what a
+    # user does when they wire an adapter into a node they have already rendered from.
+    logger.info("--- rendering WITHOUT the LoRA ---")
+    base = _render(policy, args.prompt, (), args)
+    record["without"] = {k: base[k] for k in ("load_s", "generate_s")}
+    encode_video_file(
+        out / "without-lora.mp4", base["videos"][0], fps=GRID.fps,
+        audio=base["audio"][0] if base["audio"] is not None and len(base["audio"]) else None,
+        sample_rate=base["sampling_rate"],
+    )
+
+    logger.info("--- rendering WITH the LoRA ---")
+    tuned = _render(policy, args.prompt, (LoraRef(file=args.lora, strength=args.strength),), args)
+    record["with"] = {k: tuned[k] for k in ("load_s", "generate_s")}
+    encode_video_file(
+        out / "with-lora.mp4", tuned["videos"][0], fps=GRID.fps,
+        audio=tuned["audio"][0] if tuned["audio"] is not None and len(tuned["audio"]) else None,
+        sample_rate=tuned["sampling_rate"],
+    )
+
+    record["difference"] = _difference(base["videos"][0], tuned["videos"][0])
+    record["lora"] = args.lora
+    record["strength"] = args.strength
+
+    # A few frames side by side, so the change can be looked at rather than only measured.
+    for index in (0, base["frames"] // 2, base["frames"] - 1):
+        base["videos"][0][index].save(out / f"frame{index:03d}-without.png")
+        tuned["videos"][0][index].save(out / f"frame{index:03d}-with.png")
+
+    (out / "result.json").write_text(json.dumps(record, indent=2))
+    print(json.dumps(record, indent=2))
+
+    delta = record["difference"]["mean_abs"]
+    if delta == 0.0:
+        print("\nFAIL: identical output - the LoRA reached nothing")
+        return 1
+    print(f"\nclips differ by {delta} mean absolute (0-255).")
+    print("Look at the frames before believing it.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/scripts/minimax_h3_train_matrix.py
+++ b/core/scripts/minimax_h3_train_matrix.py
@@ -1,0 +1,203 @@
+"""VRAM + step-time sweep for MiniMax H3 LoRA training: the cells behind the README benchmark table.
+
+    cd core && PYTHONPATH=src .venv/bin/python scripts/minimax_h3_train_matrix.py --dataset <dir>
+
+One cell = one real run of `python -m inline_core.training`, the same entry point the Trainer tab
+spawns, so a number here is a number a user would see.
+
+Held fixed at the settings the other architectures' rows used: 12 steps, rank 16, batch 1, gradient
+checkpointing on. Only resolution varies, because H3 has a single base mode and is 4-bit only: its
+base is 40 GB after the AdaLN factorisation, so a bf16 cell would be measuring an OOM.
+
+The peak here is not the peak a user waits on. H3 encodes latents and captions in two passes that
+never overlap the base, and the conditioner pass is the tallest of the three, so the run's
+high-water mark is set before training starts. Both are reported.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent.parent
+_CORE = _REPO / "core"
+_DEFAULT_OUT = _REPO / "outputs" / "minimax-h3-bench" / "train"
+
+#: Resolutions to sweep. 512 is the practical setting; 768 matches H3's own short edge at inference.
+CELLS: tuple[int, ...] = (512, 768)
+
+_STEPS = 12
+_RANK = 16
+
+
+def _manifest(work: Path, dataset: Path, models: Path, resolution: int) -> Path:
+    """The same manifest shape `studio/training.py::_prepare` writes."""
+    checkpoints = work / "checkpoints"
+    checkpoints.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "runId": work.name,
+        "workingDir": str(work),
+        "datasetDir": str(dataset),
+        "checkpointDir": str(checkpoints),
+        "outputPath": str(work / "lora.safetensors"),
+        "resumeFrom": None,
+        "modelsDir": str(models),
+        "arch": "minimax-h3",
+        # H3 ships one undistilled build per partition; `raw` is that mode's key.
+        "baseMode": "raw",
+        "triggerWord": "",
+        "hyperparams": {
+            "arch": "minimax-h3",
+            "baseMode": "raw",
+            "baseQuant": "auto",
+            "offload": "off",
+            "loraScope": "full",
+            "captionDropout": 0.0,
+            "flipAugment": False,
+            "rank": _RANK,
+            "alpha": _RANK,
+            "learningRate": 1e-4,
+            "batchSize": 1,
+            "steps": _STEPS,
+            "saveEvery": _STEPS,
+            "resolution": resolution,
+        },
+        "gpuIds": [],
+    }
+    path = work / "manifest.json"
+    path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return path
+
+
+def _run_cell(python: str, manifest: Path, log: Path) -> dict[str, object]:
+    """Drain the JSON-line protocol, keeping the VRAM readings and the step timing.
+
+    The precache peak is read from the progress lines before the first training step; the training
+    peak is the last reading. They are different numbers on H3 and conflating them would overstate
+    what training itself costs.
+    """
+    env = {**os.environ, "PYTHONPATH": str(_CORE / "src")}
+    proc = subprocess.Popen(
+        [python, "-m", "inline_core.training", str(manifest)],
+        cwd=str(_CORE),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    vram: float | None = None
+    error: str | None = None
+    first_step_at: float | None = None
+    last_step_at: float | None = None
+    steps_seen = 0
+    losses: list[float] = []
+    started = time.perf_counter()
+    lines: list[str] = []
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        lines.append(line)
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        kind = message.get("type")
+        if kind == "progress":
+            if message.get("vram") is not None:
+                vram = float(message["vram"])
+            if message.get("loss") is not None:
+                losses.append(float(message["loss"]))
+            if message.get("step"):
+                steps_seen = int(message["step"])
+                now = time.perf_counter()
+                if first_step_at is None:
+                    first_step_at = now
+                last_step_at = now
+        elif kind == "error":
+            error = str(message.get("message") or "")
+    proc.wait()
+    log.write_text("".join(lines), encoding="utf-8")
+
+    oom = bool(error) and ("out of gpu memory" in error.lower() or "out of memory" in error.lower())
+    # Step 1 pays for the first graph build, so time the interval after it and scale by the gap.
+    per_step: float | None = None
+    if first_step_at is not None and last_step_at is not None and steps_seen > 1:
+        per_step = (last_step_at - first_step_at) / (steps_seen - 1)
+    return {
+        "peak_vram_gb": vram,
+        "seconds_per_step": round(per_step, 2) if per_step else None,
+        "seconds_12_steps": round(per_step * _STEPS, 1) if per_step else None,
+        "total_seconds": round(time.perf_counter() - started, 1),
+        "steps_completed": steps_seen,
+        "first_loss": round(losses[0], 4) if losses else None,
+        "last_loss": round(losses[-1], 4) if losses else None,
+        "status": "oom" if oom else ("ok" if proc.returncode == 0 else "failed"),
+        "error": error,
+        "log": log.name,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", type=Path, required=True, help="dir of NNNN.jpg + NNNN.txt")
+    parser.add_argument("--out", type=Path, default=_DEFAULT_OUT)
+    parser.add_argument("--models", type=Path, default=_CORE / "models")
+    parser.add_argument("--python", default=str(_CORE / ".venv" / "bin" / "python"))
+    parser.add_argument("--gpu", default="", help="label for the results file, e.g. 'L40S (46GB)'")
+    parser.add_argument("--only", default="", help="one resolution, to redo a single row")
+    args = parser.parse_args()
+
+    if not args.dataset.is_dir():
+        raise SystemExit(f"dataset not found: {args.dataset}")
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    results_path = args.out / "results.json"
+    results: dict[str, dict[str, object]] = {}
+    if results_path.exists():
+        results = json.loads(results_path.read_text()).get("cells", {})
+
+    label = args.gpu
+    if not label:
+        try:
+            label = subprocess.run(
+                ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv,noheader"],
+                capture_output=True, text=True, check=True,
+            ).stdout.strip().splitlines()[0]
+        except Exception:  # noqa: BLE001 - the label is cosmetic
+            label = "unknown GPU"
+
+    def write() -> None:
+        results_path.write_text(
+            json.dumps(
+                {"gpu": label, "steps": _STEPS, "rank": _RANK, "cells": results}, indent=2
+            )
+        )
+
+    for resolution in CELLS:
+        cell_id = str(resolution)
+        if args.only and args.only != cell_id:
+            continue
+        work = args.out / cell_id
+        work.mkdir(parents=True, exist_ok=True)
+        manifest = _manifest(work, args.dataset, args.models, resolution)
+        print(f"--- {cell_id}px, 4-bit base ---", flush=True)
+        result = _run_cell(args.python, manifest, args.out / f"{cell_id}.log")
+        result.update({"resolution": resolution, "base_quant": "nf4"})
+        results[cell_id] = result
+        print(json.dumps(result, indent=2), flush=True)
+        write()
+
+    write()
+    print(f"\n{results_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/src/inline_core/device/memory.py
+++ b/core/src/inline_core/device/memory.py
@@ -302,8 +302,9 @@ class MemoryPolicy(DevicePolicy):
 
         **int8 overrides the fp16 preference to bf16.** torchao weight-only int8 only supports a
         bf16 compute dtype - with fp16 the quantization silently no-ops, so the "int8" weights load
-        at *full* fp16 size and blow the VRAM budget (a T4 then OOMs mid-load). The int8 matmul still
-        runs on the card's int8 tensor cores; only the residual bf16 activations pay the slow path.
+        at *full* fp16 size and blow the VRAM budget (a T4 then OOMs mid-load). The int8 matmul
+        still runs on the card's int8 tensor cores; only the residual bf16 activations pay the
+        slow path.
         bf16 also has fp32's exponent range, so the VAE no longer needs the fp32 anti-overflow
         upcast - it rides along at bf16."""
         if self.quantization() is Quantization.INT8:

--- a/core/src/inline_core/models/minimaxh3/load.py
+++ b/core/src/inline_core/models/minimaxh3/load.py
@@ -21,6 +21,7 @@ import torch
 from safetensors import safe_open
 
 from ...errors import ComponentError
+from .. import lora as lora_module
 from ..keymap import (
     AssertEqual,
     Rename,
@@ -108,18 +109,28 @@ def load_transformer(
     device: str = "cpu",
     layout: RowLayout | None = None,
     shrink: Any = None,
+    loras: tuple[Any, ...] = (),
 ) -> MiniMaxH3Transformer3DModel:
     """Build the port and stream ``path`` into it through the key plan.
 
     ``layout`` overrides the measurement, which is only useful in tests; leave it None so the file
     decides. ``shrink(model, prefix)`` is called as each transformer block finishes, which is how a
     64 GB machine loads a model whose bf16 footprint is 66 GB.
+
+    ``loras`` are fused into each block as it lands, **before** ``shrink`` factorises or quantises
+    it, because a fuse adds a full-precision delta that quantized weights cannot accept in place.
     """
     if not path.is_file():
         raise ComponentError(f"MiniMax H3 transformer not found: {path}")
     config = read_config(path)
     with torch.device("meta"):
         model = MiniMaxH3Transformer3DModel(**transformer_kwargs(config))
+
+    # Resolved against module names on the meta model, so a LoRA trained for another architecture
+    # is refused before the 62 GB read rather than a block into it.
+    lora_plan = lora_module.plan_loras(model, loras) if loras else {}
+    fused: set[str] = set()
+    shrink = _fusing_shrink(lora_plan, fused, shrink) if lora_plan else shrink
 
     with safe_open(str(path), framework="pt") as handle:
         source_keys = list(handle.keys())  # noqa: SIM118 - safe_open has no __contains__
@@ -144,9 +155,62 @@ def load_transformer(
             model, handle, plan, dtype=dtype, device=device, shrink=shrink
         )
 
+    if lora_plan:
+        _finish_fuse(model, lora_plan, fused)
     _assert_nothing_left_on_meta(model, filled)
     model.eval()
     return model
+
+
+def _fusing_shrink(plan: Any, fused: set[str], inner: Any) -> Any:
+    """Fuse a block's share of the LoRA stack the moment it lands, then hand off to ``shrink``.
+
+    Order matters both ways: after the stream the block's weights exist, and before ``shrink`` they
+    are still unquantised, which is the only window in which a full-precision delta can be added
+    in place.
+    """
+
+    def shrink(model: Any, prefix: str) -> None:
+        module = model
+        for part in prefix.split("."):
+            module = module[int(part)] if part.isdigit() else getattr(module, part)
+        fused.update(_fuse_subtree(module, plan, f"{prefix}."))
+        if inner is not None:
+            inner(model, prefix)
+
+    return shrink
+
+
+def _fuse_subtree(module: Any, plan: Any, prefix: str) -> set[str]:
+    """Apply the plan's share for one subtree, reporting which of its targets were covered."""
+    hit = {
+        path
+        for name, _child in module.named_modules()
+        if (path := f"{prefix}{name}" if prefix else name) in plan
+    }
+    lora_module.apply_plan(module, plan, prefix)
+    return hit
+
+
+def _finish_fuse(model: Any, plan: Any, fused: set[str]) -> None:
+    """Fuse what the block callback never saw, then prove nothing was missed.
+
+    The callback only fires for ``transformer_blocks.N``, so ``context_embedder``, the token
+    refiner and the output heads would silently keep their base weights - and silently is the whole
+    problem. ``plan_loras`` only raises when a key matches *no* module in the model, and these
+    modules do exist, so a partial fuse validates clean and then degrades the output without ever
+    erroring. The residual pass covers them and the check makes any remaining gap loud.
+    """
+    residual = {name: deltas for name, deltas in plan.items() if name not in fused}
+    if residual:
+        fused |= _fuse_subtree(model, residual, "")
+    missed = sorted(set(plan) - fused)
+    if missed:
+        raise ComponentError(
+            f"{len(missed)} LoRA layers resolved to modules that were never fused, starting with "
+            f"{missed[0]}. Applying only part of a LoRA degrades output without erroring, so this "
+            "is refused instead."
+        )
 
 
 def _source_for(layout: RowLayout) -> str:

--- a/core/src/inline_core/models/minimaxh3/pipeline.py
+++ b/core/src/inline_core/models/minimaxh3/pipeline.py
@@ -23,6 +23,7 @@ import torch
 
 from ...device.policy import DevicePolicy
 from ...errors import ComponentError
+from .. import loaders
 from .. import pipeline_runtime as rt
 from ..offload import (
     apply_offload,
@@ -74,8 +75,10 @@ ENCODER_KEEP_PRECISION = (
 
 def load_pipeline(
     policy: DevicePolicy, *, params: dict[str, Any], partition: str,
-    factorise_adaln: bool = True, quantize: bool = True, staged: bool = True,
+    factorise_adaln: bool = True, adaln_rank: int | None = None,
+    quantize: bool = True, staged: bool = True,
     transformer: Any = None, video_vae: Any = None, text_encoder: Any = None,
+    loras: tuple[Any, ...] = (),
 ) -> Any:
     """Build, place and cache the pipeline for one partition.
 
@@ -88,6 +91,10 @@ def load_pipeline(
     one: the factorisation perturbs the modulation 14x less than one bf16 ulp of re-rounding, which
     is below the ambiguity the checkpoint's own storage already carries. The gate's pixel tolerance
     could not decide it either way - an information-free re-rounding fails that tolerance too.
+
+    ``adaln_rank`` overrides the rank that factorisation keeps, for sweeping it against the gate.
+    It is part of the cache key: two ranks are two different sets of weights, and sharing an entry
+    would serve whichever loaded first while the log claimed the rank that was asked for.
     """
     # Precedence, matching the image nodes: a wired handle beats the node's dropdown, which beats
     # the default filename on disk. The pick is what lets a user point at a hand-placed or renamed
@@ -138,9 +145,11 @@ def load_pipeline(
         # entry and the second load would silently reuse the first partition's weights.
         variant=partition,
         quant=(policy.quantization().value if quantize else "bf16")
-        + ("+adaln" if factorise_adaln else "")
+        + (f"+adaln{_adaln_rank(adaln_rank)}" if factorise_adaln else "")
         # Part of the key because it changes where the weights are placed, not just how they run.
         + ("+staged" if staged else ""),
+        # Order- and strength-sensitive: adapters are fused, and fusing does not commute.
+        loras=loaders.lora_cache_key(loras),
     )
     with rt.PIPELINES.lock:
         cached = rt.PIPELINES.get(key)
@@ -152,6 +161,7 @@ def load_pipeline(
             policy,
             partition=partition,
             factorise_adaln=factorise_adaln,
+            adaln_rank=adaln_rank,
             quantize=quantize,
             staged=staged,
             transformer_path=transformer_path,
@@ -159,6 +169,7 @@ def load_pipeline(
             processor_dir=processor_dir,
             video_vae=video_vae_path,
             audio_vae=audio_vae,
+            loras=loras,
         )
         rt.PIPELINES.put(key, pipe)
         return pipe
@@ -222,6 +233,7 @@ def _build(
     *,
     partition: str,
     factorise_adaln: bool = False,
+    adaln_rank: int | None = None,
     quantize: bool = True,
     staged: bool = False,
     transformer_path: Path,
@@ -229,6 +241,7 @@ def _build(
     processor_dir: Path,
     video_vae: Path,
     audio_vae: Path,
+    loras: tuple[Any, ...] = (),
 ) -> Any:
     from transformers import AutoProcessor, AutoTokenizer, Qwen3VLForConditionalGeneration
 
@@ -303,9 +316,11 @@ def _build(
         # prompt is encoded, and 36 GB of int8 weights beside its 19.5 GB fits neither of them.
         # `render_staged` moves it across once the conditioner is parked.
         device="cpu" if (recipe.denoiser_offload or staged) else device,
+        loras=loras,
         shrink=_block_shrinker(
             recipe,
             transformer_path if factorise_adaln else None,
+            factorise_rank=adaln_rank,
             resident_blocks=resident_blocks,
             resident_device=str(placement.device),
         )
@@ -729,7 +744,14 @@ def _metadata_config(path: Path) -> dict[str, Any]:
     return {}
 
 
-def _adaln_basis(source: Path) -> Any:
+def _adaln_rank(rank: int | None) -> int:
+    """The rank factorisation will keep. Its own module owns the default."""
+    from . import adaln as adaln_mod
+
+    return adaln_mod.RANK if rank is None else int(rank)
+
+
+def _adaln_basis(source: Path, rank: int | None = None) -> Any:
     """The low-rank basis for the AdaLN branch, read straight from the checkpoint.
 
     Derived before the model streams, because the shrink callback needs it while the first block
@@ -753,13 +775,14 @@ def _adaln_basis(source: Path) -> Any:
         embedder.linear_2.weight.data = proj_out.float()
         embedder.linear_2.bias.data = get("time_embedder.proj_out.bias").float()
     proj = Timesteps(num_channels=proj_in.shape[1], flip_sin_to_cos=True, downscale_freq_shift=0)
-    return adaln_mod.derive_basis(proj, embedder)
+    return adaln_mod.derive_basis(proj, embedder, rank=_adaln_rank(rank))
 
 
 def _block_shrinker(
     recipe: Any,
     factorise_source: Path | None = None,
     *,
+    factorise_rank: int | None = None,
     resident_blocks: int = 0,
     resident_device: str = "",
 ) -> Any:
@@ -771,7 +794,9 @@ def _block_shrinker(
     happens here rather than after the load for the same reason the shrinking does: a block moved to
     the card as it lands is a block that never has to fit host RAM alongside the other forty-nine.
     """
-    basis = _adaln_basis(factorise_source) if factorise_source is not None else None
+    basis = (
+        _adaln_basis(factorise_source, factorise_rank) if factorise_source is not None else None
+    )
     try:
         from torchao.quantization import Int8WeightOnlyConfig, quantize_
     except ImportError:

--- a/core/src/inline_core/models/minimaxh3/runner.py
+++ b/core/src/inline_core/models/minimaxh3/runner.py
@@ -128,11 +128,13 @@ def _inputs(variant: Variant) -> tuple[Port, ...]:
     ports = [
         Port("prompt", "Prompt", PortKind.TEXT, required=True),
         # The same component handles every other Core node carries: wire a load/* subnode to
-        # override the dropdown. No `lora` port, unlike Z-Image and FLUX.2, because H3 has no LoRA
-        # path yet and a handle that silently does nothing is worse than an absent one.
+        # override the dropdown.
         Port("model", "Diffusion model", PortKind.MODEL, required=False),
         Port("vae", "Video VAE", PortKind.VAE, required=False),
         Port("text_encoder", "Text encoder", PortKind.TEXT_ENCODER, required=False),
+        # Adapters fuse into each block as it streams, before factorisation and quantisation. A
+        # LoRA trained on either partition loads on both: they are the same architecture.
+        Port("lora", "LoRA", PortKind.LORA, required=False),
     ]
     if variant.first_frame:
         ports.append(Port("image", "First frame", PortKind.IMAGE, required=False))
@@ -318,6 +320,7 @@ class MiniMaxH3Runner(NodeRunner):
             transformer=rt.component_ref(inputs, "model", "diffusion", _LABEL),
             video_vae=rt.component_ref(inputs, "vae", "vae", _LABEL),
             text_encoder=rt.component_ref(inputs, "text_encoder", "text_encoder", _LABEL),
+            loras=rt.lora_stack(inputs, _LABEL),
         )
 
         call = call_kwargs(request, self._variant, inputs)

--- a/core/src/inline_core/training/arch.py
+++ b/core/src/inline_core/training/arch.py
@@ -1,13 +1,13 @@
 """What differs between the architectures we train LoRAs for.
 
-Z-Image and Krea 2 share the whole harness - dataset export, precache-then-free, PEFT adapter,
-checkpoint/resume, the JSON-line protocol - and differ in only four things: which Linears to adapt,
-how a noise level maps to a timestep, what the model is asked to predict, and how one forward call
-is shaped. Those four live here so ``trainer.py`` stays one loop.
+Every arch shares the whole harness - dataset export, precache-then-free, PEFT adapter,
+checkpoint/resume, the JSON-line protocol - and they differ in only four things: which Linears to
+adapt, how a noise level maps to a timestep, what the model is asked to predict, and how one forward
+call is shaped. Those four live here so ``trainer.py`` stays one loop.
 
-Both are rectified flow, but with **opposite conventions**, which is exactly the kind of detail a
-test should pin: Z-Image predicts ``clean - noise`` at timestep ``1 - sigma``, Krea 2 predicts
-``noise - clean`` at timestep ``sigma``.
+All four are rectified flow, but with **opposite conventions**, which is exactly the kind of detail
+a test should pin: Z-Image and MiniMax H3 predict ``clean - noise`` at timestep ``1 - sigma``, while
+Krea 2 and FLUX.2 predict ``noise - clean`` at timestep ``sigma``.
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ from typing import Any
 Z_IMAGE = "z-image"
 KREA2 = "krea2"
 FLUX2 = "flux2"
+MINIMAX_H3 = "minimax-h3"
 
 #: Z-Image: every ZImageTransformerBlock's attention + SwiGLU feed-forward Linears, confirmed
 #: against ZImageTransformer2DModel.named_modules() (34 blocks, 238 Linears).
@@ -72,6 +73,32 @@ _FLUX2_TARGETS = [
     "x_embedder",
     "context_embedder",
     "proj_out",
+]
+
+
+#: MiniMax H3: the attention and SwiGLU feed-forward Linears of all 50 blocks, plus the text
+#: projection. Confirmed against MiniMaxH3Transformer3DModel.named_modules(): a block's Linears are
+#: exactly to_q/to_k/to_v/to_out.0, ff.net.0.proj, ff.net.2 and adaln_proj.linear.
+#:
+#: ``adaln_proj.linear`` is deliberately absent. It is replaced at load by the rank-8 factorisation
+#: (``minimaxh3/adaln.py``) that takes the checkpoint from 66GB to 40GB, so the module a LoRA would
+#: attach to carries the whole modulation signal through eight columns - the same reason
+#: ``minimaxh3/pipeline.py`` refuses to quantize it.
+#:
+#: The fp32-pinned modules are absent for a different reason: H3 ships a mixed-precision checkpoint
+#: where the patch projections, the timestep MLP and the two output heads stay float32
+#: (``_keep_in_fp32_modules``), and adapting those fights the precision split, not the model.
+#:
+#: PEFT matches by name suffix, so this also adapts the two token-refiner blocks. That is wanted,
+#: and it is why the loader must fuse outside the block stack too - see ``minimaxh3/load.py``.
+_MINIMAX_H3_TARGETS = [
+    "to_q",
+    "to_k",
+    "to_v",
+    "to_out.0",
+    "ff.net.0.proj",
+    "ff.net.2",
+    "context_embedder",
 ]
 
 
@@ -234,6 +261,49 @@ def _flux2_forward(transformer: Any, noisy: Any, timestep: Any, item: dict[str, 
 
 
 
+# --- MiniMax H3 -----------------------------------------------------------------------------------
+
+#: H3's (t, h, w) patch. A still is one latent frame, so only the spatial half ever bites.
+_H3_PATCH = (1, 2, 2)
+
+
+def _h3_forward(transformer: Any, noisy: Any, timestep: Any, item: dict[str, Any]) -> Any:
+    """One prediction from MiniMaxH3Transformer3DModel, mirroring the vendored denoise block.
+
+    H3 runs one packed 1-D sequence holding text, audio and video rows rather than separate streams,
+    and the caller owns that layout. The precache builds it once per image (it only depends on the
+    caption length and the latent grid) and caches the tensors, so a step just patchifies, assigns
+    every row this step's timestep, and selects the video rows back out.
+
+    A still is one latent frame with no audio rows at all, which the model accepts: the audio head
+    runs over an empty index and returns empty.
+    """
+    from ..models.minimaxh3.vendor.packing import patchify_video_latents, unpatchify_video_tokens
+
+    channels, frames, height, width = noisy.shape
+    rows = patchify_video_latents(noisy.unsqueeze(0), _H3_PATCH)
+
+    # One distinct noise level, so every row indexes timestep 0. Training pins no conditioning rows
+    # and a still has no audio rows, which is what collapses the vendored (timestep, index) plan to
+    # this; ``timestep_indices`` comes from the precache, which derives it from build_row_timesteps
+    # rather than assuming the collapse.
+    video, _audio = transformer(
+        hidden_states=rows.unsqueeze(0),
+        audio_hidden_states=item["audio"].unsqueeze(0),
+        encoder_hidden_states=item["embed"].unsqueeze(0),
+        timestep=timestep.reshape(1),
+        timestep_indices=item["timestep_indices"],
+        token_tags=item["token_tags"],
+        position_ids=item["position_ids"],
+        video_indices=item["video_indices"],
+        audio_indices=item["audio_indices"],
+        text_indices=item["text_indices"],
+        return_dict=False,
+    )
+    unpacked = unpatchify_video_tokens(video[0], frames, height, width, channels, _H3_PATCH)
+    return unpacked[0]
+
+
 ARCHS: dict[str, TrainingArch] = {
     Z_IMAGE: TrainingArch(
         key=Z_IMAGE,
@@ -262,6 +332,21 @@ ARCHS: dict[str, TrainingArch] = {
         timestep=lambda sigma: sigma,
         target=lambda clean, noise: noise - clean,
         forward=_flux2_forward,
+    ),
+    MINIMAX_H3: TrainingArch(
+        key=MINIMAX_H3,
+        target_modules=_MINIMAX_H3_TARGETS,
+        # H3's shift is the same expression Z-Image uses, at the scheduler's video shift of 12.0
+        # (MiniMaxH3Scheduler builds its grid as shift * s / (1 + (shift - 1) * s)), so the
+        # generic sigma applies unchanged.
+        sigma=_zimage_sigma,
+        # Z-Image's convention exactly, and worth a test rather than a comment because Krea 2 and
+        # FLUX.2 use the opposite one: MiniMaxH3Scheduler.scale_noise is
+        # x_t = t * clean + (1 - t) * noise at t = 1 - sigma, and its step reconstructs
+        # x0 = x_t + sigma * v, so the velocity the model predicts is clean - noise.
+        timestep=lambda sigma: 1.0 - sigma,
+        target=lambda clean, noise: clean - noise,
+        forward=_h3_forward,
     ),
 }
 

--- a/core/src/inline_core/training/cache.py
+++ b/core/src/inline_core/training/cache.py
@@ -1,0 +1,46 @@
+"""Build the training cache: every latent and every conditioning tensor, before the base loads.
+
+One seam so ``trainer.py`` stays a single loop. Most architectures load their VAE and text encoder
+together, encode in one sweep and drop both; MiniMax H3 cannot hold those two at once and stages
+them (see ``h3.py``). Either way the transformer loads into a card with nothing else on it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import arch as archs
+from . import dataset as ds
+from . import models
+
+#: MiniMax H3's video sigma shift. Its scheduler applies the same expression Z-Image's does, so the
+#: arch samples through it unchanged.
+_H3_SHIFT = 12.0
+
+
+def build(
+    dataset_dir: str,
+    models_dir: str,
+    arch: str,
+    device: str,
+    dtype: Any,
+    resolution: int,
+    *,
+    flip: bool = False,
+    dropout: float = 0.0,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None, float]:
+    """Return ``(items, unconditional, shift)``, all as CPU tensors, with the encoders freed."""
+    if arch == archs.MINIMAX_H3:
+        from . import h3
+
+        items, unconditional = h3.precache(
+            dataset_dir, models_dir, device, dtype, resolution, flip, dropout > 0
+        )
+        return items, unconditional, _H3_SHIFT
+
+    encoders = models.load_encoders(models_dir, arch, device, dtype)
+    items = ds.precache(dataset_dir, encoders, arch, device, dtype, resolution, flip=flip)
+    unconditional = ds.precache_empty(encoders, arch, device) if dropout > 0 else None
+    shift = float(encoders.scheduler.config.get("shift", 1.0) or 1.0)
+    models.free_encoders(encoders)
+    return items, unconditional, shift

--- a/core/src/inline_core/training/dataset.py
+++ b/core/src/inline_core/training/dataset.py
@@ -29,22 +29,26 @@ def _pairs(dataset_dir: Path) -> list[tuple[Path, str]]:
     return out
 
 
-def _to_tensor(image: Any, resolution: int, flip: bool = False) -> Any:
-    import numpy as np
-    import torch
+def _square(image: Any, resolution: int, flip: bool = False) -> Any:
+    """Center-crop to square and resize to the training resolution. Shared with the archs that do
+    not normalize to [-1, 1] - MiniMax H3 wants ImageNet statistics - so the crop cannot drift."""
     from PIL import Image
 
     img = image.convert("RGB")
-    # Center-crop to square, then resize to the training resolution; pixels normalized to [-1, 1].
     short = min(img.size)
     left = (img.width - short) // 2
     top = (img.height - short) // 2
     img = img.crop((left, top, left + short, top + short)).resize(
         (resolution, resolution), Image.LANCZOS
     )
-    if flip:
-        img = img.transpose(Image.FLIP_LEFT_RIGHT)
-    arr = np.asarray(img, dtype="float32") / 127.5 - 1.0
+    return img.transpose(Image.FLIP_LEFT_RIGHT) if flip else img
+
+
+def _to_tensor(image: Any, resolution: int, flip: bool = False) -> Any:
+    import numpy as np
+    import torch
+
+    arr = np.asarray(_square(image, resolution, flip), dtype="float32") / 127.5 - 1.0
     return torch.from_numpy(arr).permute(2, 0, 1)  # CHW
 
 

--- a/core/src/inline_core/training/h3.py
+++ b/core/src/inline_core/training/h3.py
@@ -1,0 +1,375 @@
+"""MiniMax H3's precache, which has to run in two passes that never overlap.
+
+Every other arch loads its VAE and its text encoder together and encodes both in one sweep. H3
+cannot: the video VAE is ~10 GB resident in fp32 and the Qwen3-VL conditioner is ~19 GB even at
+4-bit, so together they are most of a 46 GB card before a single latent exists. Pixels are encoded
+and the VAE dropped, then captions are encoded and the conditioner dropped, and only then does the
+62 GB transformer load.
+
+The layout of H3's packed sequence depends only on the caption length and the latent grid, so it is
+built here once per image rather than per step.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("inline_core.training.h3")
+
+#: H3's (t, h, w) patch, and the transformer's ``audio_in_channels``. A still has no audio rows, but
+#: the empty tensor still has to be the width ``audio_proj_in`` expects.
+PATCH = (1, 2, 2)
+AUDIO_LATENT_CHANNELS = 32
+
+
+def precache(
+    dataset_dir: str,
+    models_dir: str,
+    device: str,
+    dtype: Any,
+    resolution: int,
+    flip: bool,
+    want_unconditional: bool,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    """Every image as a latent and every caption as conditioning, as CPU tensors."""
+    from . import dataset as ds
+
+    pairs = ds._pairs(Path(dataset_dir))
+    if not pairs:
+        raise RuntimeError("The exported dataset is empty.")
+
+    root = Path(models_dir)
+    latents = _encode_pixels(root, pairs, device, resolution, flip)
+    captions = [caption for _img, caption in pairs for _ in ((False, True) if flip else (False,))]
+    if want_unconditional:
+        captions.append("")
+    embeds = _encode_captions(root, captions, device, dtype)
+
+    items = [
+        {"latent": latent, **_conditioning(embed, tags, latent)}
+        for latent, (embed, tags) in zip(latents, embeds, strict=False)
+    ]
+    unconditional = None
+    if want_unconditional:
+        embed, tags = embeds[-1]
+        # Caption dropout swaps in a different text length, which moves every row after it, so the
+        # whole layout travels with the embedding rather than just the embedding.
+        unconditional = _conditioning(embed, tags, latents[0])
+    return items, unconditional
+
+
+def _encode_pixels(
+    root: Path, pairs: list[tuple[Path, str]], device: str, resolution: int, flip: bool
+) -> list[Any]:
+    """Pass one: the video VAE, then dropped."""
+    import torch
+    from PIL import Image
+
+    from ..models.minimaxh3.vendor.packing import MINIMAX_H3_PIXEL_MEAN, MINIMAX_H3_PIXEL_STD
+
+    vae = _load_video_vae(root, device)
+    mean = torch.tensor(vae.config.latents_mean).view(1, -1, 1, 1, 1)
+    std = torch.tensor(vae.config.latents_std).view(1, -1, 1, 1, 1)
+    pixel_mean = torch.tensor(MINIMAX_H3_PIXEL_MEAN, device=device).view(1, -1, 1, 1, 1)
+    pixel_std = torch.tensor(MINIMAX_H3_PIXEL_STD, device=device).view(1, -1, 1, 1, 1)
+
+    from . import dataset as ds
+
+    out: list[Any] = []
+    try:
+        for img_path, _caption in pairs:
+            for mirrored in (False, True) if flip else (False,):
+                square = ds._square(Image.open(img_path), resolution, mirrored)
+                # H3 normalises with ImageNet statistics, not to [-1, 1] like the image archs, and
+                # a still is one frame: (1, 3, 1, H, W).
+                raw = torch.from_numpy(_as_array(square)).to(device)
+                pixels = raw.permute(2, 0, 1)[None, :, None]
+                pixels = (pixels.to(torch.float32).div(255.0) - pixel_mean) / pixel_std
+                with torch.no_grad():
+                    # The spatial encoder alone, the path inference uses for a single frame; the
+                    # temporal chunking is for 17n+5 clips.
+                    latent = _sample(vae._encode_clip(pixels))
+                out.append(((latent.cpu() - mean) / std)[0])
+    finally:
+        del vae
+        _reclaim()
+    logger.info("MiniMax H3: cached %d latents, video VAE released", len(out))
+    return out
+
+
+def _encode_captions(
+    root: Path, captions: list[str], device: str, dtype: Any
+) -> list[tuple[Any, Any]]:
+    """Pass two: the 4-bit conditioner, then dropped."""
+    import torch
+
+    from ..models.minimaxh3.vendor.encoders import MiniMaxH3TextEncoderStep
+
+    pipeline = _load_conditioner(root, device, dtype)
+    out: list[tuple[Any, Any]] = []
+    try:
+        for caption in captions:
+            with torch.no_grad():
+                # The staticmethod rather than the block, so nothing needs a PipelineState. `dtype`
+                # is not optional here: it defaults to `components.transformer.dtype`, and this
+                # pipeline deliberately has no transformer.
+                embeds, tags = MiniMaxH3TextEncoderStep.encode_prompt(
+                    pipeline, caption, None, device=torch.device(device), dtype=dtype
+                )
+            out.append((embeds[0].cpu(), tags.cpu()))
+    finally:
+        _drop_conditioner(pipeline)
+    logger.info("MiniMax H3: cached %d captions, conditioner released", len(out))
+    return out
+
+
+def _conditioning(embed: Any, tags: Any, latent: Any) -> dict[str, Any]:
+    """The packed layout for one caption over one still, as cacheable tensors."""
+    import torch
+
+    from ..models.minimaxh3.vendor.packing import build_packed_sequence, build_row_timesteps
+
+    _channels, frames, height, width = latent.shape
+    layout = build_packed_sequence(
+        text_token_tags=tags,
+        num_latent_frames=frames,
+        latent_height=height,
+        latent_width=width,
+        num_audio_latents=0,
+        patch_size=PATCH,
+        keyframe_anchors=(),
+    )
+    # Training pins no conditioning rows and a still has no audio rows, so every row shares one
+    # noise level and this vector is constant across steps. Derived from the vendored planner and
+    # then checked, so a change upstream is caught here rather than silently mis-addressing the
+    # AdaLN table.
+    unique, indices = build_row_timesteps(layout, 1.0, 1.0, 1.0, 1.0)
+    if unique.numel() != 1 or bool(indices.any()):
+        raise RuntimeError(
+            "MiniMax H3's row-timestep plan is no longer single-valued for a still; the cached "
+            "timestep index vector would mis-address the AdaLN table."
+        )
+    return {
+        "embed": embed,
+        "audio": torch.zeros(0, AUDIO_LATENT_CHANNELS),
+        "timestep_indices": indices,
+        "token_tags": layout.token_tags,
+        "position_ids": layout.position_ids,
+        "video_indices": layout.video_indices,
+        "audio_indices": layout.audio_indices,
+        "text_indices": layout.text_indices,
+    }
+
+
+def _load_video_vae(root: Path, device: str) -> Any:
+    import torch
+
+    from ..models.minimaxh3 import requirements as reqs
+    from ..models.minimaxh3.pipeline import _load_vae
+    from ..models.minimaxh3.vendor import AutoencoderKLMiniMaxH3
+    from . import models
+
+    path = Path(models._require(root, "minimax-h3", "vae"))
+    # fp32, not the compute dtype: the encoder builds its pixels in fp32 and a half-precision VAE
+    # meets them in a conv3d and raises. Same reason the generation pipeline pins it.
+    del reqs
+    return _load_vae(
+        AutoencoderKLMiniMaxH3, path, dtype=torch.float32, remap=True, device=device
+    )
+
+
+def _load_conditioner(root: Path, device: str, dtype: Any) -> Any:
+    """The Qwen3-VL conditioner at 4-bit, on a transformer-less pipeline.
+
+    Routed through the vendored pipeline rather than a local copy of the prompt template, for the
+    same reason Krea 2 and FLUX.2 build a transformer-less pipeline: the tokenisation, the vision
+    token type ids and the layer-50 tap are all easy to get subtly wrong and impossible to notice.
+    """
+    from transformers import AutoProcessor, AutoTokenizer, Qwen3VLForConditionalGeneration
+
+    from ..models.minimaxh3 import requirements as reqs
+    from ..models.minimaxh3.vendor import MiniMaxH3ModularPipeline
+    from ..models.minimaxh3.vendor.encoders import MiniMaxH3TextEncoderStep
+    from . import models
+
+    encoder_dir = Path(models._require(root, "minimax-h3", "text_encoders"))
+    processor_dir = reqs.resolve("text_encoders", "MiniMax-H3-processor")
+    if processor_dir is None:
+        raise RuntimeError(
+            "MiniMax H3's tokenizer and processor are missing. Download them from the node's model "
+            "popup; the conditioner cannot tokenise a caption without them."
+        )
+
+    quant, placement = _conditioner_plan(device)
+    text_encoder = Qwen3VLForConditionalGeneration.from_pretrained(
+        str(encoder_dir),
+        dtype=dtype,
+        local_files_only=True,
+        **({"quantization_config": quant, **placement} if quant is not None else {}),
+    )
+    pipeline = MiniMaxH3ModularPipeline(blocks=MiniMaxH3TextEncoderStep())
+    pipeline.update_components(
+        text_encoder=text_encoder,
+        tokenizer=AutoTokenizer.from_pretrained(str(processor_dir), local_files_only=True),
+        processor=AutoProcessor.from_pretrained(str(processor_dir), local_files_only=True),
+    )
+    return pipeline
+
+
+def _conditioner_plan(device: str) -> tuple[Any, dict[str, Any]]:
+    """4-bit, and on the card only if it fits, reusing the generation path's own decision."""
+    from ..device.memory import MemoryPolicy
+    from ..models.minimaxh3.pipeline import _encoder_config, _encoder_placement
+    from ..models.offload import recipe_for
+
+    policy = MemoryPolicy()
+    placement = policy.placement("text_encoder")
+    recipe = recipe_for(policy, keep_precision=(), stream_denoiser=False, quantize=True)
+    quant = _encoder_config(recipe)
+    if quant is None:  # bitsandbytes absent: nothing to place, and the load will speak for itself
+        return None, {}
+    del device
+    return quant, _encoder_placement(placement)
+
+
+def _drop_conditioner(pipeline: Any) -> None:
+    for name in ("text_encoder", "tokenizer", "processor"):
+        try:
+            setattr(pipeline, name, None)
+        except (AttributeError, TypeError):  # a ModularPipeline may guard its component slots
+            pass
+    _reclaim()
+
+
+def load_base(models_dir: str, device: str, dtype: Any, quant: Any) -> Any:
+    """The frozen base: streamed a block at a time, factorised, then quantised.
+
+    Order is the rule in ``models/offload.py`` and it is not negotiable: the structural transform
+    runs on unquantised weights, quantisation is last. Reversed, ``factorise_block`` would try to
+    matrix-multiply a 4-bit blob whose ``.weight`` is a uint8 column, and the result would be
+    garbage rather than an error.
+
+    Nothing here holds the whole model: at bf16 it is 62 GB on disk and each block is shrunk as its
+    weights land, so the peak is the shrunk total plus the one block being converted.
+    """
+    from ..device.policy import Quantization
+    from ..models.minimaxh3 import load as h3_load
+    from ..models.minimaxh3.pipeline import _adaln_basis
+    from . import models
+
+    path = Path(models._require(Path(models_dir), "minimax-h3", "diffusion_models"))
+    # Derived before the stream: the callback needs it while the first block lands, and
+    # `time_embedder.*` sorts after `blocks.*`. Only two tensors are read, about 60 MB of 62 GB.
+    basis = _adaln_basis(path)
+    staging = "cpu" if quant is Quantization.NF4 else device
+    model = h3_load.load_transformer(
+        path, dtype=dtype, device=staging, shrink=_shrinker(basis, quant, device, dtype)
+    )
+    _place_unstreamed(model, device)
+    logger.info("MiniMax H3 base loaded for training (%s)", quant.value)
+    return model
+
+
+def _shrinker(basis: Any, quant: Any, device: str, dtype: Any) -> Any:
+    """Shrink one transformer block as soon as its weights land, and place it."""
+    from ..device.policy import Quantization
+    from ..models.minimaxh3 import adaln as adaln_mod
+
+    def shrink(model: Any, prefix: str) -> None:
+        module = model
+        for part in prefix.split("."):
+            module = module[int(part)] if part.isdigit() else getattr(module, part)
+        module.requires_grad_(False)
+        module.adaln_proj = adaln_mod.factorise_block(module, basis)  # clause 1: unquantised
+        if quant is Quantization.NF4:  # clause 2: quantisation last
+            _swap_to_4bit(module, keep=_keeps_precision)
+            module.to(device)  # bitsandbytes quantizes each weight during this move
+        else:
+            module.to(device=device, dtype=dtype)
+
+    return shrink
+
+
+def _keeps_precision(path: str) -> bool:
+    """Whether a Linear is spared the 4-bit swap.
+
+    Only the factorised AdaLN projection. Unfactorised it is [96768, 2688] and quantising it is
+    ordinary; factorised it is [96768, 8] and those eight columns carry the entire modulation
+    signal, so the error concentrates instead of averaging. It is 1.5 MB a block, 75 MB across the
+    stack, which is not worth that.
+    """
+    return "adaln_proj" in path
+
+
+def _swap_to_4bit(module: Any, keep: Any = None, prefix: str = "") -> None:
+    """Replace every ``nn.Linear`` under ``module`` with a bitsandbytes NF4 layer.
+
+    The QLoRA arrangement: the base is frozen and 4-bit, gradients still flow through it to the
+    adapter on top, and quantization itself happens when the layer moves to CUDA.
+
+    Deliberately not ``loaders._swap_to_4bit``, which takes no keep-predicate and would convert the
+    factorised AdaLN projection along with everything else. Kept local rather than widening the
+    shared loader, so the two shipping architectures that use it are untouched.
+    """
+    import bitsandbytes as bnb
+    import torch
+
+    for name, child in list(module.named_children()):
+        path = f"{prefix}{name}"
+        if isinstance(child, torch.nn.Linear) and not (keep is not None and keep(path)):
+            layer = bnb.nn.Linear4bit(
+                child.in_features,
+                child.out_features,
+                bias=child.bias is not None,
+                compute_dtype=child.weight.dtype,
+                quant_type="nf4",
+            )
+            layer.weight = bnb.nn.Params4bit(
+                child.weight.data, requires_grad=False, quant_type="nf4"
+            )
+            if child.bias is not None:
+                layer.bias = torch.nn.Parameter(child.bias.data, requires_grad=False)
+            setattr(module, name, layer)
+        else:
+            _swap_to_4bit(child, keep, f"{path}.")
+
+
+def _place_unstreamed(model: Any, device: str) -> None:
+    """Move what the block callback never sees.
+
+    ``load.py`` fires ``shrink`` only for ``transformer_blocks.N``, so the embedders, the token
+    refiner, the norms and the two output heads are still wherever the stream staged them. Left on
+    the CPU they meet CUDA activations in the first forward.
+    """
+    stack = model.transformer_blocks
+    for child in model.children():
+        if child is not stack:
+            child.to(device)
+    for tensor in (*model.parameters(recurse=False), *model.buffers(recurse=False)):
+        tensor.data = tensor.data.to(device)
+
+
+def _sample(moments: Any) -> Any:
+    """Sample the posterior. Unlike the conditioning path this takes no fixed seed and no fp16
+    round trip: those exist to make a *reference* reproducible, and baking them into training
+    latents would narrow what the LoRA ever sees."""
+    from diffusers.models.autoencoders.vae import DiagonalGaussianDistribution
+
+    return DiagonalGaussianDistribution(moments).sample()
+
+
+def _as_array(image: Any) -> Any:
+    import numpy as np
+
+    return np.asarray(image, dtype="uint8")
+
+
+def _reclaim() -> None:
+    import torch
+
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()

--- a/core/src/inline_core/training/h3.py
+++ b/core/src/inline_core/training/h3.py
@@ -24,6 +24,14 @@ logger = logging.getLogger("inline_core.training.h3")
 PATCH = (1, 2, 2)
 AUDIO_LATENT_CHANNELS = 32
 
+#: What an absent caption becomes. H3 tokenises with ``add_special_tokens=False`` and has no BOS,
+#: so the empty string is genuinely zero tokens and the conditioner reshapes a (1, 0) sequence into
+#: an attention head and raises. A single space is one real token and the closest thing this model
+#: has to no caption: it is guidance-distilled, so inference never encodes an unconditional prompt
+#: and there is no established unconditional embedding to match. Covers caption dropout and an
+#: image whose ``.txt`` is missing or blank.
+_EMPTY_CAPTION = " "
+
 
 def precache(
     dataset_dir: str,
@@ -112,6 +120,7 @@ def _encode_captions(
     out: list[tuple[Any, Any]] = []
     try:
         for caption in captions:
+            caption = caption or _EMPTY_CAPTION
             with torch.no_grad():
                 # The staticmethod rather than the block, so nothing needs a PipelineState. `dtype`
                 # is not optional here: it defaults to `components.transformer.dtype`, and this

--- a/core/src/inline_core/training/models.py
+++ b/core/src/inline_core/training/models.py
@@ -38,6 +38,12 @@ _ENV = {
         "text_encoders": "INLINE_FLUX2_TEXT_ENCODER",
         "adapter": "INLINE_FLUX2_TRAIN_ADAPTER",
     },
+    archs.MINIMAX_H3: {
+        "diffusion_models": "INLINE_MINIMAXH3_MODEL",
+        "vae": "INLINE_MINIMAXH3_VIDEO_VAE",
+        "text_encoders": "INLINE_MINIMAXH3_TEXT_ENCODER",
+        "adapter": "INLINE_MINIMAXH3_TRAIN_ADAPTER",
+    },
 }
 
 
@@ -75,6 +81,17 @@ def _require(root: Path, arch: str, category: str) -> str:
 
 def _resolve(arch: str, category: str) -> Any:
     """The arch's own answer for a component, so training and generation pick the same file."""
+    if arch == archs.MINIMAX_H3:
+        from ..models.minimaxh3 import requirements as h3_reqs
+
+        if category == "vae":
+            return h3_reqs.resolve("vae", h3_reqs.VIDEO_VAE_FILE)
+        if category == "text_encoders":
+            return h3_reqs.resolve("text_encoders", "MiniMax-H3-text-encoder")
+        # Only fl2va trains: ref2va is the same architecture reached through reference conditioning,
+        # so a LoRA learned on one loads on the other.
+        return h3_reqs.resolve_transformer("fl2va")
+
     if arch == archs.FLUX2:
         from ..models.flux2 import requirements as flux2_reqs
 
@@ -261,6 +278,17 @@ def resolve_quant(
     fine, then OOMs at 1024 where the activations alone want ~21GB."""
     from ..device.policy import Quantization
 
+    if arch == archs.MINIMAX_H3:
+        # 4-bit is not a rung on a ladder for H3, it is the only way it loads: 40GB of base after
+        # the AdaLN factorisation, before activations or the adapter, does not leave room on any
+        # card this trains on. Refused rather than offered and then failing hours in.
+        if base_quant == "none":
+            raise RuntimeError(
+                "MiniMax H3 has no full-precision training path. Its base is 40GB after the AdaLN "
+                "factorisation, so it trains in 4-bit. Set the base precision back to auto."
+            )
+        return Quantization.NF4
+
     if base_quant == "none":
         return Quantization.NONE
     if base_quant == "nf4":
@@ -341,6 +369,14 @@ def load_transformer(
     from ..models import loaders
 
     quant = quant or Quantization.NONE
+
+    if arch == archs.MINIMAX_H3:
+        from . import h3
+
+        # No de-distillation adapter and no base-mode branch: H3 ships one undistilled build per
+        # partition, and only fl2va trains.
+        del base_mode
+        return h3.load_base(models_dir, device, dtype, quant)
 
     root = Path(models_dir)
     adapter = _adapter_path(root, arch, base_mode)

--- a/core/src/inline_core/training/trainer.py
+++ b/core/src/inline_core/training/trainer.py
@@ -18,8 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from . import arch as archs
-from . import dataset as ds
-from . import models, protocol
+from . import cache, models, protocol
 
 
 class _Stop:
@@ -133,19 +132,27 @@ def _activation_offload(enabled: bool) -> Any:
     return torch.autograd.graph.save_on_cpu(pin_memory=True)
 
 
+#: The cached-item keys that carry activations and take the compute dtype. Everything else moves to
+#: the device unchanged: a boolean mask would become weights, integer row tags and index tensors
+#: would stop addressing anything, and H3's float64 rotary position grid would lose most of its
+#: mantissa - none of which raises, they just train against the wrong thing.
+_ACTIVATION_KEYS = frozenset({"latent", "embed", "audio"})
+
+
 def _to_device(item: dict[str, Any], device: Any, dtype: Any) -> dict[str, Any]:
-    """A cached item on the training device. The attention mask stays boolean - casting it to the
-    compute dtype would turn a mask into weights."""
-    out: dict[str, Any] = {}
-    for key, value in item.items():
-        out[key] = value.to(device) if key == "mask" else value.to(device, dtype)
-    return out
+    """A cached item on the training device, casting only its activations."""
+    return {
+        key: value.to(device, dtype) if key in _ACTIVATION_KEYS else value.to(device)
+        for key, value in item.items()
+    }
 
 
 def train(manifest: dict[str, Any]) -> str | None:
     import torch
     from accelerate import Accelerator
     from peft import LoraConfig
+
+    from ..device.policy import Quantization
 
     arch = archs.get(manifest.get("arch"))
     hp = manifest["hyperparams"]
@@ -161,19 +168,12 @@ def train(manifest: dict[str, Any]) -> str | None:
 
     # Two phases, never overlapping: encoders -> precache -> free, THEN the transformer. Held
     # together they add the text encoder's several GB to the base; apart, peak is just the base.
-    protocol.progress(0, steps, status="loading encoders")
-    encoders = models.load_encoders(manifest["modelsDir"], arch.key, str(device), dtype)
-
     protocol.progress(0, steps, status="caching latents")
-    data = ds.precache(
-        manifest["datasetDir"], encoders, arch.key, str(device), dtype, resolution,
-        flip=bool(hp.get("flipAugment")),
-    )
-    # Encoded while the text encoder is still loaded; caption dropout swaps it in per step.
     dropout = max(0.0, min(1.0, float(hp.get("captionDropout") or 0.0)))
-    unconditional = ds.precache_empty(encoders, arch.key, str(device)) if dropout > 0 else None
-    shift = float(encoders.scheduler.config.get("shift", 1.0) or 1.0)
-    models.free_encoders(encoders)
+    data, unconditional, shift = cache.build(
+        manifest["datasetDir"], manifest["modelsDir"], arch.key, str(device), dtype, resolution,
+        flip=bool(hp.get("flipAugment")), dropout=dropout,
+    )
 
     quant = models.resolve_quant(
         str(hp.get("baseQuant") or "auto"),
@@ -196,6 +196,11 @@ def train(manifest: dict[str, Any]) -> str | None:
         manifest["modelsDir"], arch.key, manifest["baseMode"], str(device), dtype, quant
     )
     transformer.requires_grad_(False)
+    # PEFT picks its bitsandbytes-aware LoRA layer off this one attribute. Without it, and because
+    # bnb's Linear4bit subclasses nn.Linear, the generic dispatcher matches instead: grads still
+    # flow, so it looks fine, but it is not the path peft tests and merging would be wrong.
+    if quant is Quantization.NF4:
+        transformer.is_loaded_in_4bit = True
     transformer.add_adapter(
         LoraConfig(
             r=int(hp["rank"]),

--- a/core/tests/test_extension_install.py
+++ b/core/tests/test_extension_install.py
@@ -565,5 +565,8 @@ def test_every_channel_uses_the_installers_root_not_the_environment(
     default_root = extensions_dir()
     leaked = sorted(default_root.rglob("registry.json")) if default_root.exists() else []
     assert not leaked, f"wrote the registry cache to the process default: {leaked}"
-    assert not (Path.cwd() / "extensions").exists(), "wrote to the checkout's ./extensions"
+    # Assert on the artifact, not on the directory existing: a checkout where someone ran the server
+    # (or a restored machine image) already has an empty ./extensions, and that is not this bug.
+    stray = sorted((Path.cwd() / "extensions").rglob("registry.json"))
+    assert not stray, f"wrote to the checkout's ./extensions: {stray}"
     assert (installer.paths.cache / "registry.json").is_file(), "not under the installer's root"

--- a/core/tests/test_minimaxh3_nodes.py
+++ b/core/tests/test_minimaxh3_nodes.py
@@ -58,7 +58,7 @@ def test_every_node_outputs_video_plus_a_separate_audio_port(node_type: str) -> 
 
 #: On every Core node, so a load/* subnode can override the dropdowns. Not part of what a node is
 #: *for*, which is what the media ports below say.
-COMPONENTS = ["model", "vae", "text_encoder"]
+COMPONENTS = ["model", "vae", "text_encoder", "lora"]
 
 
 def test_the_inputs_are_what_each_node_is_for() -> None:
@@ -79,8 +79,9 @@ def test_every_node_carries_the_component_handles(node_type: str) -> None:
     for name in COMPONENTS:
         assert name in ports, f"{node_type} has no {name} handle"
         assert not ports[name].required
-    # No LoRA handle: H3 has no LoRA path, and a dot that does nothing is worse than no dot.
-    assert "lora" not in ports
+    # The LoRA handle is on every variant, including ref2va: the two partitions are structurally
+    # identical, so an adapter trained on one loads on the other.
+    assert ports["lora"].kind is PortKind.LORA
 
 
 def test_first_and_last_frame_are_both_optional() -> None:

--- a/core/tests/test_minimaxh3_training.py
+++ b/core/tests/test_minimaxh3_training.py
@@ -1,0 +1,306 @@
+"""MiniMax H3's training behaviour.
+
+The flow convention is the sharp edge, and H3 uses **Z-Image's**, the opposite of Krea 2 and FLUX.2.
+Getting it backwards trains a LoRA that quietly makes output worse rather than erroring, so it is
+pinned against the vendored scheduler itself rather than against a restated constant here: if the
+scheduler is ever re-synced from upstream and its convention moves, these fail.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from inline_core.training import arch as archs
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+
+packing = pytest.importorskip("inline_core.models.minimaxh3.vendor.packing")
+scheduling = pytest.importorskip("inline_core.models.minimaxh3.vendor.scheduling_minimax_h3")
+
+PATCH = (1, 2, 2)
+
+
+def _layout(text_tokens: int = 5, latent: int = 8):
+    return packing.build_packed_sequence(
+        text_token_tags=torch.full((text_tokens,), packing.MINIMAX_H3_TEXT_TAG, dtype=torch.long),
+        num_latent_frames=1,
+        latent_height=latent,
+        latent_width=latent,
+        num_audio_latents=0,
+        patch_size=PATCH,
+        keyframe_anchors=(),
+    )
+
+
+def test_minimax_h3_is_a_registered_training_arch() -> None:
+    assert archs.get(archs.MINIMAX_H3).key == archs.MINIMAX_H3
+
+
+def test_h3_shares_z_images_flow_convention_not_krea2s() -> None:
+    h3, zimage, krea2 = (
+        archs.get(archs.MINIMAX_H3),
+        archs.get(archs.Z_IMAGE),
+        archs.get(archs.KREA2),
+    )
+    clean, noise, sigma = torch.ones(2), torch.zeros(2), torch.tensor(0.3)
+
+    assert torch.equal(h3.target(clean, noise), zimage.target(clean, noise))
+    assert h3.timestep(sigma) == pytest.approx(float(zimage.timestep(sigma)))
+    assert not torch.equal(h3.target(clean, noise), krea2.target(clean, noise))
+
+
+def test_the_forward_process_matches_the_schedulers_own_scale_noise() -> None:
+    """What the loop noises must be what MiniMaxH3Scheduler calls x_t at the same timestep."""
+    h3 = archs.get(archs.MINIMAX_H3)
+    scheduler = scheduling.MiniMaxH3Scheduler(shift=12.0)
+    clean, noise = torch.randn(4, 6), torch.randn(4, 6)
+
+    for sigma in (0.05, 0.3, 0.71, 0.99):
+        loop = (1 - sigma) * clean + sigma * noise
+        theirs = scheduler.scale_noise(clean, h3.timestep(torch.tensor(sigma)), noise)
+        assert torch.allclose(loop, theirs, atol=1e-6), sigma
+
+
+def test_the_prediction_target_is_what_the_schedulers_step_inverts() -> None:
+    """A step on the trained target must recover the clean latent, which is what fixes the sign."""
+    h3 = archs.get(archs.MINIMAX_H3)
+    scheduler = scheduling.MiniMaxH3Scheduler(shift=12.0)
+    scheduler.set_timesteps(num_inference_steps=8)
+    clean, noise = torch.randn(4, 6), torch.randn(4, 6)
+
+    for sigma in (0.15, 0.5, 0.9):
+        timestep = h3.timestep(torch.tensor(sigma))
+        noisy = (1 - sigma) * clean + sigma * noise
+        # step()'s own x0 estimate, which it builds as sample + (1 - t) * velocity.
+        denoised = noisy + (1 - timestep) * h3.target(clean, noise)
+        assert torch.allclose(denoised, clean, atol=1e-5), sigma
+
+
+def test_sigma_uses_the_schedulers_shift_expression() -> None:
+    """H3's grid is shift * s / (1 + (shift - 1) * s), the same map the arch samples through."""
+    h3 = archs.get(archs.MINIMAX_H3)
+    for _ in range(50):
+        sigma = h3.sigma("cpu", 12.0)
+        assert sigma.shape == ()
+        assert 0.0 < float(sigma) < 1.0
+
+    scheduler = scheduling.MiniMaxH3Scheduler(shift=12.0)
+    scheduler.set_timesteps(num_inference_steps=64)
+    assert scheduler.sigmas is not None
+    # Shifted toward the noisy end: the median sigma of the inference grid sits well above 0.5.
+    assert float(scheduler.sigmas.median()) > 0.5
+
+
+def test_h3_targets_cover_a_blocks_linears_but_not_the_factorised_adaln() -> None:
+    targets = set(archs.get(archs.MINIMAX_H3).target_modules)
+
+    assert {"to_q", "to_k", "to_v", "to_out.0", "ff.net.0.proj", "ff.net.2"} <= targets
+    assert "context_embedder" in targets
+    # adaln_proj is replaced by the rank-8 factorisation at load, so adapting it is both tiny and
+    # aimed at eight columns carrying the whole modulation signal.
+    assert not any("adaln" in t for t in targets)
+    # The fp32-pinned heads stay out of it.
+    assert not {"proj_in", "proj_out", "audio_proj_in", "audio_proj_out"} & targets
+    # Z-Image's and Krea 2's feed-forward names match nothing in H3.
+    assert not {"w1", "w2", "w3", "ff.up", "ff.down"} & targets
+
+
+def test_attention_scope_narrows_to_the_projections_h3_has() -> None:
+    h3 = archs.get(archs.MINIMAX_H3)
+
+    assert archs.target_modules(h3, "attention") == ["to_q", "to_k", "to_v", "to_out.0"]
+
+
+def test_a_still_packs_to_one_latent_frame_with_no_audio_rows() -> None:
+    layout = _layout(text_tokens=5, latent=8)
+
+    # 8x8 latent under a 2x2 patch is 16 video rows, after the 5 text rows.
+    assert layout.sequence_length == 5 + 16
+    assert layout.video_indices.numel() == 16
+    assert layout.audio_indices.numel() == 0
+    assert layout.num_condition_video_rows == 0
+
+
+def test_every_row_shares_one_timestep_so_the_index_vector_is_constant() -> None:
+    """The forward caches timestep_indices instead of rebuilding the plan each step; this is the
+    assumption that makes that safe."""
+    layout = _layout()
+
+    for step in (0.1, 0.6, 0.95):
+        unique, indices = packing.build_row_timesteps(layout, step, step, step, step)
+        assert unique.numel() == 1
+        assert torch.equal(indices, torch.zeros(layout.sequence_length, dtype=indices.dtype))
+
+
+def test_h3_refuses_a_full_precision_base_rather_than_offering_one_that_will_not_fit() -> None:
+    from inline_core.training import models
+
+    with pytest.raises(RuntimeError, match="no full-precision training path"):
+        models.resolve_quant("none", "/models", archs.MINIMAX_H3, "raw", 512)
+
+
+def test_h3_always_trains_in_4bit() -> None:
+    from inline_core.device.policy import Quantization
+    from inline_core.training import models
+
+    for asked in ("auto", "nf4"):
+        assert models.resolve_quant(asked, "/models", archs.MINIMAX_H3, "raw", 512) is (
+            Quantization.NF4
+        )
+
+
+def test_the_4bit_swap_spares_the_factorised_adaln_projection() -> None:
+    """Quantising the rank-8 AdaLN projection concentrates error into eight columns carrying the
+    whole modulation signal, so the keep-predicate has to reach it wherever it is nested."""
+    from inline_core.training import h3
+
+    assert h3._keeps_precision("adaln_proj.linear")
+    assert h3._keeps_precision("transformer_blocks.7.adaln_proj.linear")
+    for spared in ("attn.to_q", "ff.net.0.proj", "ff.net.2", "attn.to_out.0"):
+        assert not h3._keeps_precision(spared)
+
+
+def test_the_swap_walks_nested_children_and_honours_the_predicate() -> None:
+    """The real swap. bitsandbytes builds a Linear4bit on the CPU fine - quantization happens when
+    the layer moves to CUDA - so the traversal and the predicate are testable without a card."""
+    bnb = pytest.importorskip("bitsandbytes")
+
+    from inline_core.training import h3
+
+    block = torch.nn.Module()
+    block.attn = torch.nn.Module()
+    block.attn.to_q = torch.nn.Linear(8, 8, bias=False)
+    block.attn.to_out = torch.nn.ModuleList([torch.nn.Linear(8, 8, bias=False), torch.nn.Dropout()])
+    block.ff = torch.nn.Module()
+    block.ff.net = torch.nn.ModuleList([torch.nn.Linear(8, 16), torch.nn.Linear(16, 8)])
+    block.norm = torch.nn.RMSNorm(8)
+    block.adaln_proj = torch.nn.Module()
+    block.adaln_proj.linear = torch.nn.Linear(8, 96)
+    original = block.adaln_proj.linear.weight.data.clone()
+
+    h3._swap_to_4bit(block, keep=h3._keeps_precision)
+
+    kinds = {name: type(mod) for name, mod in block.named_modules()}
+    assert kinds["attn.to_q"] is bnb.nn.Linear4bit
+    assert kinds["attn.to_out.0"] is bnb.nn.Linear4bit
+    assert kinds["ff.net.0"] is bnb.nn.Linear4bit
+    assert kinds["ff.net.1"] is bnb.nn.Linear4bit
+    # Spared, and left byte-identical rather than merely left as an nn.Linear.
+    assert kinds["adaln_proj.linear"] is torch.nn.Linear
+    assert torch.equal(block.adaln_proj.linear.weight.data, original)
+    # A norm is not a Linear and must not be touched either.
+    assert kinds["norm"] is torch.nn.RMSNorm
+
+
+def test_the_swap_keeps_biases_and_frozen_base_weights() -> None:
+    pytest.importorskip("bitsandbytes")
+
+    from inline_core.training import h3
+
+    module = torch.nn.Module()
+    module.proj = torch.nn.Linear(8, 16, bias=True)
+    bias = module.proj.bias.data.clone()
+
+    h3._swap_to_4bit(module)
+
+    assert torch.equal(module.proj.bias.data, bias)
+    # The base is frozen; only the adapter on top learns.
+    assert not module.proj.weight.requires_grad
+    assert not module.proj.bias.requires_grad
+
+
+def test_the_residual_fuse_reaches_modules_outside_the_block_stack() -> None:
+    """The load callback only fires for ``transformer_blocks.N``, so a per-block fuse silently
+    misses ``context_embedder`` and the token refiner - both of which are LoRA targets and both of
+    which exist, so ``plan_loras`` validates clean and the LoRA is then half-applied."""
+    from inline_core.models.minimaxh3 import load as h3_load
+
+    model = torch.nn.Module()
+    model.transformer_blocks = torch.nn.ModuleList([torch.nn.Module()])
+    model.transformer_blocks[0].to_q = torch.nn.Linear(4, 4, bias=False)
+    model.context_embedder = torch.nn.Linear(4, 4, bias=False)
+    for module in (model.transformer_blocks[0].to_q, model.context_embedder):
+        torch.nn.init.zeros_(module.weight)
+
+    down, up = torch.ones(1, 4), torch.ones(4, 1)
+    plan = {"transformer_blocks.0.to_q": [(down, up, 1.0)], "context_embedder": [(down, up, 1.0)]}
+
+    fused: set[str] = set()
+    shrink = h3_load._fusing_shrink(plan, fused, None)
+    shrink(model, "transformer_blocks.0")
+    # The block was covered by the callback; the top-level projection was not.
+    assert fused == {"transformer_blocks.0.to_q"}
+    assert not torch.equal(model.transformer_blocks[0].to_q.weight, torch.zeros(4, 4))
+    assert torch.equal(model.context_embedder.weight, torch.zeros(4, 4))
+
+    h3_load._finish_fuse(model, plan, fused)
+
+    assert fused == set(plan)
+    assert not torch.equal(model.context_embedder.weight, torch.zeros(4, 4))
+
+
+def test_a_lora_layer_that_never_fuses_is_refused_rather_than_half_applied() -> None:
+    from inline_core.errors import ComponentError
+    from inline_core.models.minimaxh3 import load as h3_load
+
+    model = torch.nn.Module()
+    model.context_embedder = torch.nn.Linear(4, 4, bias=False)
+    plan = {"context_embedder": [], "somewhere.that.vanished": []}
+
+    with pytest.raises(ComponentError, match="never fused"):
+        h3_load._finish_fuse(model, plan, {"context_embedder"})
+
+
+def test_the_residual_pass_does_not_fuse_a_block_twice() -> None:
+    """Double-fusing is the other way this goes wrong, and it also does not raise."""
+    from inline_core.models.minimaxh3 import load as h3_load
+
+    model = torch.nn.Module()
+    model.transformer_blocks = torch.nn.ModuleList([torch.nn.Module()])
+    model.transformer_blocks[0].to_q = torch.nn.Linear(4, 4, bias=False)
+    torch.nn.init.zeros_(model.transformer_blocks[0].to_q.weight)
+
+    plan = {"transformer_blocks.0.to_q": [(torch.ones(1, 4), torch.ones(4, 1), 1.0)]}
+    fused: set[str] = set()
+    h3_load._fusing_shrink(plan, fused, None)(model, "transformer_blocks.0")
+    once = model.transformer_blocks[0].to_q.weight.clone()
+
+    h3_load._finish_fuse(model, plan, fused)
+
+    assert torch.equal(model.transformer_blocks[0].to_q.weight, once)
+
+
+class _EchoTransformer:
+    """Returns the packed video rows unchanged, so pack/unpack must round trip to the input."""
+
+    def __init__(self) -> None:
+        self.seen: dict[str, object] = {}
+
+    def __call__(self, **kwargs: object) -> tuple[object, object]:
+        self.seen = kwargs
+        return kwargs["hidden_states"], kwargs["audio_hidden_states"]
+
+
+def test_h3_forward_packs_and_unpacks_back_to_the_latent_grid() -> None:
+    latent = torch.arange(24 * 1 * 8 * 8, dtype=torch.float32).reshape(24, 1, 8, 8)
+    layout = _layout(text_tokens=5, latent=8)
+    item = {
+        "embed": torch.zeros(5, 5120),
+        "audio": torch.zeros(0, 32),
+        "timestep_indices": torch.zeros(layout.sequence_length, dtype=torch.long),
+        "token_tags": layout.token_tags,
+        "position_ids": layout.position_ids,
+        "video_indices": layout.video_indices,
+        "audio_indices": layout.audio_indices,
+        "text_indices": layout.text_indices,
+    }
+    transformer = _EchoTransformer()
+
+    out = archs.get(archs.MINIMAX_H3).forward(transformer, latent, torch.tensor(0.5), item)
+
+    assert torch.equal(out, latent)
+    # 2x2 patches over one latent frame: 16 rows of 24 * 4 channels.
+    assert tuple(transformer.seen["hidden_states"].shape) == (1, 16, 96)
+    assert tuple(transformer.seen["audio_hidden_states"].shape) == (1, 0, 32)
+    assert tuple(transformer.seen["timestep"].shape) == (1,)

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -60,6 +60,32 @@ wheels = [
 ]
 
 [[package]]
+name = "av"
+version = "18.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/a4/570a5a35c8638aba01e739925846c35fdd6b0756a15526766d0a4dd3b7df/av-18.0.0.tar.gz", hash = "sha256:4ef7e72c3d3a872584a1215173b16e0226811037f40dcdbf75992631098df1ba", size = 4340222, upload-time = "2026-07-02T06:37:58.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/4a/9e3463df030e063d757fa12f0f39be6541b45b06b5bad48c2ce361b924bf/av-18.0.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:149289d40e732a6e49c9530bc245b49d9964cfd1c8c9e06778703b7d5bba6b25", size = 22499354, upload-time = "2026-07-02T06:36:58.751Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b3/2576a44b4f39c7462ced4c17fec04c756f7b0f3c5cb940d124173e417d6a/av-18.0.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:35274c20d2ad3b4774fe632bcef2e34af79858ddf899352339cc3babbc13a484", size = 18175248, upload-time = "2026-07-02T06:37:01.741Z" },
+    { url = "https://files.pythonhosted.org/packages/84/74/6732f17b96dc23fd23b876b2805435855abdc8a3b397142be4e581165de8/av-18.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4d683b7747a0ba9222b8a5f81e41db5f796e7f64473454ec4fe2548e083c2fa0", size = 33387843, upload-time = "2026-07-02T06:37:05.097Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b9/7708c43fed7ae28b4a1bad060b4221e3334cd827cec24f7165902a6ac1f4/av-18.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ae56b40b6f8b067a8ad2dac664fbfbabac7f7a55b9a7bb031eb99289252bc017", size = 35536910, upload-time = "2026-07-02T06:37:08.806Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/94/eba99691d184f6a395a242d54dc370e2fd2265e95bbc98e2963a0fdbdd6c/av-18.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:ea2e8ebbce521f21b55df9400e00d721623c9020ef158f5a188a96130be0743f", size = 38984619, upload-time = "2026-07-02T06:37:11.861Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/cf/0d7aee07fe16aa9ffdf96043c14bed5485a52c0dea4259de87aa306ecab4/av-18.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef96dabb3e50dac249913145dff5424b302b257fd95dcb64be3c7b7a8aef16d1", size = 34451176, upload-time = "2026-07-02T06:37:15.154Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/810da80b12680d4c4fe235bd1b4003289be9213ac7f114b77b8ecf0e3b3e/av-18.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0f65518a184613e41536f29e8758c8e3d8293e46bf5bef108f04f925bbfa3f44", size = 36619869, upload-time = "2026-07-02T06:37:18.495Z" },
+    { url = "https://files.pythonhosted.org/packages/11/85/0f121ff43dc5a70696676c98a8f1674e2fa787614c2abaacb15fa1a9bc99/av-18.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:aaf4d354d2beaa6651e4f92e54409a578bde64f79c0beef9a30b388d06f7c629", size = 27556236, upload-time = "2026-07-02T06:37:21.388Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f6/2509754d4d2356abc6fc0ea3d57c12ade29bac23a1fb7fc215a53ca518fb/av-18.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:adac2b3833b6cb9bd6cb52664a522b94db453615b3675b1dbb26e13fe1c80da6", size = 20221133, upload-time = "2026-07-02T06:37:23.88Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/25/4ee23a7f1609adf9b2f140c7a8ffade64a1449d89ab431d922a809eebf19/av-18.0.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:88dd8e35e9242662b409a6a05fd24a6775d949eb05da0ba31cab4f250eacbab5", size = 22740741, upload-time = "2026-07-02T06:37:26.659Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f0/b9f8363d07aa4521913e483f6a30c7c164973ef01de62769bf9b97049cd8/av-18.0.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f8f454349c402e2c8d6fa80b54eb2a3f86c00f414d2b399f01ae6dab075c6fd8", size = 18384189, upload-time = "2026-07-02T06:37:29.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/e5/69397019aed280a72a43e97a252dee4295df1a9e608848452e5300ec4dab/av-18.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:88ce194c2201c6a6d40336adee8a5ddde46ed743eacb500e3ae9368d1c6d889e", size = 36749881, upload-time = "2026-07-02T06:37:33.096Z" },
+    { url = "https://files.pythonhosted.org/packages/37/3a/1614d74f0d676ea6745eb59553c9ad01ca25db523cba808d522e838f4f5b/av-18.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:aa15e567a018cc94a26b0ab45da676dee70c4146ace6e92e47d30cc9689cbfbe", size = 38645927, upload-time = "2026-07-02T06:37:37.086Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3c/5f54710d69b0ea93634134f92b49c7a2a7fd27da5486a8a7e6251ac1cfb4/av-18.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:613153e48cefc91700746dde0ad0282d4677b194cba22cc771de14c78411cf8b", size = 40454783, upload-time = "2026-07-02T06:37:40.904Z" },
+    { url = "https://files.pythonhosted.org/packages/26/92/8293e6a267e0591b543abd96ae01e7e8ed228509bdb4e4644a8a8395d90f/av-18.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:30404f53ca1ea7f350ac86ff22a2c04f903014758e9b33f398c5a62de34bd84f", size = 37573117, upload-time = "2026-07-02T06:37:44.856Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0c/38ed7601277ae57dfe857d040be4762530fd728efff45c2fb8f035fef96a/av-18.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6882a48f7aec2863c96cddee3256ff2da98f7fb6cbed83cee9d7e70a8f186a6b", size = 39669026, upload-time = "2026-07-02T06:37:48.761Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/0636ca04d5d89d01c49bd366d2b660cc85d1f8117c476b2be62eb0c70855/av-18.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:55a646e9afce9fdc5de5224205a8a12c7ed1ba9803145dcc876c40bfc03a109b", size = 28448336, upload-time = "2026-07-02T06:37:52.477Z" },
+    { url = "https://files.pythonhosted.org/packages/01/20/1e24450ea981c44ed328691496fd2774dfa9fa3c3b00fd07f72fd5614abe/av-18.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:96f594ff506a09475e5549359352332049a25d37a08f00b4623f7f6e92e45b9c", size = 21377289, upload-time = "2026-07-02T06:37:55.935Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -576,7 +602,7 @@ wheels = [
 
 [[package]]
 name = "inline-core"
-version = "1.2.6"
+version = "1.2.61"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -621,6 +647,7 @@ parallel = [
 ]
 runtime = [
     { name = "accelerate" },
+    { name = "av" },
     { name = "controlnet-aux" },
     { name = "diffusers" },
     { name = "huggingface-hub" },
@@ -652,6 +679,7 @@ training = [
 requires-dist = [
     { name = "accelerate", marker = "extra == 'all'", specifier = ">=0.30" },
     { name = "accelerate", marker = "extra == 'runtime'", specifier = ">=0.30" },
+    { name = "av", marker = "extra == 'runtime'", specifier = ">=12" },
     { name = "bitsandbytes", marker = "sys_platform != 'darwin' and extra == 'all'", specifier = ">=0.43" },
     { name = "bitsandbytes", marker = "sys_platform != 'darwin' and extra == 'training'", specifier = ">=0.43" },
     { name = "controlnet-aux", marker = "extra == 'all'", specifier = ">=0.0.7" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inline-studio",
-  "version": "1.2.53",
+  "version": "1.2.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inline-studio",
-      "version": "1.2.53",
+      "version": "1.2.62",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@react-three/drei": "^10.7.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,33 @@
 {
   "name": "inline-studio",
-  "version": "1.2.61",
-  "description": "An experimentation layer for visual artists: a node canvas for building generative pipelines, served by the Inline Core engine.",
+  "version": "1.2.62",
+  "description": "AI filmmaking on a node canvas. Generate locally on your own GPU and train your own LoRAs on the same canvas, with the built-in Inline Core engine and hosted models. Every render is kept as a versioned take.",
+  "keywords": [
+    "ai-filmmaking",
+    "node-canvas",
+    "lora",
+    "lora-training",
+    "train-lora-locally",
+    "local-ai",
+    "diffusion",
+    "text-to-image",
+    "text-to-video",
+    "z-image",
+    "krea-2",
+    "flux2",
+    "minimax-h3",
+    "stable-diffusion",
+    "generative-ai",
+    "open-source"
+  ],
+  "homepage": "https://inlinestudio.art",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/inlineresearch/Inline-Studio.git"
+  },
+  "bugs": {
+    "url": "https://github.com/inlineresearch/Inline-Studio/issues"
+  },
   "author": "Inline Studio",
   "license": "GPL-3.0-or-later",
   "type": "module",

--- a/packages/frontend/pyproject.toml
+++ b/packages/frontend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inline-studio-frontend"
-version = "1.2.61"
+version = "1.2.62"
 description = "Prebuilt Inline Studio web UI (SPA), served by Inline Core. Mirrors comfyui-frontend-package."
 requires-python = ">=3.9"
 readme = "README.md"

--- a/src/renderer/views/Trainer/TrainerSettingsPanel.tsx
+++ b/src/renderer/views/Trainer/TrainerSettingsPanel.tsx
@@ -54,9 +54,16 @@ const BASES: Record<TrainingArch, { value: TrainingBaseMode; label: string }[]> 
   // FLUX.2 has no de-distillation adapter: you train on a Base checkpoint and the adapter still
   // loads on the distilled build for generation, which is both faster and better.
   flux2: [{ value: 'raw', label: 'FLUX.2 Base (required)' }],
+  // H3 ships one undistilled build per partition, and only fl2va trains. The LoRA loads on all four
+  // H3 nodes afterwards, ref2va included - the two partitions are the same architecture.
+  'minimax-h3': [{ value: 'raw', label: 'MiniMax H3 FL2VA (required)' }],
 }
 
-/** Krea 2 and FLUX.2 have a 4-bit base path; the control is hidden for Z-Image rather than lying. */
+/**
+ * Which archs offer a base-precision choice. Z-Image is absent because it trains in bf16 on the
+ * cards people have; MiniMax H3 is absent for the opposite reason - it is 4-bit only, and a picker
+ * with one option is a lie. Both are hidden rather than shown and then refused.
+ */
 const QUANTIZABLE: TrainingArch[] = ['krea2', 'flux2']
 
 const QUANTS: { value: TrainingBaseQuant; label: string }[] = [
@@ -81,6 +88,7 @@ const ARCHS: { value: TrainingArch; label: string }[] = [
   { value: 'z-image', label: 'Z-Image' },
   { value: 'krea2', label: 'Krea 2' },
   { value: 'flux2', label: 'FLUX.2' },
+  { value: 'minimax-h3', label: 'MiniMax H3 (video)' },
 ]
 
 function NumberField({
@@ -261,6 +269,13 @@ export function TrainerSettingsPanel({ itemId }: { itemId: string }): React.JSX.
         {arch === 'flux2' && (
           <span className="text-[10px] text-zinc-600">
             Train on Base, then generate with the distilled build - the LoRA carries over.
+          </span>
+        )}
+        {arch === 'minimax-h3' && (
+          <span className="text-[10px] text-zinc-600">
+            Trains on still images and applies to video. Learns look, style and character, not
+            motion. Wire the result into any H3 node's LoRA input. 4-bit base, so it needs a big
+            card.
           </span>
         )}
       </label>

--- a/src/renderer/views/Trainer/nodes/TrainerNode.tsx
+++ b/src/renderer/views/Trainer/nodes/TrainerNode.tsx
@@ -30,6 +30,7 @@ function requirementType(arch: string, baseMode: string): string {
   if (arch === 'krea2')
     return baseMode === 'turbo_adapter' ? 'krea/krea-2-turbo' : 'krea/krea-2-raw'
   if (arch === 'flux2') return 'black-forest-labs/flux-2'
+  if (arch === 'minimax-h3') return 'minimax/h3-text-to-video'
   return 'alibaba/z-image-turbo'
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -424,8 +424,11 @@ export interface ModelDownloadErrorEvent {
 // LoRA training ------------------------------------------------------------
 
 /** Turbo needs a training adapter to avoid "turbo drift"; a de-turbo base trains without one. */
-/** The model family a LoRA is trained for. */
-export type TrainingArch = 'z-image' | 'krea2' | 'flux2'
+/**
+ * The model family a LoRA is trained for. `minimax-h3` is the video model: it trains on stills and
+ * the adapter applies to every H3 node at generation time.
+ */
+export type TrainingArch = 'z-image' | 'krea2' | 'flux2' | 'minimax-h3'
 
 /**
  * Which base checkpoint a run trains against. `raw` is Krea 2's undistilled base (the recommended


### PR DESCRIPTION
## Summary

### MiniMax H3 LoRA training

Adds MiniMax H3 as a fourth trainable architecture. Trains on still images, and the adapter applies to video.

### What's new

- H3 arch entry in [arch.py](core/src/inline_core/training/arch.py), sharing Z-Image's flow convention
- Staged precache in [h3.py](core/src/inline_core/training/h3.py), because the fp32 video VAE and the 32B conditioner cannot be resident together
- 4-bit base loader: factorise the AdaLN branch, then quantise, streaming block by block
- `lora` port on all four H3 nodes in [runner.py](core/src/inline_core/models/minimaxh3/runner.py), so the trained file is usable
- Trainer UI picker, plus the model download popup wired to the H3 requirements

### Measured on an L40S

| Phase | Peak |
| --- | --- |
| Latent caching | 10.8GB |
| Caption caching | 20.5GB |
| Training | 11.7GB |

- Run peaks at 20.6GB, set by the caption pass, so 512px and 768px cost the same
- 0.63s a step at 512px, 0.77s at 768px, about 7 minutes of startup
- 62GB checkpoint down to 11.7GB, host RAM stays near 1.1GB
- Full tables in [TRAINING.md](TRAINING.md)

### Fixes two live bugs in the existing trainer

- `_to_device` cast every non-`mask` tensor to the compute dtype, which would destroy index tensors
- PEFT never saw `is_loaded_in_4bit`, so NF4 runs silently used the generic LoRA layer instead of the bitsandbytes one. Affects Krea 2 and FLUX.2 today

### Verified

- 771 Python tests, 205 TS tests, typecheck and lint clean
- Trained a 400 step LoRA and rendered the same seed with and without it. Clips differ by 50.4 mean absolute out of 255, both coherent
- Fuse checked arithmetically: all 313 adapted modules, including 13 outside the block stack that a per-block fuse would have silently missed

### Known, not fixed here

- A LoRA trained with alpha different from rank fuses at the wrong strength, on all four architectures. Hidden by the default of alpha equalling rank
- 15 pre-existing `UP042` lint errors in unrelated files, deferred deliberately

Also bumps to 1.2.62.
Closes #

## Checklist

- [ ] `npm run typecheck && npm run lint && npm run test` pass
- [ ] `cd core && ruff check . && uv run pytest -q` pass (if the engine changed)
- [ ] Commits use Conventional Commits and are signed off (`git commit -s`)
- [ ] Change is small and focused, and matches the surrounding style
