### PR TITLE
minimax step progress fix

### DIFF
--- a/core/src/inline_core/models/pipeline_runtime.py
+++ b/core/src/inline_core/models/pipeline_runtime.py
@@ -742,6 +742,10 @@ class _StepReporter:
         return getattr(self._inner, name)
 
 
+#: Marks our replacement so a re-attach unwraps to the real bar instead of stacking on itself.
+_ORIGINAL = "_inline_original"
+
+
 def attach_step_progress(pipe: Any, on_step: Any) -> bool:
     """Report every denoising step of ``pipe``. Returns whether a loop was found to hook.
 
@@ -754,13 +758,17 @@ def attach_step_progress(pipe: Any, on_step: Any) -> bool:
         if loop is None:
             continue
         found = True
-        original = loop.progress_bar
+        # Replace a previous hook rather than wrap it. The pipeline is cached across renders, so
+        # wrapping stacked a layer per render, each holding an earlier run's callback. A cancelled
+        # token stays cancelled, so one cancel made every later render raise at its first step.
+        original = getattr(loop.progress_bar, _ORIGINAL, loop.progress_bar)
 
         def progress_bar(
             total: Any = None, _original: Any = original, **kw: Any
         ) -> _StepReporter:
             return _StepReporter(_original(total=total, **kw), int(total or 0), on_step)
 
+        setattr(progress_bar, _ORIGINAL, original)
         loop.progress_bar = progress_bar
     return found
 

--- a/core/tests/test_minimaxh3_nodes.py
+++ b/core/tests/test_minimaxh3_nodes.py
@@ -558,7 +558,8 @@ class _FakeLoop:
 
 def test_step_progress_hooks_the_denoise_loop() -> None:
     """The modular loop has no callback_on_step_end, so the progress bar is the only per-step hook.
-    Without it a long denoise emits nothing and the UI shows 'loading model' for the whole render."""
+    Without it a long denoise emits nothing and the UI shows 'loading model' for the whole
+    render."""
     from inline_core.models import pipeline_runtime as rt
 
     loop = _FakeLoop()
@@ -615,3 +616,60 @@ def test_step_progress_survives_the_blocks_property_returning_a_copy() -> None:
         bar.update()
         bar.update()
     assert seen == [(1, 2), (2, 2)]
+
+
+def test_re_attaching_replaces_the_hook_instead_of_stacking() -> None:
+    """The pipeline is cached across renders, so attach runs again on the same loop object.
+
+    Wrapping instead of replacing kept every earlier run's callback alive. Those closures hold the
+    run's cancel token, and a cancelled token stays cancelled, so one cancelled render made every
+    later render raise at its first step.
+    """
+    from inline_core.models import pipeline_runtime as rt
+
+    loop = _FakeLoop()
+
+    class _Blocks:
+        sub_blocks = {"denoise": loop}
+
+    class _Pipe:
+        _blocks = _Blocks()
+
+    pipe = _Pipe()
+    first: list[tuple[int, int]] = []
+    second: list[tuple[int, int]] = []
+    rt.attach_step_progress(pipe, lambda d, t: first.append((d, t)))
+    rt.attach_step_progress(pipe, lambda d, t: second.append((d, t)))
+
+    with loop.progress_bar(total=2) as bar:
+        bar.update()
+        bar.update()
+
+    assert second == [(1, 2), (2, 2)]
+    assert first == []  # the earlier run's callback is gone, not merely outvoted
+    assert loop.bar.updates == 2  # and the real bar is driven once per step, not twice
+
+
+def test_a_cancelled_run_does_not_poison_the_next_one() -> None:
+    """The symptom the stacking caused: render, cancel, then every later render dies immediately."""
+    from inline_core.errors import CancelledError
+    from inline_core.models import pipeline_runtime as rt
+
+    loop = _FakeLoop()
+
+    class _Blocks:
+        sub_blocks = {"denoise": loop}
+
+    class _Pipe:
+        _blocks = _Blocks()
+
+    pipe = _Pipe()
+
+    def cancelled(_done: int, _total: int) -> None:
+        raise CancelledError("Run cancelled.")
+
+    rt.attach_step_progress(pipe, cancelled)
+    rt.attach_step_progress(pipe, lambda _d, _t: None)
+
+    with loop.progress_bar(total=1) as bar:
+        bar.update()  # must not raise: the cancelled run's callback is no longer installed

--- a/core/tests/test_minimaxh3_nodes.py
+++ b/core/tests/test_minimaxh3_nodes.py
@@ -558,8 +558,7 @@ class _FakeLoop:
 
 def test_step_progress_hooks_the_denoise_loop() -> None:
     """The modular loop has no callback_on_step_end, so the progress bar is the only per-step hook.
-    Without it a long denoise emits nothing and the UI shows 'loading model' for the whole
-    render."""
+    Without it a long denoise emits nothing and the UI shows 'loading model' for the whole render."""
     from inline_core.models import pipeline_runtime as rt
 
     loop = _FakeLoop()


### PR DESCRIPTION
- **style: wrap an over-long docstring line**
- **fix: unwrap a previous step-progress hook instead of stacking on it**
