### PR TITLE
Portable lora quantised model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="LICENSE"><img alt="License: GPLv3" src="https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge"></a>
   <a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/Python-3.11%2B-blue?style=for-the-badge&logo=python&logoColor=white"></a>
-  <a href="../../releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/Release-v1.2.63-blue?style=for-the-badge"></a>
+  <a href="../../releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/Release-v1.2.67-blue?style=for-the-badge"></a>
   <a href="https://discord.gg/cSUS88VdY9"><img alt="Join our Discord" src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white&style=for-the-badge"></a>
 </p>
 

--- a/core/CLAUDE.md
+++ b/core/CLAUDE.md
@@ -246,6 +246,11 @@ real codec that moves tensors lives with the model runner.
   (a style LoRA) to 1.2% (a restoration LoRA), so "this adapter looks weak" is not a finding. What
   predicts a LoRA doing nothing is whether its per-weight change clears one quantization step. Warn
   on that, and only when the base is actually quantized.
+- **Patching a diffusers object may patch a copy, and it will not tell you.**
+  `ModularPipeline.blocks` is a property returning `deepcopy(self._blocks)`, so hooking the block
+  graph through it installs cleanly onto a throwaway and reports success. That is how H3's denoise
+  ran with no per-step progress while the hook said it was attached. Reach for the backing
+  attribute, and prove a hook fires against the real object rather than trusting a return value.
 - **Verify image models by rendering.** The FLUX.2 work shipped five bugs past a green test suite,
   and every one produced a _wrong image rather than an error_: a mis-keyed checkpoint, a
   vision-language encoder loaded in place of a text one, an unnormalized latent, and a control context

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 # PyPI name; the import package is `inline_core` (src/inline_core).
 name = "inline-core"
-version = "1.2.66"
+version = "1.2.67"
 description = "The generation engine behind Inline Studio."
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/core/src/inline_core/models/pipeline_runtime.py
+++ b/core/src/inline_core/models/pipeline_runtime.py
@@ -705,10 +705,15 @@ def attach_step_progress(pipe: Any, on_step: Any) -> bool:
 
 
 def _blocksets(pipe: Any) -> list[Any]:
-    """Every blockset that might run: a staged pipeline keeps the denoise in its second half."""
+    """Every blockset that might run: a staged pipeline keeps the denoise in its second half.
+
+    Reads ``_blocks`` and not the public ``blocks``, which is a property documented as returning a
+    *copy*. Patching the copy silently does nothing, which is exactly what it did.
+    """
     phases = getattr(pipe, "_inline_phases", None)
     targets = list(phases) if phases else [pipe]
-    return [t.blocks for t in targets if getattr(t, "blocks", None) is not None]
+    found = [getattr(t, "_blocks", None) or getattr(t, "blocks", None) for t in targets]
+    return [b for b in found if b is not None]
 
 
 def _denoise_loop(blocks: Any) -> Any:

--- a/core/tests/test_minimaxh3_nodes.py
+++ b/core/tests/test_minimaxh3_nodes.py
@@ -587,3 +587,31 @@ def test_step_progress_reports_when_there_is_no_loop_to_hook() -> None:
     from inline_core.models import pipeline_runtime as rt
 
     assert rt.attach_step_progress(_Pipe(), lambda *_a: None) is False
+
+
+def test_step_progress_survives_the_blocks_property_returning_a_copy() -> None:
+    """``ModularPipeline.blocks`` is a property that deepcopies, so patching what it returns is a
+    silent no-op. This is the bug that made the hook look installed while the UI showed nothing."""
+    from inline_core.models import pipeline_runtime as rt
+
+    loop = _FakeLoop()
+
+    class _Blocks:
+        sub_blocks = {"denoise": loop}
+
+    class _Pipe:
+        _blocks = _Blocks()
+
+        @property
+        def blocks(self) -> object:
+            import copy
+
+            return copy.deepcopy(self._blocks)
+
+    seen: list[tuple[int, int]] = []
+    assert rt.attach_step_progress(_Pipe(), lambda done, total: seen.append((done, total)))
+
+    with loop.progress_bar(total=2) as bar:
+        bar.update()
+        bar.update()
+    assert seen == [(1, 2), (2, 2)]

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -601,7 +601,7 @@ wheels = [
 
 [[package]]
 name = "inline-core"
-version = "1.2.66"
+version = "1.2.67"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },

--- a/docker/README.md
+++ b/docker/README.md
@@ -114,7 +114,7 @@ model: [inlinestudio.art/lora-training](https://inlinestudio.art/lora-training).
 | Tag                  | What                                             |
 | -------------------- | ------------------------------------------------ |
 | `latest`             | the most recent stable release                   |
-| `1.2.66` and similar | a specific release, pin this for reproducibility |
+| `1.2.67` and similar | a specific release, pin this for reproducibility |
 
 Every tag is built from the matching GitHub release by CI, so the image and the source always agree.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inline-studio",
-  "version": "1.2.66",
+  "version": "1.2.67",
   "description": "AI filmmaking on a node canvas. Generate locally on your own GPU and train your own LoRAs on the same canvas, with the built-in Inline Core engine and hosted models. Every render is kept as a versioned take.",
   "keywords": [
     "ai-filmmaking",

--- a/packages/frontend/pyproject.toml
+++ b/packages/frontend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inline-studio-frontend"
-version = "1.2.66"
+version = "1.2.67"
 description = "Prebuilt Inline Studio web UI (SPA), served by Inline Core. Mirrors comfyui-frontend-package."
 requires-python = ">=3.9"
 readme = "README.md"


### PR DESCRIPTION
## Summary

What this changes and why.

Closes #

## Checklist

- [ ] `npm run typecheck && npm run lint && npm run test` pass
- [ ] `cd core && ruff check . && uv run pytest -q` pass (if the engine changed)
- [ ] Commits use Conventional Commits and are signed off (`git commit -s`)
- [ ] Change is small and focused, and matches the surrounding style
