### PR TITLE
fix: never quantize an already-quantized text encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="LICENSE"><img alt="License: GPLv3" src="https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge"></a>
   <a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/Python-3.11%2B-blue?style=for-the-badge&logo=python&logoColor=white"></a>
-  <a href="../../releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/Release-v1.2.72-blue?style=for-the-badge"></a>
+  <a href="../../releases/latest"><img alt="Latest release" src="https://img.shields.io/badge/Release-v1.2.73-blue?style=for-the-badge"></a>
   <a href="https://discord.gg/cSUS88VdY9"><img alt="Join our Discord" src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white&style=for-the-badge"></a>
 </p>
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 # PyPI name; the import package is `inline_core` (src/inline_core).
 name = "inline-core"
-version = "1.2.72"
+version = "1.2.73"
 description = "The generation engine behind Inline Studio."
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/core/src/inline_core/models/checkpoint.py
+++ b/core/src/inline_core/models/checkpoint.py
@@ -34,6 +34,38 @@ _DTYPE_NAMES = {
 }
 
 
+#: Markers a checkpoint carries when it was already quantized by someone else. ``comfy_quant`` is
+#: ComfyUI's own tag; ``weight_scale`` is the per-tensor scale every fp8/int8 repack ships beside
+#: the packed weights. Never match a bare ``.scale``: real models carry RMSNorm weights so named.
+_QUANT_MARKERS = ("comfy_quant", "weight_scale", "scale_weight", "weight_scale_2")
+_QUANT_DTYPES = frozenset({"I8", "U8"})
+
+
+def prequantized_kind(path: str | Path) -> str | None:
+    """What quantization a checkpoint already carries, or None if it is plain weights.
+
+    Loading one of these into a stock model silently drops the scales as unexpected keys, leaving
+    packed tensors in layers sized for unpacked ones - which surfaces as a shape mismatch deep in a
+    matmul rather than as a load error. Quantizing it a second time compounds that.
+    """
+    file = Path(path)
+    if not file.is_file() or file.suffix.lower() not in (".safetensors", ".sft"):
+        return None
+    try:
+        reader = CheckpointReader(file)
+        dtypes = reader.dtypes()
+    except Exception:  # noqa: BLE001 - unreadable is not classifiable
+        return None
+    if any(any(m in key for m in _QUANT_MARKERS) for key in dtypes):
+        return "prequantized"
+    weights = {d for key, d in dtypes.items() if key.endswith(".weight")}
+    if any(d.startswith("F8_") for d in weights):
+        return "fp8"
+    if weights & _QUANT_DTYPES:
+        return "int8"
+    return None
+
+
 class CheckpointReader:
     """Random access to one safetensors file, one tensor at a time."""
 

--- a/core/src/inline_core/models/loaders.py
+++ b/core/src/inline_core/models/loaders.py
@@ -25,6 +25,7 @@ over it. Callers are the model-runner subpackages, which the server registers be
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -35,6 +36,9 @@ from typing import TYPE_CHECKING, Any
 from ..config import data_dir
 from ..device.policy import Quantization
 from ..errors import ComponentError
+from . import checkpoint
+
+logger = logging.getLogger("inline_core.loaders")
 
 if TYPE_CHECKING:
     from ..graph.loader_runners import LoraRef
@@ -663,14 +667,33 @@ def load_text_encoder(
         root = ensure_assets(arch)
         weights_dir = _staged_encoder_dir(arch, file)
         device_map = {"": device} if device else None
-        text_encoder = Qwen3Model.from_pretrained(
-            str(weights_dir),
-            torch_dtype=dtype,
-            low_cpu_mem_usage=True,
-            device_map=device_map,
-            local_files_only=True,
-            quantization_config=_quant_config(quant, framework="transformers"),
-        )
+        # A repack that already carries its own scales must not be quantized again, and transformers
+        # drops those scales as unexpected keys - leaving packed tensors in layers sized for
+        # unpacked ones, which surfaces as a matmul shape error rather than a load failure.
+        carried = checkpoint.prequantized_kind(file)
+        effective = Quantization.NONE if carried else quant
+        if carried:
+            logger.info(
+                "%s is a %s text encoder; loading it as-is rather than quantizing on top.",
+                Path(file).name, carried,
+            )
+        try:
+            text_encoder = Qwen3Model.from_pretrained(
+                str(weights_dir),
+                torch_dtype=dtype,
+                low_cpu_mem_usage=True,
+                device_map=device_map,
+                local_files_only=True,
+                quantization_config=_quant_config(effective, framework="transformers"),
+            )
+        except Exception as error:
+            if not carried:
+                raise
+            raise ComponentError(
+                f"{Path(file).name} is a {carried} text encoder, which this loader cannot read: "
+                "its scales are not part of the stock Qwen3 layout. Use the full-precision encoder "
+                "(qwen_3_8b.safetensors from Comfy-Org/flux2-klein-9B)."
+            ) from error
         tokenizer = AutoTokenizer.from_pretrained(str(root / "tokenizer"), local_files_only=True)
         return text_encoder, tokenizer
 

--- a/core/tests/test_checkpoint.py
+++ b/core/tests/test_checkpoint.py
@@ -8,9 +8,14 @@ must agree with safetensors exactly.
 
 from __future__ import annotations
 
+import json
+import struct
+from pathlib import Path
+
 import pytest
 
 from inline_core.errors import ComponentError
+from inline_core.models import checkpoint
 from inline_core.models.checkpoint import CheckpointReader
 
 torch = pytest.importorskip("torch")
@@ -77,3 +82,62 @@ def test_a_non_checkpoint_file_is_a_clear_error(tmp_path) -> None:
 def test_a_missing_file_is_a_clear_error(tmp_path) -> None:
     with pytest.raises(ComponentError, match="Could not read checkpoint"):
         CheckpointReader(tmp_path / "absent.safetensors")
+
+
+# --- already-quantized checkpoints ---------------------------------------------------------------
+#
+# A ComfyUI-quantized text encoder loads into a stock Qwen3Model with its `comfy_quant` and
+# `weight_scale` keys dropped as unexpected, leaving packed tensors in layers sized for unpacked
+# ones. That surfaced as a matmul shape error deep inside torchao, after the pipeline had
+# already reported itself ready.
+
+
+def _write(path: Path, index: dict[str, object]) -> Path:
+    blob = json.dumps(index).encode()
+    path.write_bytes(struct.pack("<Q", len(blob)) + blob + b"\x00" * 64)
+    return path
+
+
+def _t(dtype: str, shape: list[int]) -> dict[str, object]:
+    return {"dtype": dtype, "shape": shape, "data_offsets": [0, 1]}
+
+
+def test_a_comfy_quantized_encoder_is_recognised(tmp_path: Path) -> None:
+    file = _write(
+        tmp_path / "qwen_3_8b_comfyquant.safetensors",
+        {
+            "model.layers.0.self_attn.k_proj.weight": _t("I8", [1024, 2048]),
+            "model.layers.0.self_attn.k_proj.weight_scale": _t("F32", [1024]),
+            "model.layers.0.self_attn.k_proj.comfy_quant": _t("I8", []),
+        },
+    )
+    assert checkpoint.prequantized_kind(file) == "prequantized"
+
+
+def test_an_fp8_checkpoint_is_recognised(tmp_path: Path) -> None:
+    file = _write(
+        tmp_path / "enc_fp8.safetensors",
+        {"model.layers.0.mlp.up_proj.weight": _t("F8_E4M3", [4096, 4096])},
+    )
+    assert checkpoint.prequantized_kind(file) == "fp8"
+
+
+def test_a_plain_checkpoint_is_not_flagged(tmp_path: Path) -> None:
+    """A false positive here refuses to quantize a model that needs it, so it must not fire on
+    ordinary weights or on the RMSNorm tensors every transformer carries."""
+    file = _write(
+        tmp_path / "qwen_3_8b.safetensors",
+        {
+            "model.layers.0.self_attn.k_proj.weight": _t("BF16", [1024, 4096]),
+            "model.layers.0.input_layernorm.weight": _t("BF16", [4096]),
+            "model.layers.0.self_attn.q_norm.scale": _t("BF16", [128]),
+        },
+    )
+    assert checkpoint.prequantized_kind(file) is None
+
+
+def test_an_unreadable_file_is_not_classified(tmp_path: Path) -> None:
+    junk = tmp_path / "junk.safetensors"
+    junk.write_bytes(b"\x00" * 32)
+    assert checkpoint.prequantized_kind(junk) is None
+    assert checkpoint.prequantized_kind(tmp_path / "missing.safetensors") is None

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inline-studio",
-  "version": "1.2.72",
+  "version": "1.2.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inline-studio",
-      "version": "1.2.72",
+      "version": "1.2.73",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@react-three/drei": "^10.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inline-studio",
-  "version": "1.2.72",
+  "version": "1.2.73",
   "description": "AI filmmaking on a node canvas. Generate locally on your own GPU and train your own LoRAs on the same canvas, with the built-in Inline Core engine and hosted models. Every render is kept as a versioned take.",
   "keywords": [
     "ai-filmmaking",

--- a/packages/frontend/pyproject.toml
+++ b/packages/frontend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inline-studio-frontend"
-version = "1.2.72"
+version = "1.2.73"
 description = "Prebuilt Inline Studio web UI (SPA), served by Inline Core. Mirrors comfyui-frontend-package."
 requires-python = ">=3.9"
 readme = "README.md"


### PR DESCRIPTION
## Summary: never quantize an already-quantized text encoder

A ComfyUI-quantized Qwen3 loads into a stock Qwen3Model with its comfy_quant and weight_scale keys dropped as unexpected, leaving packed tensors in layers sized for unpacked ones, and the fit plan then applied torchao int8 on top. The result was a matmul shape error deep inside torchao, long after the pipeline had reported itself ready.

#52 